### PR TITLE
Tools: add a new CLI in rust and related CI tests

### DIFF
--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -37,5 +37,7 @@ jobs:
           export PATH=$PATH:~/.bpftime
           bpftime --help
           cd example/malloc
-          timeout -s 2 5s bpftime load ./malloc || if [ $? = 124 ]; then exit 0; else exit $?; fi
+          timeout -s 2 5s bpftime load ./malloc || if [ $? = 124 ]; then exit 0; else exit $?; fi &
+          ID1=$!
           timeout -s 2 5s bpftime start ./test || if [ $? = 124 ]; then exit 0; else exit $?; fi
+          fg $ID1 || true

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -37,5 +37,5 @@ jobs:
           export PATH=$PATH:~/.bpftime
           bpftime --help
           cd example/malloc
-          timeout -s 2 5s bpftime load ./malloc || if [ $$? = 124 ]; then exit 0; else exit $$?; fi
-          timeout -s 2 5s bpftime start ./test || if [ $$? = 124 ]; then exit 0; else exit $$?; fi
+          timeout -s 2 5s bpftime load ./malloc || if [ $? = 124 ]; then exit 0; else exit $?; fi
+          timeout -s 2 5s bpftime start ./test || if [ $? = 124 ]; then exit 0; else exit $?; fi

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -1,0 +1,41 @@
+name: Test whether CLI works properly
+
+on:
+  push:
+    branches: [master]
+  pull_request: 
+    branches: [master]
+
+jobs: 
+  build-runtime-cli-and-test-cli:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - name: Install dependencies
+        run: | 
+          sudo apt-get install binutils-dev libboost1.74-all-dev libelf-dev zlib1g-dev
+      - name: Build and install runtime
+        run: |
+          make install
+      - name: Build and install CLI
+        run: |
+          cd tools/cli-rs
+          RUSTFLAGS="-C target-feature=+crt-static" cargo build --release --target x86_64-unknown-linux-gnu
+          cp ./target/x86_64-unknown-linux-gnu/release/bpftime ~/.bpftime
+      - uses: actions/upload-artifact@v3
+        with:
+          name: bpftime-cli
+          path: ~/.bpftime/bpftime
+      - name: Build test assets
+        run: |
+          cd example/malloc
+          make -j
+      - name: Test CLI - attach by running
+        run: |
+          export PATH=$PATH:~/.bpftime
+          bpftime --help
+          cd example/malloc
+          timeout -s 2 5s bpftime load ./malloc || if [ $$? = 124 ]; then exit 0; else exit $$?; fi
+          timeout -s 2 5s bpftime start ./test || if [ $$? = 124 ]; then exit 0; else exit $$?; fi

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -37,7 +37,8 @@ jobs:
           export PATH=$PATH:~/.bpftime
           bpftime --help
           cd example/malloc
-          timeout -s 2 5s bpftime load ./malloc || if [ $? = 124 ]; then exit 0; else exit $?; fi &
+          timeout -s 2 15s bpftime load ./malloc || if [ $? = 124 ]; then exit 0; else exit $?; fi &
+          sleep 10s
           ID1=$!
           timeout -s 2 5s bpftime start ./test || if [ $? = 124 ]; then exit 0; else exit $?; fi
           fg $ID1 || true

--- a/tools/cli-rs/Cargo.toml
+++ b/tools/cli-rs/Cargo.toml
@@ -9,7 +9,12 @@ anyhow = "1.0.75"
 clap = { version = "4.4.5", features = ["derive"] }
 dirs = "5.0.1"
 exec = "0.3.1"
-libbpf-rs = { version = "0.21.2" }
+libbpf-rs = { version = "0.21.2", optional = true }
 
 [build-dependencies]
 bindgen = "0.68.1"
+
+[features]
+default = []
+support-load-bpf = ["dep:libbpf-rs"]
+all = ["support-load-bpf"]

--- a/tools/cli-rs/src/main.rs
+++ b/tools/cli-rs/src/main.rs
@@ -28,6 +28,7 @@ enum SubCommand {
     },
     #[clap(about = "Inject bpftime-agent to a certain pid")]
     Attach { pid: i32 },
+    #[cfg(feature = "support-load-bpf")]
     #[clap(about = "Load and attach an eBPF object into kernel")]
     LoadBpf {
         #[arg(help = "Path to the ELF file")]
@@ -88,6 +89,7 @@ fn inject_by_frida(pid: i32, agent: impl AsRef<Path>) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "support-load-bpf")]
 fn load_ebpf_object_into_kernel(path: impl AsRef<Path>) -> anyhow::Result<()> {
     let mut obj = libbpf_rs::ObjectBuilder::default()
         .open_file(path.as_ref())
@@ -139,9 +141,10 @@ fn main() -> anyhow::Result<()> {
             if !so_path.exists() {
                 bail!("Library not found: {:?}", so_path);
             }
-            println!("Inject: {:?}",so_path);
+            println!("Inject: {:?}", so_path);
             inject_by_frida(pid, so_path)
         }
+        #[cfg(feature = "support-load-bpf")]
         SubCommand::LoadBpf { path } => load_ebpf_object_into_kernel(PathBuf::from(path))
             .with_context(|| anyhow!("Failed to load ebpf object into kernel")),
     }


### PR DESCRIPTION
This PR adds:
- A new bpftime cli named `bpftime` which is located in `tools/cli-rs`. It has the ability to inject server or agent into applications and run them. It can also be statically linked which provides a more convenient way to distribute
- Related workflows to test the new CLI. They are in `test-cli.yml`. The workflow will build & install runtime and cli, and invokes cli to inject server and agent, and test if them exist successfully.