### PR TITLE
Replace libopcodes with frida-capstone

### DIFF
--- a/.github/workflows/test-verifier.yml
+++ b/.github/workflows/test-verifier.yml
@@ -19,7 +19,7 @@ jobs:
           sudo apt-get install binutils-dev libboost1.74-all-dev libelf-dev zlib1g-dev ninja-build libyaml-cpp-dev -y
       - name: Build test target
         run: |
-          cmake -DBPFTIME_ENABLE_UNIT_TESTING=YES -DBPFTIME_LLVM_JIT=NO -DUSE_NEW_BINUTILS=YES -DENABLE_EBPF_VERIFIER=YES -DCMAKE_BUILD_TYPE:STRING=Release -S . -B build -G Ninja
+          cmake -DBPFTIME_ENABLE_UNIT_TESTING=YES -DBPFTIME_LLVM_JIT=NO -DENABLE_EBPF_VERIFIER=YES -DCMAKE_BUILD_TYPE:STRING=Release -S . -B build -G Ninja
           cmake --build build --config Release --target bpftime_verifier_tests
       - name: Run tests
         run: |

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ build-old-binutils: ## build the package with old binutils
 	cmake --build build --config Debug
 
 release: ## build the package
-	(cmake -Bbuild  -DBPFTIME_ENABLE_UNIT_TESTING=0 && cmake --build build --config Release -j --target install) || (cmake -Bbuild  -DBPFTIME_ENABLE_UNIT_TESTING=0 -DUSE_NEW_BINUTILS=YES && cmake --build build --config Release -j  --target install)
+	cmake -Bbuild  -DBPFTIME_ENABLE_UNIT_TESTING=0 && cmake --build build --config Release -j --target install
 
 build-vm: ## build only the core library
 	make -C vm build

--- a/benchmark/syscall/README.md
+++ b/benchmark/syscall/README.md
@@ -5,7 +5,7 @@ Here is a example that demonstrates the usage of userspace syscall trace
 ## Usage
 
 - Install binutils dev: `sudo apt install binutils-dev`
-- Configure & build the project `cmake -S . -B build -G Ninja && cmake --build build --target all --config Debug`. If you encounter errors about `init_disassemble_info`, try `cmake -S . -B build -G Ninja -D USE_NEW_BINUTILS=YES && cmake --build build --target all --config Debug`
+- Configure & build the project `cmake -S . -B build -G Ninja && cmake --build build --target all --config Debug`.
 
 ## build
 

--- a/runtime/agent-transformer/CMakeLists.txt
+++ b/runtime/agent-transformer/CMakeLists.txt
@@ -1,5 +1,3 @@
-option(USE_NEW_BINUTILS "Use the binutils version that requires four arguments in init_disassemble_info" NO)
-
 add_library(bpftime-agent-transformer SHARED
     agent-transformer.cpp
     text_segment_transformer.cpp
@@ -8,7 +6,6 @@ add_dependencies(bpftime-agent-transformer spdlog::spdlog FridaGum)
 set_property(TARGET bpftime-agent-transformer PROPERTY CXX_STANDARD 20)
 
 target_link_libraries(bpftime-agent-transformer
-    opcodes
     spdlog::spdlog
     ${FRIDA_GUM_INSTALL_DIR}/libfrida-gum.a
 )
@@ -18,7 +15,3 @@ target_include_directories(bpftime-agent-transformer
     ${FRIDA_GUM_INSTALL_DIR}
     ${SPDLOG_INCLUDE}
 )
-
-if(${USE_NEW_BINUTILS})
-    target_compile_definitions(bpftime-agent-transformer PRIVATE USE_NEW_BINUTILS)
-endif()

--- a/runtime/agent-transformer/CMakeLists.txt
+++ b/runtime/agent-transformer/CMakeLists.txt
@@ -10,6 +10,7 @@ set_property(TARGET bpftime-agent-transformer PROPERTY CXX_STANDARD 20)
 target_link_libraries(bpftime-agent-transformer
     opcodes
     spdlog::spdlog
+    ${FRIDA_GUM_INSTALL_DIR}/libfrida-gum.a
 )
 
 target_include_directories(bpftime-agent-transformer

--- a/runtime/agent-transformer/agent-transformer.cpp
+++ b/runtime/agent-transformer/agent-transformer.cpp
@@ -8,6 +8,7 @@
 #include "text_segment_transformer.hpp"
 #include <spdlog/cfg/env.h>
 #include <string>
+#include <frida-gum.h>
 using putchar_func = int (*)(int c);
 using puts_func_t = int (*)(const char *);
 
@@ -60,6 +61,7 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 	assert(agent_so &&
 	       "Please set AGENT_SO to the bpftime-agent when use this tranformer");
 	spdlog::info("Using agent {}", agent_so);
+	cs_arch_register_x86();
 	bpftime::setup_syscall_tracer();
 	spdlog::info("Loading dynamic library..");
 	auto next_handle =

--- a/runtime/agent-transformer/agent-transformer.cpp
+++ b/runtime/agent-transformer/agent-transformer.cpp
@@ -6,8 +6,6 @@
 #include <cstdio>
 #include <frida-gum.h>
 #include "text_segment_transformer.hpp"
-#include <iostream>
-#include <ostream>
 #include <spdlog/cfg/env.h>
 #include <string>
 using putchar_func = int (*)(int c);

--- a/runtime/agent-transformer/text_segment_transformer.cpp
+++ b/runtime/agent-transformer/text_segment_transformer.cpp
@@ -4,17 +4,12 @@
 #include <cstdarg>
 #include <cstddef>
 #include <cstdio>
-#include <cassert>
 #include <cinttypes>
 #include <cstdlib>
 #include <cstring>
 #include <dlfcn.h>
 #include <fcntl.h>
 #include <fstream>
-#include <ios>
-#include <iostream>
-#include <iterator>
-#include <ostream>
 #include <sys/mman.h>
 #include <vector>
 #include <cstdint>

--- a/runtime/agent-transformer/text_segment_transformer.cpp
+++ b/runtime/agent-transformer/text_segment_transformer.cpp
@@ -147,6 +147,7 @@ static inline void rewrite_segment(uint8_t *code, size_t len, int perm)
 			}
 		}
 	}
+	cs_close(&cs_handle);
 	if (int err = mprotect(code, len, perm); err < 0) {
 		spdlog::error(
 			"Failed to change the protect status of the rewriting page {:x}",

--- a/runtime/include/bpftime.hpp
+++ b/runtime/include/bpftime.hpp
@@ -1,21 +1,15 @@
 #ifndef _BPFTIME_RUNTIME_HEADERS_H_
 #define _BPFTIME_RUNTIME_HEADERS_H_
 
-#include <memory>
-#include <map>
-#include <set>
-#include <vector>
-#include <string>
-#include <cstdint>
-#include <cassert>
-#include <cstdlib>
 #include <ebpf-vm.h>
 #include <common/bpftime_config.hpp>
 #include "bpf_attach_ctx.hpp"
-#include "bpftime_prog.hpp"
 #include "hook_entry.hpp"
 #include "bpftime_ffi.hpp"
 #include "bpftime_helper_group.hpp"
+#include "bpftime_prog.hpp"
+#include "bpftime_shm.hpp"
+
 extern "C" {
 
 struct trace_entry {

--- a/runtime/include/bpftime_shm.hpp
+++ b/runtime/include/bpftime_shm.hpp
@@ -1,16 +1,15 @@
 #ifndef BPFTIME_SHM_CPP_H
 #define BPFTIME_SHM_CPP_H
 
+#include "common/bpftime_config.hpp"
 #include <boost/interprocess/interprocess_fwd.hpp>
 #include <cstddef>
-#include <iostream>
-#include <variant>
 #include <boost/interprocess/containers/vector.hpp>
 #include <boost/interprocess/allocators/allocator.hpp>
 #include <boost/interprocess/managed_shared_memory.hpp>
 #include <boost/interprocess/smart_ptr/unique_ptr.hpp>
 #include <boost/interprocess/containers/string.hpp>
-#include "bpftime.hpp"
+#include <ebpf-vm.h>
 
 namespace bpftime
 {

--- a/runtime/include/syscall_table.hpp
+++ b/runtime/include/syscall_table.hpp
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <string>
 #include <unordered_map>
-#include <cinttypes>
+#include <utility>
 namespace bpftime
 {
 using syscall_tracepoint_table = std::unordered_map<int32_t, std::string>;

--- a/runtime/object/bpf_object.cpp
+++ b/runtime/object/bpf_object.cpp
@@ -1,12 +1,8 @@
-#include <assert.h>
 #include <linux/bpf.h>
 #include <string>
 #include <list>
 #include <memory>
-#include <iostream>
 #include <string_view>
-#include <unordered_map>
-#include <vector>
 #include "bpftime.hpp"
 #include "bpftime_internal.h"
 #include <spdlog/spdlog.h>

--- a/runtime/src/attach/attach_internal.cpp
+++ b/runtime/src/attach/attach_internal.cpp
@@ -1,25 +1,12 @@
-#include "bpftime_handler.hpp"
-#include "spdlog/spdlog.h"
-#include <algorithm>
-#include <cassert>
 #include <cstddef>
 #include <cstdint>
-#include <iterator>
-#include <map>
-#include <mutex>
-#include <iostream>
-#include <fstream>
 #include <fcntl.h>
 #include <cstring>
-#include <optional>
-#include <ostream>
 #include <unistd.h>
 #include "bpftime.hpp"
 #include "bpftime_internal.h"
 #include <frida-gum.h>
 #include <syscall_table.hpp>
-#include <variant>
-#include <vector>
 #include <spdlog/spdlog.h>
 #include <attach/attach_internal.hpp>
 using namespace std;

--- a/runtime/src/attach/bpf_attach_ctx.cpp
+++ b/runtime/src/attach/bpf_attach_ctx.cpp
@@ -1,8 +1,7 @@
+#include "bpftime.hpp"
 #include "frida-gum.h"
 #include "handler/epoll_handler.hpp"
 #include <filesystem>
-#include <iostream>
-#include <ostream>
 #include <syscall_table.hpp>
 #include <bpf_attach_ctx.hpp>
 #include <bpftime_shm_internal.hpp>

--- a/runtime/src/bpf_helper.cpp
+++ b/runtime/src/bpf_helper.cpp
@@ -1,9 +1,9 @@
+#include "bpftime_helper_group.hpp"
 #ifdef ENABLE_BPFTIME_VERIFIER
 #include "bpftime-verifier.hpp"
 #endif
 #include "spdlog/spdlog.h"
 #include <map>
-#include <iostream>
 #include <stdio.h>
 #include <stdarg.h>
 #include <cstring>

--- a/runtime/src/bpftime_internal.h
+++ b/runtime/src/bpftime_internal.h
@@ -3,11 +3,12 @@
 
 #include <cstdint>
 #include <cstddef>
-
+#include "bpftime.hpp"
+#include <bpftime_ffi.hpp>
 namespace bpftime
 {
 
-#include "bpftime.hpp"
+
 
 class bpftime_prog;
 class bpftime_object;

--- a/runtime/src/bpftime_prog.cpp
+++ b/runtime/src/bpftime_prog.cpp
@@ -1,4 +1,5 @@
 #include "bpftime.hpp"
+#include "bpftime_helper_group.hpp"
 #include "bpftime_internal.h"
 #include "ebpf-vm.h"
 #include <cstring>

--- a/runtime/src/bpftime_shm.cpp
+++ b/runtime/src/bpftime_shm.cpp
@@ -4,7 +4,6 @@
 #include <errno.h>
 #include <bpftime_shm_internal.hpp>
 #include <thread>
-#include <variant>
 #include <chrono>
 namespace bpftime
 {

--- a/runtime/src/ffi.cpp
+++ b/runtime/src/ffi.cpp
@@ -1,9 +1,6 @@
-#include <cinttypes>
+#include <cstdint>
 #include <cstring>
-#include "bpftime.hpp"
 #include "bpftime_internal.h"
-#include <type_traits>
-#include <string>
 #include <spdlog/spdlog.h>
 namespace bpftime
 {

--- a/runtime/src/syscall_table.cpp
+++ b/runtime/src/syscall_table.cpp
@@ -4,7 +4,6 @@
 #include <cassert>
 #include <optional>
 #include <syscall_id_list.h>
-#include <utility>
 static const char *SYSCALL_TRACEPOINT_ROOT =
 	"/sys/kernel/tracing/events/syscalls";
 

--- a/runtime/syscall-server/syscall_server.cpp
+++ b/runtime/syscall-server/syscall_server.cpp
@@ -1,24 +1,22 @@
 #include "syscall_server.hpp"
-#include "bpftime.hpp"
-#include "bpftime_handler.hpp"
 #include "bpftime_shm.hpp"
+#include "handler/perf_event_handler.hpp"
 #include "linux/bpf.h"
 #include "spdlog/cfg/env.h"
 #include <asm-generic/errno-base.h>
 #include <cstdlib>
 #include <cstring>
-#include <iostream>
 #include <optional>
-#include <ostream>
 #include <ranges>
 #include <spdlog/spdlog.h>
-#include <sstream>
 #include <string_view>
 #include <unistd.h>
 #ifdef ENABLE_BPFTIME_VERIFIER
 #include <bpftime-verifier.hpp>
-#endif
 #include <iomanip>
+#include <sstream>
+#endif
+
 #include <sys/epoll.h>
 #include <spdlog/cfg/env.h>
 using namespace bpftime;

--- a/runtime/test/src/test_attach_uprobe.cpp
+++ b/runtime/test/src/test_attach_uprobe.cpp
@@ -1,3 +1,4 @@
+#include "bpftime_helper_group.hpp"
 #include <stdio.h>
 #include <cstdlib>
 #include <cstdint>

--- a/runtime/test/src/test_helpers.cpp
+++ b/runtime/test/src/test_helpers.cpp
@@ -1,4 +1,5 @@
 // test register raw function and call it from ffi
+#include "bpftime_helper_group.hpp"
 #include "test_defs.h"
 #include "bpftime.hpp"
 #include "bpftime_object.h"

--- a/runtime/test/src/test_shm_progs_attach.cpp
+++ b/runtime/test/src/test_shm_progs_attach.cpp
@@ -1,5 +1,8 @@
+#include "bpf_attach_ctx.hpp"
+#include "bpftime_ffi.hpp"
+#include "bpftime_shm.hpp"
+#include "handler/handler_manager.hpp"
 #include <cstdlib>
-#include "bpftime_handler.hpp"
 #include "bpftime_object.h"
 #include "test_defs.h"
 #include <boost/interprocess/creation_tags.hpp>


### PR DESCRIPTION
Closes #15 

This PR uses frida-capstone to decompile assembly in text segment transformer, instead of libopcodes. Thus we don't depend on libopcodes anymore.
