### PR TITLE
Remove LD_PRELOAD env var after intializing syscall context

### DIFF
--- a/runtime/syscall-server/syscall_context.hpp
+++ b/runtime/syscall-server/syscall_context.hpp
@@ -2,6 +2,7 @@
 #define _SYSCALL_CONTEXT_HPP
 #include "linux/perf_event.h"
 #include <cstddef>
+#include <cstdlib>
 #include <dlfcn.h>
 #include <sys/types.h>
 #include <spdlog/spdlog.h>
@@ -35,6 +36,7 @@ class syscall_context {
 		orig_mmap64_fn = (mmap64_fn)dlsym(RTLD_NEXT, "mmap");
 		orig_close_fn = (close_fn)dlsym(RTLD_NEXT, "close");
 		orig_munmap_fn = (munmap_fn)dlsym(RTLD_NEXT, "munmap");
+		unsetenv("LD_PRELOAD");
 	}
 
     public:


### PR DESCRIPTION
To avoid polluting other child processes, we unset the `LD_PRELOAD` env var after syscall context being initialized