### PR TITLE
Use `__libc_start_main` as agent entrypoint

### DIFF
--- a/example/malloc/.gitignore
+++ b/example/malloc/.gitignore
@@ -8,3 +8,4 @@ ecli
 malloc
 .output
 test
+victim

--- a/example/malloc/Makefile
+++ b/example/malloc/Makefile
@@ -66,10 +66,10 @@ $(call allow-override,CC,$(CROSS_COMPILE)cc)
 $(call allow-override,LD,$(CROSS_COMPILE)ld)
 
 .PHONY: all
-all: $(APPS) test
+all: $(APPS) victim
 
-test: test.c
-	gcc test.c -o test
+victim: victim.c
+	gcc victim.c -o victim -Wall -g
 
 .PHONY: clean
 clean:

--- a/example/malloc/victim.c
+++ b/example/malloc/victim.c
@@ -3,7 +3,6 @@
 #include <unistd.h>
 
 int main(int argc, char *argv[]) {
-    puts("\nHello malloc!\n");
     while(1) {
         void *p = malloc(1024);
         printf("continue malloc...\n");

--- a/example/opensnoop/victim.cpp
+++ b/example/opensnoop/victim.cpp
@@ -7,7 +7,6 @@
 
 int main()
 {
-	puts("");
 	while (true) {
 		std::cout << "Opening test.txt" << std::endl;
 

--- a/example/perf-opensnoop/victim.cpp
+++ b/example/perf-opensnoop/victim.cpp
@@ -6,7 +6,6 @@
 #include <unistd.h>
 int main()
 {
-    puts("");
 	while (true) {
 		std::cout << "Opening test.txt" << std::endl;
 

--- a/example/statsnoop/victim.cpp
+++ b/example/statsnoop/victim.cpp
@@ -18,7 +18,6 @@ int main()
 		sscanf(line.c_str(), "%*s%s", path);
 		paths.push_back(path);
 	}
-	puts("");
 	struct statfs fst;
 	while (1) {
 		for (const auto &p : paths) {


### PR DESCRIPTION
This PR updates agent/agent-transformer with `__libc_start_main` as entrypoint. In this way, we don't need to hook specify functions (usually puts or putchar) to enter agent