### PR TITLE
Fix some issues that may cause sslsniff not working

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ tests
 gdb.py
 test.txt
 test.gdb
+index.html*
 ### VisualStudioCode ###
 .vscode/settings.json
 .vscode/runtime.json

--- a/runtime/agent/agent.cpp
+++ b/runtime/agent/agent.cpp
@@ -1,4 +1,5 @@
 #include "bpf_attach_ctx.hpp"
+#include "bpftime_shm_internal.hpp"
 #include "spdlog/common.h"
 #include <cassert>
 #include <ctime>
@@ -47,6 +48,7 @@ extern "C" int bpftime_hooked_main(int argc, char **argv, char **envp)
 {
 	int stay_resident = 0;
 	spdlog::cfg::load_env_levels();
+	initialize_global_shm();
 	ctx_holder.init();
 	bpftime_agent_main("", &stay_resident);
 	return orig_main_func(argc, argv, envp);
@@ -105,6 +107,7 @@ __c_abi_setup_syscall_trace_callback(syscall_hooker_func_t *hooker)
 {
 	orig_hooker = *hooker;
 	*hooker = &syscall_callback;
+	initialize_global_shm();
 	ctx_holder.init();
 	ctx_holder.ctx.set_orig_syscall_func(orig_hooker);
 	gboolean val;

--- a/runtime/agent/agent.cpp
+++ b/runtime/agent/agent.cpp
@@ -1,3 +1,4 @@
+#include "bpf_attach_ctx.hpp"
 #include "spdlog/common.h"
 #include <cassert>
 #include <ctime>
@@ -24,29 +25,47 @@ using main_func_t = int (*)(int, char **, char **);
 
 static main_func_t orig_main_func = nullptr;
 
-extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident);
+union bpf_attach_ctx_holder {
+	bpf_attach_ctx ctx;
+	bpf_attach_ctx_holder()
+	{
+	}
+	~bpf_attach_ctx_holder()
+	{
+		ctx.~bpf_attach_ctx();
+	}
+	void init()
+	{
+		new (&ctx) bpf_attach_ctx;
+	}
+};
+static bpf_attach_ctx_holder ctx_holder;
 
+extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident);
 
 extern "C" int bpftime_hooked_main(int argc, char **argv, char **envp)
 {
 	int stay_resident = 0;
+	spdlog::cfg::load_env_levels();
+	ctx_holder.init();
 	bpftime_agent_main("", &stay_resident);
 	return orig_main_func(argc, argv, envp);
 }
 
-extern "C" int __libc_start_main(int (*main)(int, char **, char **), int argc, char **argv,
-		      int (*init)(int, char **, char **), void (*fini)(void),
-		      void (*rtld_fini)(void), void *stack_end)
+extern "C" int __libc_start_main(int (*main)(int, char **, char **), int argc,
+				 char **argv,
+				 int (*init)(int, char **, char **),
+				 void (*fini)(void), void (*rtld_fini)(void),
+				 void *stack_end)
 {
 	spdlog::info("Entering bpftime agent");
 	orig_main_func = main;
 	using this_func_t = decltype(&__libc_start_main);
 	this_func_t orig = (this_func_t)dlsym(RTLD_NEXT, "__libc_start_main");
 
-	return orig(bpftime_hooked_main, argc, argv, init, fini, rtld_fini, stack_end);
+	return orig(bpftime_hooked_main, argc, argv, init, fini, rtld_fini,
+		    stack_end);
 }
-
-static bpf_attach_ctx ctx;
 
 extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 {
@@ -58,7 +77,8 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 
 	int res = 1;
 
-	res = ctx.init_attach_ctx_from_handlers(bpftime_get_agent_config());
+	res = ctx_holder.ctx.init_attach_ctx_from_handlers(
+		bpftime_get_agent_config());
 	if (res != 0) {
 		spdlog::error("Failed to initialize attach context");
 		return;
@@ -76,8 +96,8 @@ int64_t syscall_callback(int64_t sys_nr, int64_t arg1, int64_t arg2,
 	// spdlog::info(
 	// "Calling syscall callback: sys_nr {}, args {} {} {} {} {} {}",
 	// sys_nr, arg1, arg2, arg3, arg4, arg5, arg6);
-	return ctx.run_syscall_hooker(sys_nr, arg1, arg2, arg3, arg4, arg5,
-				      arg6);
+	return ctx_holder.ctx.run_syscall_hooker(sys_nr, arg1, arg2, arg3, arg4,
+						 arg5, arg6);
 }
 
 extern "C" void
@@ -85,7 +105,8 @@ __c_abi_setup_syscall_trace_callback(syscall_hooker_func_t *hooker)
 {
 	orig_hooker = *hooker;
 	*hooker = &syscall_callback;
-	ctx.set_orig_syscall_func(orig_hooker);
+	ctx_holder.init();
+	ctx_holder.ctx.set_orig_syscall_func(orig_hooker);
 	gboolean val;
 	bpftime_agent_main("", &val);
 }

--- a/runtime/src/attach/bpf_attach_ctx.cpp
+++ b/runtime/src/attach/bpf_attach_ctx.cpp
@@ -265,6 +265,9 @@ int bpf_attach_ctx::init_attach_ctx_from_handlers(
 			}
 			case bpf_perf_event_handler::bpf_event_type::
 				BPF_TYPE_URETPROBE: {
+				spdlog::debug(
+					"Creating uretprobe for perf event fd {}",
+					i);
 				fd = create_uprobe(function, i, true);
 				break;
 			}
@@ -344,6 +347,7 @@ void *bpf_attach_ctx::module_find_export_by_name(const char *module_name,
 
 void *bpf_attach_ctx::module_get_base_addr(const char *module_name)
 {
+	gum_module_load(module_name, nullptr);
 	return (void *)gum_module_find_base_address(module_name);
 }
 

--- a/runtime/src/attach/bpf_attach_ctx.cpp
+++ b/runtime/src/attach/bpf_attach_ctx.cpp
@@ -206,7 +206,7 @@ int bpf_attach_ctx::init_attach_ctx_from_handlers(
 			spdlog::info("bpf_map_handler found at {}", i);
 		} else if (std::holds_alternative<bpf_perf_event_handler>(
 				   handler)) {
-			spdlog::info("Will handle bpf_perf_events later...");
+			spdlog::debug("Will handle bpf_perf_events later...");
 
 		} else if (std::holds_alternative<epoll_handler>(handler)) {
 			spdlog::info(
@@ -329,7 +329,7 @@ void *bpf_attach_ctx::find_function_by_name(const char *name)
 		return addr;
 	}
 	if (addr == NULL) {
-		spdlog::error("Unable to finc function {} {}", name,
+		spdlog::error("Unable to find function {} {}", name,
 			      __FUNCTION__);
 	}
 	return NULL;
@@ -630,6 +630,7 @@ int bpf_attach_ctx::replace_func(void *new_function, void *target_function,
 // create a probe context
 bpf_attach_ctx::bpf_attach_ctx(void)
 {
+	spdlog::debug("Initialzing frida gum");
 	gum_init_embedded();
 
 	interceptor = gum_interceptor_obtain();

--- a/runtime/src/bpf_helper.cpp
+++ b/runtime/src/bpf_helper.cpp
@@ -537,6 +537,12 @@ const bpftime_helper_group kernel_helper_group = {
 		    .name = "bpf_probe_read_kernel",
 		    .fn = (void *)bpftime_probe_read,
 	    } },
+	  { BPF_FUNC_probe_read_user,
+	    bpftime_helper_info{
+		    .index = BPF_FUNC_probe_read_user,
+		    .name = "bpf_probe_read_user",
+		    .fn = (void *)bpftime_probe_read,
+	    } },
 	  { BPF_FUNC_ktime_get_ns,
 	    bpftime_helper_info{
 		    .index = BPF_FUNC_ktime_get_ns,

--- a/runtime/src/bpf_map/array_map.cpp
+++ b/runtime/src/bpf_map/array_map.cpp
@@ -1,4 +1,5 @@
 #include <bpf_map/array_map.hpp>
+#include <cerrno>
 namespace bpftime
 {
 
@@ -51,11 +52,14 @@ long array_map_impl::elem_delete(const void *key)
 
 int array_map_impl::bpf_map_get_next_key(const void *key, void *next_key)
 {
-	if (key == nullptr || *(uint32_t *)key >= _max_entries - 1) {
+	// Not found
+	if (key == nullptr || *(uint32_t *)key >= _max_entries) {
 		*(uint32_t *)next_key = 0;
 		return 0;
 	}
-	if (_max_entries == 0 || *(uint32_t *)key == _max_entries - 1) {
+	uint32_t deref_key = *(uint32_t *)key;
+	// Last element
+	if (deref_key == _max_entries - 1) {
 		errno = ENOENT;
 		return -1;
 	}

--- a/runtime/src/bpf_map/array_map.cpp
+++ b/runtime/src/bpf_map/array_map.cpp
@@ -51,13 +51,13 @@ long array_map_impl::elem_delete(const void *key)
 
 int array_map_impl::bpf_map_get_next_key(const void *key, void *next_key)
 {
-	if (_max_entries == 0 || *(uint32_t *)key == _max_entries - 1) {
-		errno = ENOENT;
-		return -1;
-	}
 	if (key == nullptr || *(uint32_t *)key >= _max_entries - 1) {
 		*(uint32_t *)next_key = 0;
 		return 0;
+	}
+	if (_max_entries == 0 || *(uint32_t *)key == _max_entries - 1) {
+		errno = ENOENT;
+		return -1;
 	}
 	auto key_val = *(uint32_t *)key;
 	*(uint32_t *)next_key = key_val + 1;

--- a/runtime/src/bpf_map/hash_map.cpp
+++ b/runtime/src/bpf_map/hash_map.cpp
@@ -30,6 +30,8 @@ void *hash_map_impl::elem_lookup(const void *key)
 long hash_map_impl::elem_update(const void *key, const void *value,
 				uint64_t flags)
 {
+	bytes_vec key_vec = this->key_vec;
+	bytes_vec value_vec = this->value_vec;
 	key_vec.assign((uint8_t *)key, (uint8_t *)key + _key_size);
 	value_vec.assign((uint8_t *)value, (uint8_t *)value + _value_size);
 	if (auto itr = map_impl.find(key_vec); itr != map_impl.end()) {
@@ -42,6 +44,7 @@ long hash_map_impl::elem_update(const void *key, const void *value,
 
 long hash_map_impl::elem_delete(const void *key)
 {
+	bytes_vec key_vec = this->key_vec;
 	key_vec.assign((uint8_t *)key, (uint8_t *)key + _key_size);
 	map_impl.erase(key_vec);
 	return 0;

--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -6,6 +6,13 @@
 namespace bpftime
 {
 
+void initialize_global_shm()
+{
+	// Use placement new, which will not allocate memory, but just
+	// call the constructor
+	new (&shm_holder.global_shared_memory) bpftime_shm;
+}
+
 bpftime_shm_holder shm_holder;
 
 static __attribute__((destructor(101))) void __destroy_bpftime_shm_holder()

--- a/runtime/src/bpftime_shm_internal.hpp
+++ b/runtime/src/bpftime_shm_internal.hpp
@@ -111,14 +111,13 @@ union bpftime_shm_holder {
 	bpftime_shm global_shared_memory;
 	bpftime_shm_holder()
 	{
-		// Use placement new, which will not allocate memory, but just
-		// call the constructor
-		new (&global_shared_memory) bpftime_shm;
+		
 	}
 	~bpftime_shm_holder()
 	{
 	}
 };
 extern bpftime_shm_holder shm_holder;
+void initialize_global_shm();
 } // namespace bpftime
 #endif

--- a/runtime/syscall-server/syscall_server_utils.cpp
+++ b/runtime/syscall-server/syscall_server_utils.cpp
@@ -1,3 +1,4 @@
+#include "bpftime_shm_internal.hpp"
 #include <ranges>
 #include <spdlog/cfg/env.h>
 #include <spdlog/spdlog.h>
@@ -14,6 +15,7 @@ void start_up()
 {
 	if (already_setup)
 		return;
+	initialize_global_shm();
 	spdlog::cfg::load_env_levels();
 	spdlog::set_pattern("[%Y-%m-%d %H:%M:%S][%^%l%$][%t] %v");
 	auto &agent_config = bpftime_get_agent_config();


### PR DESCRIPTION
includes:
- Forbid the auto initialization of bpf_attach_ctx and bpftime_shm. They will be manually initialized when syscall server was loaded (firstly called sys_bpf) or agent was loaded (before the execution of main function)
- Add a helper bpf_probe_read_user that sslsniff will use
- Fix an null-deref issue of the get next key implementation of array_map
- 