### PR TITLE
Make bpftrace work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ gdb.py
 test.txt
 test.gdb
 index.html*
+dump*
 ### VisualStudioCode ###
 .vscode/settings.json
 .vscode/runtime.json

--- a/benchmark/test_embed.c
+++ b/benchmark/test_embed.c
@@ -1,4 +1,4 @@
-#include "ebpf_vm.h"
+#include "ebpf-vm.h"
 #include <assert.h>
 #include <string.h>
 #include <stdlib.h>

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -66,6 +66,8 @@ set(sources
   src/bpf_map/hash_map.cpp
   src/bpf_map/ringbuf_map.cpp
   src/bpf_map/perf_event_array_map.cpp
+  src/bpf_map/per_cpu_array_map.cpp
+  src/bpf_map/per_cpu_hash_map.cpp
 )
 
 # list(APPEND sources

--- a/runtime/agent-transformer/agent-transformer.cpp
+++ b/runtime/agent-transformer/agent-transformer.cpp
@@ -75,5 +75,5 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 		bpftime::get_call_hook();
 	entry_func(&orig_syscall_hooker_func);
 	bpftime::set_call_hook(orig_syscall_hooker_func);
-	spdlog::info("Transformer exiting..");
+	spdlog::info("Transformer exiting, trace will be usable now");
 }

--- a/runtime/agent-transformer/agent-transformer.cpp
+++ b/runtime/agent-transformer/agent-transformer.cpp
@@ -10,16 +10,18 @@
 #include <frida-gum.h>
 
 using main_func_t = int (*)(int, char **, char **);
+using shm_destroy_func_t = void (*)(void);
 
 static main_func_t orig_main_func = nullptr;
-
+static shm_destroy_func_t shm_destroy_func = nullptr;
 extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident);
 
 extern "C" int bpftime_hooked_main(int argc, char **argv, char **envp)
 {
 	int stay_resident = 0;
 	bpftime_agent_main("", &stay_resident);
-	return orig_main_func(argc, argv, envp);
+	int ret = orig_main_func(argc, argv, envp);
+	return ret;
 }
 
 extern "C" int __libc_start_main(int (*main)(int, char **, char **), int argc,
@@ -62,8 +64,11 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 		spdlog::error("Failed to open agent: {}", dlerror());
 		exit(1);
 	}
+	shm_destroy_func = (shm_destroy_func_t)dlsym(
+		next_handle, "bpftime_destroy_global_shm");
 	auto entry_func = (void (*)(syscall_hooker_func_t *))dlsym(
 		next_handle, "__c_abi_setup_syscall_trace_callback");
+
 	assert(entry_func &&
 	       "Malformed agent so, expected symbol __c_abi_setup_syscall_trace_callback");
 	syscall_hooker_func_t orig_syscall_hooker_func =

--- a/runtime/agent-transformer/agent-transformer.cpp
+++ b/runtime/agent-transformer/agent-transformer.cpp
@@ -57,7 +57,7 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 	spdlog::info("Using agent {}", agent_so);
 	cs_arch_register_x86();
 	bpftime::setup_syscall_tracer();
-	spdlog::info("Loading dynamic library..");
+	spdlog::debug("Loading dynamic library..");
 	auto next_handle =
 		dlmopen(LM_ID_NEWLM, agent_so, RTLD_NOW | RTLD_LOCAL);
 	if (next_handle == nullptr) {

--- a/runtime/agent/agent.cpp
+++ b/runtime/agent/agent.cpp
@@ -33,6 +33,9 @@ union bpf_attach_ctx_holder {
 	}
 	~bpf_attach_ctx_holder()
 	{
+	}
+	void destroy()
+	{
 		ctx.~bpf_attach_ctx();
 	}
 	void init()
@@ -48,10 +51,12 @@ extern "C" int bpftime_hooked_main(int argc, char **argv, char **envp)
 {
 	int stay_resident = 0;
 	spdlog::cfg::load_env_levels();
-	initialize_global_shm();
+	bpftime_initialize_global_shm();
 	ctx_holder.init();
 	bpftime_agent_main("", &stay_resident);
-	return orig_main_func(argc, argv, envp);
+	int ret = orig_main_func(argc, argv, envp);
+	ctx_holder.destroy();
+	return ret;
 }
 
 extern "C" int __libc_start_main(int (*main)(int, char **, char **), int argc,
@@ -107,7 +112,7 @@ __c_abi_setup_syscall_trace_callback(syscall_hooker_func_t *hooker)
 {
 	orig_hooker = *hooker;
 	*hooker = &syscall_callback;
-	initialize_global_shm();
+	bpftime_initialize_global_shm();
 	ctx_holder.init();
 	ctx_holder.ctx.set_orig_syscall_func(orig_hooker);
 	gboolean val;

--- a/runtime/agent/agent.cpp
+++ b/runtime/agent/agent.cpp
@@ -117,4 +117,5 @@ __c_abi_setup_syscall_trace_callback(syscall_hooker_func_t *hooker)
 	ctx_holder.ctx.set_orig_syscall_func(orig_hooker);
 	gboolean val;
 	bpftime_agent_main("", &val);
+	spdlog::info("Agent syscall trace setup exiting..");
 }

--- a/runtime/agent/agent.cpp
+++ b/runtime/agent/agent.cpp
@@ -91,7 +91,6 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 		return;
 	}
 	spdlog::info("Attach successfully");
-
 	// don't free ctx here
 	return;
 }

--- a/runtime/include/bpf_attach_ctx.hpp
+++ b/runtime/include/bpf_attach_ctx.hpp
@@ -113,6 +113,9 @@ class bpf_attach_ctx {
 
 	std::vector<const bpftime_prog *> sys_enter_progs[512];
 	std::vector<const bpftime_prog *> sys_exit_progs[512];
+	std::vector<const bpftime_prog *> global_sys_enter_progs;
+	std::vector<const bpftime_prog *> global_sys_exit_progs;
+
 	syscall_hooker_func_t orig_syscall = nullptr;
 };
 

--- a/runtime/include/bpftime_shm.hpp
+++ b/runtime/include/bpftime_shm.hpp
@@ -59,7 +59,8 @@ long bpftime_map_delete_elem(int fd, const void *key);
 int bpftime_uprobe_create(int pid, const char *name, uint64_t offset,
 			  bool retprobe, size_t ref_ctr_off);
 int bpftime_tracepoint_create(int pid, int32_t tp_id);
-int bpftime_attach_enable(int fd);
+int bpftime_perf_event_enable(int fd);
+int bpftime_perf_event_disable(int fd);
 int bpftime_attach_perf_to_bpf(int perf_fd, int bpf_fd);
 int bpftime_add_ringbuf_fd_to_epoll(int ringbuf_fd, int epoll_fd,
 				    epoll_data_t extra_data);

--- a/runtime/include/bpftime_shm.hpp
+++ b/runtime/include/bpftime_shm.hpp
@@ -46,15 +46,25 @@ int bpftime_progs_create(const ebpf_inst *insn, size_t insn_cnt,
 			 const char *prog_name, int prog_type);
 
 int bpftime_maps_create(const char *name, bpftime::bpf_map_attr attr);
-int bpftime_map_get_next_key(int fd, const void *key, void *next_key);
+
 int bpftime_map_get_info(int fd, bpftime::bpf_map_attr *out_attr,
 			 const char **out_name, int *type);
 
-uint32_t bpftime_map_value_size(int fd);
-const void *bpftime_map_lookup_elem(int fd, const void *key);
-long bpftime_map_update_elem(int fd, const void *key, const void *value,
-			     uint64_t flags);
-long bpftime_map_delete_elem(int fd, const void *key);
+uint32_t bpftime_map_value_size_from_syscall(int fd);
+int bpftime_map_get_next_key_from_helper(int fd, const void *key,
+					 void *next_key);
+const void *bpftime_map_lookup_elem_from_helper(int fd, const void *key);
+long bpftime_map_update_elem_from_helper(int fd, const void *key,
+					 const void *value, uint64_t flags);
+long bpftime_map_delete_elem_from_helper(int fd, const void *key);
+
+int bpftime_map_get_next_key_from_syscall(int fd, const void *key,
+					 void *next_key);
+const void *bpftime_map_lookup_elem_from_syscall(int fd, const void *key);
+long bpftime_map_update_elem_from_syscall(int fd, const void *key,
+					 const void *value, uint64_t flags);
+long bpftime_map_delete_elem_from_syscall(int fd, const void *key);
+
 
 int bpftime_uprobe_create(int pid, const char *name, uint64_t offset,
 			  bool retprobe, size_t ref_ctr_off);
@@ -76,8 +86,8 @@ void *bpftime_get_array_map_raw_data(int fd);
 void bpftime_close(int fd);
 void *bpftime_ringbuf_reserve(int fd, uint64_t size);
 void bpftime_ringbuf_submit(int fd, void *data, int discard);
-int bpftime_epoll_wait(int fd, struct epoll_event* out_evts, int max_evt,
-			       int timeout);
+int bpftime_epoll_wait(int fd, struct epoll_event *out_evts, int max_evt,
+		       int timeout);
 int bpftime_add_software_perf_event(int cpu, int32_t sample_type,
 				    int64_t config);
 int bpftime_is_software_perf_event(int fd);

--- a/runtime/include/syscall_table.hpp
+++ b/runtime/include/syscall_table.hpp
@@ -19,6 +19,10 @@ syscall_tracepoint_table create_syscall_tracepoint_table();
 const syscall_tracepoint_table &get_global_syscall_tracepoint_table();
 // Get the name mapping of syscall name <-> syscall id
 const syscall_id_pair &get_global_syscall_id_table();
+
+constexpr const char *GLOBAL_SYS_ENTER_NAME = "*SYS_ENTER";
+constexpr const char *GLOBAL_SYS_EXIT_NAME = "*SYS_EXIT";
+
 } // namespace bpftime
 
 #endif

--- a/runtime/src/attach/bpf_attach_ctx.cpp
+++ b/runtime/src/attach/bpf_attach_ctx.cpp
@@ -143,7 +143,8 @@ int64_t bpf_attach_ctx::run_syscall_hooker(int64_t sys_nr, int64_t arg1,
 {
 	if (sys_nr == __NR_exit_group || sys_nr == __NR_exit)
 		return orig_syscall(sys_nr, arg1, arg2, arg3, arg4, arg5, arg6);
-	spdlog::debug("Syscall callback");
+	spdlog::debug("Syscall callback {} {} {} {} {} {} {}", sys_nr, arg1,
+		      arg2, arg3, arg4, arg5, arg6);
 	if (!sys_enter_progs[sys_nr].empty() ||
 	    !global_sys_enter_progs.empty()) {
 		trace_event_raw_sys_enter ctx;
@@ -305,8 +306,8 @@ int bpf_attach_ctx::init_attach_ctx_from_handlers(
 				break;
 			}
 			spdlog::debug("Create attach event {} {} {} for {}", i,
-				     event_handler._module_name,
-				     event_handler.offset, fd);
+				      event_handler._module_name,
+				      event_handler.offset, fd);
 			if (fd < 0) {
 				return fd;
 			}

--- a/runtime/src/attach/bpf_attach_ctx.cpp
+++ b/runtime/src/attach/bpf_attach_ctx.cpp
@@ -143,7 +143,7 @@ int64_t bpf_attach_ctx::run_syscall_hooker(int64_t sys_nr, int64_t arg1,
 {
 	if (sys_nr == __NR_exit_group || sys_nr == __NR_exit)
 		return orig_syscall(sys_nr, arg1, arg2, arg3, arg4, arg5, arg6);
-	// spdlog::debug("Syscall callback");
+	spdlog::debug("Syscall callback");
 	if (!sys_enter_progs[sys_nr].empty() ||
 	    !global_sys_enter_progs.empty()) {
 		trace_event_raw_sys_enter ctx;
@@ -156,7 +156,7 @@ int64_t bpf_attach_ctx::run_syscall_hooker(int64_t sys_nr, int64_t arg1,
 		ctx.args[4] = arg5;
 		ctx.args[5] = arg6;
 		const auto exec = [&](const bpftime_prog *prog) {
-			// spdlog::debug("Call {}",prog->prog_name());
+			spdlog::debug("Call {}", prog->prog_name());
 			auto lctx = ctx;
 			// Avoid polluting other ebpf programs..
 			uint64_t ret;
@@ -217,15 +217,15 @@ int bpf_attach_ctx::init_attach_ctx_from_handlers(
 			if (res < 0) {
 				return res;
 			}
-			spdlog::info("Load prog {} {}", i, prog_handler.name);
+			spdlog::debug("Load prog {} {}", i, prog_handler.name);
 		} else if (std::holds_alternative<bpf_map_handler>(handler)) {
-			spdlog::info("bpf_map_handler found at {}", i);
+			spdlog::debug("bpf_map_handler found at {}", i);
 		} else if (std::holds_alternative<bpf_perf_event_handler>(
 				   handler)) {
 			spdlog::debug("Will handle bpf_perf_events later...");
 
 		} else if (std::holds_alternative<epoll_handler>(handler)) {
-			spdlog::info(
+			spdlog::debug(
 				"No extra operations needed for epoll_handler..");
 		} else {
 			spdlog::error("Unsupported handler type {}",
@@ -297,14 +297,14 @@ int bpf_attach_ctx::init_attach_ctx_from_handlers(
 			}
 			case bpf_perf_event_handler::bpf_event_type::
 				PERF_TYPE_SOFTWARE: {
-				spdlog::info(
+				spdlog::debug(
 					"Attaching software perf event, nothing need to do");
 				fd = i;
 			}
 			default:
 				break;
 			}
-			spdlog::info("Create attach event {} {} {} for {}", i,
+			spdlog::debug("Create attach event {} {} {} for {}", i,
 				     event_handler._module_name,
 				     event_handler.offset, fd);
 			if (fd < 0) {
@@ -325,7 +325,7 @@ int bpf_attach_ctx::attach_progs_in_manager(const handler_manager *manager)
 		auto &prog_handler =
 			std::get<bpf_prog_handler>(manager->get_handler(id));
 		for (auto fd : prog_handler.attach_fds) {
-			spdlog::info("Attaching prog {} to fd {}", id, fd);
+			spdlog::debug("Attaching prog {} to fd {}", id, fd);
 			attach_prog(prog.second.get(), fd);
 		}
 	}

--- a/runtime/src/bpf_helper.cpp
+++ b/runtime/src/bpf_helper.cpp
@@ -115,21 +115,21 @@ uint64_t bpftime_get_current_comm(uint64_t buf, uint64_t size, uint64_t,
 uint64_t bpftime_map_lookup_elem_helper(uint64_t map, uint64_t key, uint64_t,
 					uint64_t, uint64_t)
 {
-	return (uint64_t)bpftime_map_lookup_elem(map >> 32, (void *)key);
+	return (uint64_t)bpftime_map_lookup_elem_from_helper(map >> 32, (void *)key);
 }
 
 uint64_t bpftime_map_update_elem_helper(uint64_t map, uint64_t key,
 					uint64_t value, uint64_t flags,
 					uint64_t)
 {
-	return (uint64_t)bpftime_map_update_elem(map >> 32, (void *)key,
+	return (uint64_t)bpftime_map_update_elem_from_helper(map >> 32, (void *)key,
 						 (void *)value, flags);
 }
 
 uint64_t bpftime_map_delete_elem_helper(uint64_t map, uint64_t key, uint64_t,
 					uint64_t, uint64_t)
 {
-	return (uint64_t)bpftime_map_delete_elem(map >> 32, (void *)key);
+	return (uint64_t)bpftime_map_delete_elem_from_helper(map >> 32, (void *)key);
 }
 
 uint64_t bpf_probe_read_str(uint64_t buf, uint64_t bufsz, uint64_t ptr,
@@ -204,7 +204,7 @@ uint64_t bpf_perf_event_output(uint64_t ctx, uint64_t map, uint64_t flags,
 	}
 	int fd = map >> 32;
 	const int32_t *val_ptr =
-		(int32_t *)(uintptr_t)bpftime_map_lookup_elem(fd, &current_cpu);
+		(int32_t *)(uintptr_t)bpftime_map_lookup_elem_from_helper(fd, &current_cpu);
 	if (val_ptr == nullptr) {
 		spdlog::error("Invalid map fd for perf event output: {}", fd);
 		errno = EINVAL;

--- a/runtime/src/bpf_map/hash_map.cpp
+++ b/runtime/src/bpf_map/hash_map.cpp
@@ -1,3 +1,5 @@
+#include "spdlog/fmt/bin_to_hex.h"
+#include "spdlog/spdlog.h"
 #include <bpf_map/hash_map.hpp>
 #include <algorithm>
 #include <functional>
@@ -15,13 +17,16 @@ hash_map_impl::hash_map_impl(managed_shared_memory &memory, uint32_t key_size,
 }
 void *hash_map_impl::elem_lookup(const void *key)
 {
+	spdlog::trace("Peform elem lookup of hash map");
 	// Allocate as a local variable to make
 	//  it thread safe, since we use sharable lock
 	bytes_vec key_vec = this->key_vec;
 	key_vec.assign((uint8_t *)key, (uint8_t *)key + _key_size);
 	if (auto itr = map_impl.find(key_vec); itr != map_impl.end()) {
+		spdlog::trace("Exit elem lookup of hash map");
 		return &itr->second[0];
 	} else {
+		spdlog::trace("Exit elem lookup of hash map");
 		errno = ENOENT;
 		return nullptr;
 	}
@@ -67,6 +72,7 @@ int hash_map_impl::bpf_map_get_next_key(const void *key, void *next_key)
 	// it thread safe, since we use sharable lock
 	bytes_vec key_vec = this->key_vec;
 	key_vec.assign((uint8_t *)key, (uint8_t *)key + _key_size);
+
 	auto itr = map_impl.find(key_vec);
 	if (itr == map_impl.end()) {
 		// not found, should be refer to the first key

--- a/runtime/src/bpf_map/hash_map.cpp
+++ b/runtime/src/bpf_map/hash_map.cpp
@@ -1,4 +1,3 @@
-#include "spdlog/fmt/bin_to_hex.h"
 #include "spdlog/spdlog.h"
 #include <bpf_map/hash_map.hpp>
 #include <algorithm>

--- a/runtime/src/bpf_map/hash_map.hpp
+++ b/runtime/src/bpf_map/hash_map.hpp
@@ -7,23 +7,11 @@
 #include <bpf_map/map_common_def.hpp>
 #include <boost/unordered/unordered_map.hpp>
 #include <boost/functional/hash.hpp>
-#include <cstddef>
 namespace bpftime
 {
 
 using namespace boost::interprocess;
 
-struct bytes_vec_hasher {
-	size_t operator()(bytes_vec const &vec) const
-	{
-		using boost::hash_combine;
-		size_t seed = 0;
-		hash_combine(seed, vec.size());
-		for (auto x : vec)
-			hash_combine(seed, x);
-		return seed;
-	}
-};
 
 // implementation of hash map
 class hash_map_impl {

--- a/runtime/src/bpf_map/map_common_def.hpp
+++ b/runtime/src/bpf_map/map_common_def.hpp
@@ -1,6 +1,7 @@
 #ifndef _MAP_COMMON_DEF_HPP
 #define _MAP_COMMON_DEF_HPP
 #include "spdlog/spdlog.h"
+#include <boost/container_hash/hash.hpp>
 #include <cinttypes>
 #include <boost/interprocess/managed_shared_memory.hpp>
 #include <boost/interprocess/containers/vector.hpp>
@@ -27,6 +28,17 @@ template <class T> T ensure_on_current_cpu(std::function<T(int cpu)> func)
 	return ret;
 }
 
+struct bytes_vec_hasher {
+	size_t operator()(bytes_vec const &vec) const
+	{
+		using boost::hash_combine;
+		size_t seed = 0;
+		hash_combine(seed, vec.size());
+		for (auto x : vec)
+			hash_combine(seed, x);
+		return seed;
+	}
+};
 } // namespace bpftime
 
 #endif

--- a/runtime/src/bpf_map/map_common_def.hpp
+++ b/runtime/src/bpf_map/map_common_def.hpp
@@ -1,14 +1,31 @@
 #ifndef _MAP_COMMON_DEF_HPP
 #define _MAP_COMMON_DEF_HPP
+#include "spdlog/spdlog.h"
 #include <cinttypes>
 #include <boost/interprocess/managed_shared_memory.hpp>
 #include <boost/interprocess/containers/vector.hpp>
+#include <functional>
+#include <sched.h>
 namespace bpftime
 {
 
 using bytes_vec_allocator = boost::interprocess::allocator<
 	uint8_t, boost::interprocess::managed_shared_memory::segment_manager>;
 using bytes_vec = boost::interprocess::vector<uint8_t, bytes_vec_allocator>;
+
+template <class T> T ensure_on_current_cpu(std::function<T(int cpu)> func)
+{
+	cpu_set_t orig, set;
+	CPU_ZERO(&orig);
+	CPU_ZERO(&set);
+	sched_getaffinity(0, sizeof(orig), &orig);
+	int currcpu = sched_getcpu();
+	CPU_SET(currcpu, &set);
+	sched_setaffinity(0, sizeof(set), &set);
+	T ret = func(currcpu);
+	sched_setaffinity(0, sizeof(orig), &orig);
+	return ret;
+}
 
 } // namespace bpftime
 

--- a/runtime/src/bpf_map/per_cpu_array_map.cpp
+++ b/runtime/src/bpf_map/per_cpu_array_map.cpp
@@ -1,45 +1,130 @@
 #include "bpf_map/map_common_def.hpp"
+#include "spdlog/spdlog.h"
+#include <algorithm>
 #include <bpf_map/per_cpu_array_map.hpp>
+#include <cerrno>
 #include <unistd.h>
 namespace bpftime
 {
 per_cpu_array_map_impl::per_cpu_array_map_impl(
 	boost::interprocess::managed_shared_memory &memory, uint32_t value_size,
-	uint32_t max_entries)
-	: impl(memory.get_segment_manager())
+	uint32_t max_entries, uint32_t ncpu)
+	: data(memory.get_segment_manager()), ncpu(ncpu),
+	  value_size(value_size), max_ent(max_entries)
 {
-	int num_cpu = sysconf(_SC_NPROCESSORS_ONLN);
-	for (int i = 0; i < num_cpu; i++) {
-		impl.emplace_back(memory, value_size, max_entries);
-	}
+	data.resize(max_entries * ncpu * value_size);
+}
+
+per_cpu_array_map_impl::per_cpu_array_map_impl(
+	boost::interprocess::managed_shared_memory &memory, uint32_t value_size,
+	uint32_t max_entries)
+	: per_cpu_array_map_impl(memory, value_size, max_entries,
+				 sysconf(_SC_NPROCESSORS_ONLN))
+{
 }
 
 void *per_cpu_array_map_impl::elem_lookup(const void *key)
 {
-	return ensure_on_current_cpu<void *>(
-		[&](int cpu) { return impl[cpu].elem_lookup(key); });
+	return ensure_on_current_cpu<void *>([&](int cpu) -> void * {
+		if (key == nullptr) {
+			errno = ENOENT;
+			return nullptr;
+		}
+		uint32_t key_val = *(uint32_t *)key;
+		if (key_val >= max_ent) {
+			errno = E2BIG;
+			return nullptr;
+		}
+		return data_at(key_val, cpu);
+	});
 }
 
 long per_cpu_array_map_impl::elem_update(const void *key, const void *value,
 					 uint64_t flags)
 {
-	return ensure_on_current_cpu<long>([&](int cpu) {
-		return impl[cpu].elem_update(key, value, flags);
+	return ensure_on_current_cpu<long>([&](int cpu) -> long {
+		// return impl[cpu].elem_update(key, value, flags);
+		if (key == nullptr) {
+			errno = ENOENT;
+			return -1;
+		}
+		uint32_t key_val = *(uint32_t *)key;
+		if (key_val >= max_ent) {
+			errno = E2BIG;
+			return -1;
+		}
+		std::copy((uint8_t *)value, (uint8_t *)value + value_size,
+			  data_at(key_val, cpu));
+		return 0;
 	});
 }
 
 long per_cpu_array_map_impl::elem_delete(const void *key)
 {
-	return ensure_on_current_cpu<long>(
-		[&](int cpu) { return impl[cpu].elem_delete(key); });
+	errno = ENOTSUP;
+	spdlog::error("Deleting of per cpu array is not supported");
+	return -1;
+	// return ensure_on_current_cpu<long>([&](int cpu) {
+
+	// });
 }
 
 int per_cpu_array_map_impl::bpf_map_get_next_key(const void *key,
 						 void *next_key)
 {
-	return ensure_on_current_cpu<int>([&](int cpu) {
-		return impl[cpu].bpf_map_get_next_key(key, next_key);
-	});
+	// Not found
+	if (key == nullptr || *(uint32_t *)key >= max_ent) {
+		*(uint32_t *)next_key = 0;
+		return 0;
+	}
+	uint32_t deref_key = *(uint32_t *)key;
+	// Last element
+	if (deref_key == max_ent - 1) {
+		errno = ENOENT;
+		return -1;
+	}
+	auto key_val = *(uint32_t *)key;
+	*(uint32_t *)next_key = key_val + 1;
+	return 0;
+}
+
+void *per_cpu_array_map_impl::elem_lookup_userspace(const void *key)
+{
+	if (key == nullptr) {
+		errno = ENOENT;
+		return nullptr;
+	}
+	uint32_t key_val = *(uint32_t *)key;
+	if (key_val >= max_ent) {
+		errno = E2BIG;
+		return nullptr;
+	}
+	return data_at(key_val, 0);
+}
+
+long per_cpu_array_map_impl::elem_update_userspace(const void *key,
+						   const void *value,
+						   uint64_t flags)
+{
+	if (key == nullptr) {
+		errno = ENOENT;
+		return -1;
+	}
+	uint32_t key_val = *(uint32_t *)key;
+	if (key_val >= max_ent) {
+		errno = E2BIG;
+		return -1;
+	}
+	std::copy((uint8_t *)value, (uint8_t *)value + ncpu * value_size,
+		  data_at(key_val, 0));
+	return 0;
+}
+
+long per_cpu_array_map_impl::elem_delete_userspace(const void *key)
+{
+	errno = ENOTSUP;
+	spdlog::error("Element delete is not supported by per cpu array");
+	return -1;
 }
 
 } // namespace bpftime

--- a/runtime/src/bpf_map/per_cpu_array_map.cpp
+++ b/runtime/src/bpf_map/per_cpu_array_map.cpp
@@ -1,0 +1,45 @@
+#include "bpf_map/map_common_def.hpp"
+#include <bpf_map/per_cpu_array_map.hpp>
+#include <unistd.h>
+namespace bpftime
+{
+per_cpu_array_map_impl::per_cpu_array_map_impl(
+	boost::interprocess::managed_shared_memory &memory, uint32_t value_size,
+	uint32_t max_entries)
+	: impl(memory.get_segment_manager())
+{
+	int num_cpu = sysconf(_SC_NPROCESSORS_ONLN);
+	for (int i = 0; i < num_cpu; i++) {
+		impl.emplace_back(memory, value_size, max_entries);
+	}
+}
+
+void *per_cpu_array_map_impl::elem_lookup(const void *key)
+{
+	return ensure_on_current_cpu<void *>(
+		[&](int cpu) { return impl[cpu].elem_lookup(key); });
+}
+
+long per_cpu_array_map_impl::elem_update(const void *key, const void *value,
+					 uint64_t flags)
+{
+	return ensure_on_current_cpu<long>([&](int cpu) {
+		return impl[cpu].elem_update(key, value, flags);
+	});
+}
+
+long per_cpu_array_map_impl::elem_delete(const void *key)
+{
+	return ensure_on_current_cpu<long>(
+		[&](int cpu) { return impl[cpu].elem_delete(key); });
+}
+
+int per_cpu_array_map_impl::bpf_map_get_next_key(const void *key,
+						 void *next_key)
+{
+	return ensure_on_current_cpu<int>([&](int cpu) {
+		return impl[cpu].bpf_map_get_next_key(key, next_key);
+	});
+}
+
+} // namespace bpftime

--- a/runtime/src/bpf_map/per_cpu_array_map.hpp
+++ b/runtime/src/bpf_map/per_cpu_array_map.hpp
@@ -1,0 +1,39 @@
+#ifndef _BPFTIME_PER_CPU_ARRAY_MAP_HPP
+#define _BPFTIME_PER_CPU_ARRAY_MAP_HPP
+#include "bpf_map/array_map.hpp"
+#include <boost/interprocess/allocators/allocator.hpp>
+#include <boost/interprocess/interprocess_fwd.hpp>
+#include <boost/interprocess/managed_shared_memory.hpp>
+#include <boost/interprocess/smart_ptr/unique_ptr.hpp>
+#include <boost/interprocess/containers/vector.hpp>
+
+#include <cstdint>
+namespace bpftime
+{
+
+using array_map_vec_allocator = boost::interprocess::allocator<
+	array_map_impl,
+	boost::interprocess::managed_shared_memory::segment_manager>;
+using array_map_vec =
+	boost::interprocess::vector<array_map_impl, array_map_vec_allocator>;
+class per_cpu_array_map_impl {
+	array_map_vec impl;
+
+    public:
+	const static bool should_lock = false;
+
+	per_cpu_array_map_impl(
+		boost::interprocess::managed_shared_memory &memory,
+		uint32_t value_size, uint32_t max_entries);
+
+	void *elem_lookup(const void *key);
+
+	long elem_update(const void *key, const void *value, uint64_t flags);
+
+	long elem_delete(const void *key);
+
+	int bpf_map_get_next_key(const void *key, void *next_key);
+};
+} // namespace bpftime
+
+#endif

--- a/runtime/src/bpf_map/per_cpu_array_map.hpp
+++ b/runtime/src/bpf_map/per_cpu_array_map.hpp
@@ -1,6 +1,6 @@
 #ifndef _BPFTIME_PER_CPU_ARRAY_MAP_HPP
 #define _BPFTIME_PER_CPU_ARRAY_MAP_HPP
-#include "bpf_map/array_map.hpp"
+#include "bpf_map/map_common_def.hpp"
 #include <boost/interprocess/allocators/allocator.hpp>
 #include <boost/interprocess/interprocess_fwd.hpp>
 #include <boost/interprocess/managed_shared_memory.hpp>
@@ -11,17 +11,23 @@
 namespace bpftime
 {
 
-using array_map_vec_allocator = boost::interprocess::allocator<
-	array_map_impl,
-	boost::interprocess::managed_shared_memory::segment_manager>;
-using array_map_vec =
-	boost::interprocess::vector<array_map_impl, array_map_vec_allocator>;
 class per_cpu_array_map_impl {
-	array_map_vec impl;
+	bytes_vec data;
+
+	int ncpu;
+	uint32_t value_size;
+	uint32_t max_ent;
+	uint8_t *data_at(size_t idx, size_t cpu)
+	{
+		return data.data() + idx * value_size * ncpu + cpu * value_size;
+	}
 
     public:
 	const static bool should_lock = false;
 
+	per_cpu_array_map_impl(
+		boost::interprocess::managed_shared_memory &memory,
+		uint32_t value_size, uint32_t max_entries, uint32_t ncpu);
 	per_cpu_array_map_impl(
 		boost::interprocess::managed_shared_memory &memory,
 		uint32_t value_size, uint32_t max_entries);
@@ -33,6 +39,13 @@ class per_cpu_array_map_impl {
 	long elem_delete(const void *key);
 
 	int bpf_map_get_next_key(const void *key, void *next_key);
+
+	void *elem_lookup_userspace(const void *key);
+
+	long elem_update_userspace(const void *key, const void *value,
+				   uint64_t flags);
+
+	long elem_delete_userspace(const void *key);
 };
 } // namespace bpftime
 

--- a/runtime/src/bpf_map/per_cpu_hash_map.cpp
+++ b/runtime/src/bpf_map/per_cpu_hash_map.cpp
@@ -1,0 +1,51 @@
+#include "bpf_map/map_common_def.hpp"
+#include "spdlog/spdlog.h"
+#include <bpf_map/per_cpu_hash_map.hpp>
+#include <unistd.h>
+namespace bpftime
+{
+per_cpu_hash_map_impl::per_cpu_hash_map_impl(
+	boost::interprocess::managed_shared_memory &memory, uint32_t key_size,
+	uint32_t value_size)
+	: impl(memory.get_segment_manager())
+{
+	int num_cpu = sysconf(_SC_NPROCESSORS_ONLN);
+	for (int i = 0; i < num_cpu; i++) {
+		impl.emplace_back(memory, key_size, value_size);
+	}
+}
+
+void *per_cpu_hash_map_impl::elem_lookup(const void *key)
+{
+	return ensure_on_current_cpu<void *>([&](int cpu) {
+		spdlog::debug("Run per cpu hash lookup at cpu {}", cpu);
+		return impl[cpu].elem_lookup(key);
+	});
+}
+
+long per_cpu_hash_map_impl::elem_update(const void *key, const void *value,
+					uint64_t flags)
+{
+	return ensure_on_current_cpu<long>([&](int cpu) {
+		spdlog::debug("Run per cpu hash update at cpu {}", cpu);
+		return impl[cpu].elem_update(key, value, flags);
+	});
+}
+
+long per_cpu_hash_map_impl::elem_delete(const void *key)
+{
+	return ensure_on_current_cpu<long>([&](int cpu) {
+		spdlog::debug("Run per cpu hash delete at cpu {}", cpu);
+		return impl[cpu].elem_delete(key);
+	});
+}
+
+int per_cpu_hash_map_impl::bpf_map_get_next_key(const void *key, void *next_key)
+{
+	return ensure_on_current_cpu<int>([&](int cpu) {
+		spdlog::debug("Run per cpu hash get next key at cpu {}", cpu);
+		return impl[cpu].bpf_map_get_next_key(key, next_key);
+	});
+}
+
+} // namespace bpftime

--- a/runtime/src/bpf_map/per_cpu_hash_map.cpp
+++ b/runtime/src/bpf_map/per_cpu_hash_map.cpp
@@ -1,5 +1,7 @@
 #include "bpf_map/map_common_def.hpp"
+#include "spdlog/fmt/bin_to_hex.h"
 #include "spdlog/spdlog.h"
+#include <algorithm>
 #include <bpf_map/per_cpu_hash_map.hpp>
 #include <unistd.h>
 namespace bpftime
@@ -7,45 +9,159 @@ namespace bpftime
 per_cpu_hash_map_impl::per_cpu_hash_map_impl(
 	boost::interprocess::managed_shared_memory &memory, uint32_t key_size,
 	uint32_t value_size)
-	: impl(memory.get_segment_manager())
+	: per_cpu_hash_map_impl(memory, key_size, value_size,
+				sysconf(_SC_NPROCESSORS_ONLN))
 {
-	int num_cpu = sysconf(_SC_NPROCESSORS_ONLN);
-	for (int i = 0; i < num_cpu; i++) {
-		impl.emplace_back(memory, key_size, value_size);
-	}
+}
+
+per_cpu_hash_map_impl::per_cpu_hash_map_impl(
+	boost::interprocess::managed_shared_memory &memory, uint32_t key_size,
+	uint32_t value_size, int ncpu)
+	: impl(memory.get_segment_manager()), key_size(key_size),
+	  value_size(value_size), ncpu(ncpu),
+	  key_template(key_size, memory.get_segment_manager()),
+	  value_template(value_size * ncpu, memory.get_segment_manager()),
+	  single_value_template(value_size, memory.get_segment_manager())
+{
+	spdlog::debug(
+		"Initializing per cpu hash, key size {}, value size {}, ncpu {}",
+		key_size, value_size, ncpu);
 }
 
 void *per_cpu_hash_map_impl::elem_lookup(const void *key)
 {
-	return ensure_on_current_cpu<void *>([&](int cpu) {
+	return ensure_on_current_cpu<void *>([&](int cpu) -> void * {
 		spdlog::debug("Run per cpu hash lookup at cpu {}", cpu);
-		return impl[cpu].elem_lookup(key);
+		if (key == nullptr) {
+			errno = ENOENT;
+			return nullptr;
+		}
+		bytes_vec key_vec = this->key_template;
+		key_vec.assign((uint8_t *)key, (uint8_t *)key + key_size);
+		if (auto itr = impl.find(key_vec); itr != impl.end()) {
+			spdlog::trace("Exit elem lookup of hash map");
+			return &itr->second[value_size * cpu];
+		} else {
+			spdlog::trace("Exit elem lookup of hash map");
+			errno = ENOENT;
+			return nullptr;
+		}
 	});
 }
 
 long per_cpu_hash_map_impl::elem_update(const void *key, const void *value,
 					uint64_t flags)
 {
-	return ensure_on_current_cpu<long>([&](int cpu) {
+	spdlog::debug("Per cpu update, key {}, value {}",(const char*)key,*(long*)value);
+	return ensure_on_current_cpu<long>([&](int cpu) -> long {
 		spdlog::debug("Run per cpu hash update at cpu {}", cpu);
-		return impl[cpu].elem_update(key, value, flags);
+		bytes_vec key_vec = this->key_template;
+		bytes_vec value_vec = this->single_value_template;
+		key_vec.assign((uint8_t *)key, (uint8_t *)key + key_size);
+		value_vec.assign((uint8_t *)value,
+				 (uint8_t *)value + value_size);
+		if (auto itr = impl.find(key_vec); itr != impl.end()) {
+			std::copy(value_vec.begin(), value_vec.end(),
+				  itr->second.begin() + cpu * value_size);
+		} else {
+			bytes_vec full_value_vec = this->value_template;
+			std::copy(value_vec.begin(), value_vec.end(),
+				  full_value_vec.begin() + cpu * value_size);
+
+			impl.insert(bi_map_value_ty(key_vec, full_value_vec));
+		}
+
+		return 0;
 	});
 }
 
 long per_cpu_hash_map_impl::elem_delete(const void *key)
 {
-	return ensure_on_current_cpu<long>([&](int cpu) {
+	return ensure_on_current_cpu<long>([&](int cpu) -> long {
 		spdlog::debug("Run per cpu hash delete at cpu {}", cpu);
-		return impl[cpu].elem_delete(key);
+		bytes_vec key_vec = this->key_template;
+		key_vec.assign((uint8_t *)key, (uint8_t *)key + key_size);
+		if (auto itr = impl.find(key_vec); itr != impl.end()) {
+			std::fill(itr->second.begin(),
+				  itr->second.begin() + cpu * value_size, 0);
+		}
+		return 0;
 	});
 }
 
 int per_cpu_hash_map_impl::bpf_map_get_next_key(const void *key, void *next_key)
 {
-	return ensure_on_current_cpu<int>([&](int cpu) {
-		spdlog::debug("Run per cpu hash get next key at cpu {}", cpu);
-		return impl[cpu].bpf_map_get_next_key(key, next_key);
-	});
+	if (key == nullptr) {
+		// nullptr means the first key
+		auto itr = impl.begin();
+		if (itr == impl.end()) {
+			errno = ENOENT;
+			return -1;
+		}
+		std::copy(itr->first.begin(), itr->first.end(),
+			  (uint8_t *)next_key);
+		return 0;
+	}
+	// No need to be allocated at shm. Allocate as a local variable to make
+	// it thread safe, since we use sharable lock
+	bytes_vec key_vec = this->key_template;
+	key_vec.assign((uint8_t *)key, (uint8_t *)key + key_size);
+
+	auto itr = impl.find(key_vec);
+	if (itr == impl.end()) {
+		// not found, should be refer to the first key
+		return bpf_map_get_next_key(nullptr, next_key);
+	}
+	itr++;
+	if (itr == impl.end()) {
+		// If *key* is the last element, returns -1 and *errno*
+		// is set to **ENOENT**.
+		errno = ENOENT;
+		return -1;
+	}
+	std::copy(itr->first.begin(), itr->first.end(), (uint8_t *)next_key);
+	return 0;
+}
+void *per_cpu_hash_map_impl::elem_lookup_userspace(const void *key)
+{
+	if (key == nullptr) {
+		errno = ENOENT;
+		return nullptr;
+	}
+	bytes_vec key_vec = this->key_template;
+	key_vec.assign((uint8_t *)key, (uint8_t *)key + key_size);
+	if (auto itr = impl.find(key_vec); itr != impl.end()) {
+		spdlog::trace("Exit elem lookup of hash map: {}",spdlog::to_hex(itr->second.begin(),itr->second.end()));
+		return &itr->second[0];
+	} else {
+		spdlog::trace("Exit elem lookup of hash map");
+		errno = ENOENT;
+		return nullptr;
+	}
 }
 
+long per_cpu_hash_map_impl::elem_update_userspace(const void *key,
+						  const void *value,
+						  uint64_t flags)
+{
+	bytes_vec key_vec = this->key_template;
+	bytes_vec value_vec = this->value_template;
+	key_vec.assign((uint8_t *)key, (uint8_t *)key + key_size);
+	value_vec.assign((uint8_t *)value,
+			 (uint8_t *)value + value_size * ncpu);
+
+	if (auto itr = impl.find(key_vec); itr != impl.end()) {
+		itr->second = value_vec;
+	} else {
+		impl.insert(bi_map_value_ty(key_vec, value_vec));
+	}
+	return 0;
+}
+long per_cpu_hash_map_impl::elem_delete_userspace(const void *key)
+{
+	bytes_vec key_vec = this->key_template;
+	key_vec.assign((uint8_t *)key, (uint8_t *)key + key_size);
+	impl.erase(key_vec);
+	return 0;
+}
 } // namespace bpftime

--- a/runtime/src/bpf_map/per_cpu_hash_map.hpp
+++ b/runtime/src/bpf_map/per_cpu_hash_map.hpp
@@ -1,30 +1,39 @@
 #ifndef _BPFTIME_PER_CPU_HASH_MAP_HPP
 #define _BPFTIME_PER_CPU_HASH_MAP_HPP
-#include "bpf_map/hash_map.hpp"
 #include <boost/interprocess/allocators/allocator.hpp>
 #include <boost/interprocess/interprocess_fwd.hpp>
 #include <boost/interprocess/managed_shared_memory.hpp>
 #include <boost/interprocess/smart_ptr/unique_ptr.hpp>
 #include <boost/interprocess/containers/vector.hpp>
-
+#include <bpf_map/map_common_def.hpp>
+#include <boost/unordered/unordered_map.hpp>
 #include <cstdint>
 namespace bpftime
 {
 
-using hash_map_vec_allocator = boost::interprocess::allocator<
-	hash_map_impl,
-	boost::interprocess::managed_shared_memory::segment_manager>;
-using hash_map_vec =
-	boost::interprocess::vector<hash_map_impl, hash_map_vec_allocator>;
 class per_cpu_hash_map_impl {
-	hash_map_vec impl;
+	using bi_map_value_ty = std::pair<const bytes_vec, bytes_vec>;
+	using bi_map_allocator = boost::interprocess::allocator<
+		bi_map_value_ty,
+		boost::interprocess::managed_shared_memory::segment_manager>;
+	using shm_hash_map =
+		boost::unordered_map<bytes_vec, bytes_vec, bytes_vec_hasher,
+				     std::equal_to<bytes_vec>, bi_map_allocator>;
+
+	shm_hash_map impl;
+	uint32_t key_size;
+	uint32_t value_size;
+	int ncpu;
+
+	bytes_vec key_template, value_template, single_value_template;
 
     public:
 	const static bool should_lock = false;
 
 	per_cpu_hash_map_impl(boost::interprocess::managed_shared_memory &memory,
 			      uint32_t key_size, uint32_t value_size);
-
+	per_cpu_hash_map_impl(boost::interprocess::managed_shared_memory &memory,
+			      uint32_t key_size, uint32_t value_size, int ncpu);
 	void *elem_lookup(const void *key);
 
 	long elem_update(const void *key, const void *value, uint64_t flags);
@@ -32,6 +41,13 @@ class per_cpu_hash_map_impl {
 	long elem_delete(const void *key);
 
 	int bpf_map_get_next_key(const void *key, void *next_key);
+
+	void *elem_lookup_userspace(const void *key);
+
+	long elem_update_userspace(const void *key, const void *value,
+				   uint64_t flags);
+
+	long elem_delete_userspace(const void *key);
 };
 } // namespace bpftime
 

--- a/runtime/src/bpf_map/per_cpu_hash_map.hpp
+++ b/runtime/src/bpf_map/per_cpu_hash_map.hpp
@@ -1,0 +1,38 @@
+#ifndef _BPFTIME_PER_CPU_HASH_MAP_HPP
+#define _BPFTIME_PER_CPU_HASH_MAP_HPP
+#include "bpf_map/hash_map.hpp"
+#include <boost/interprocess/allocators/allocator.hpp>
+#include <boost/interprocess/interprocess_fwd.hpp>
+#include <boost/interprocess/managed_shared_memory.hpp>
+#include <boost/interprocess/smart_ptr/unique_ptr.hpp>
+#include <boost/interprocess/containers/vector.hpp>
+
+#include <cstdint>
+namespace bpftime
+{
+
+using hash_map_vec_allocator = boost::interprocess::allocator<
+	hash_map_impl,
+	boost::interprocess::managed_shared_memory::segment_manager>;
+using hash_map_vec =
+	boost::interprocess::vector<hash_map_impl, hash_map_vec_allocator>;
+class per_cpu_hash_map_impl {
+	hash_map_vec impl;
+
+    public:
+	const static bool should_lock = false;
+
+	per_cpu_hash_map_impl(boost::interprocess::managed_shared_memory &memory,
+			      uint32_t key_size, uint32_t value_size);
+
+	void *elem_lookup(const void *key);
+
+	long elem_update(const void *key, const void *value, uint64_t flags);
+
+	long elem_delete(const void *key);
+
+	int bpf_map_get_next_key(const void *key, void *next_key);
+};
+} // namespace bpftime
+
+#endif

--- a/runtime/src/bpftime_prog.cpp
+++ b/runtime/src/bpftime_prog.cpp
@@ -34,7 +34,7 @@ int bpftime_prog::bpftime_prog_load(bool jit)
 {
 	int res = -1;
 
-	spdlog::info("Load insn cnt {}", insns.size());
+	spdlog::debug("Load insn cnt {}", insns.size());
 	res = ebpf_load(vm, insns.data(),
 			insns.size() * sizeof(struct ebpf_inst), &errmsg);
 	if (res < 0) {

--- a/runtime/src/bpftime_shm.cpp
+++ b/runtime/src/bpftime_shm.cpp
@@ -28,31 +28,57 @@ int bpftime_maps_create(const char *name, bpftime::bpf_map_attr attr)
 {
 	return shm_holder.global_shared_memory.add_bpf_map(name, attr);
 }
-uint32_t bpftime_map_value_size(int fd)
+uint32_t bpftime_map_value_size_from_syscall(int fd)
 {
 	return shm_holder.global_shared_memory.bpf_map_value_size(fd);
 }
 
-const void *bpftime_map_lookup_elem(int fd, const void *key)
+const void *bpftime_map_lookup_elem_from_helper(int fd, const void *key)
 {
-	return shm_holder.global_shared_memory.bpf_map_lookup_elem(fd, key);
+	return shm_holder.global_shared_memory.bpf_map_lookup_elem(fd, key,
+								   false);
 }
 
-long bpftime_map_update_elem(int fd, const void *key, const void *value,
-			     uint64_t flags)
+long bpftime_map_update_elem_from_helper(int fd, const void *key,
+					 const void *value, uint64_t flags)
 {
-	return shm_holder.global_shared_memory.bpf_update_elem(fd, key, value,
-							       flags);
+	return shm_holder.global_shared_memory.bpf_map_update_elem(
+		fd, key, value, flags, false);
 }
 
-long bpftime_map_delete_elem(int fd, const void *key)
+long bpftime_map_delete_elem_from_helper(int fd, const void *key)
 {
-	return shm_holder.global_shared_memory.bpf_delete_elem(fd, key);
+	return shm_holder.global_shared_memory.bpf_delete_elem(fd, key, false);
 }
-int bpftime_map_get_next_key(int fd, const void *key, void *next_key)
+int bpftime_map_get_next_key_from_helper(int fd, const void *key,
+					 void *next_key)
 {
-	return shm_holder.global_shared_memory.bpf_map_get_next_key(fd, key,
-								    next_key);
+	return shm_holder.global_shared_memory.bpf_map_get_next_key(
+		fd, key, next_key, false);
+}
+
+const void *bpftime_map_lookup_elem_from_syscall(int fd, const void *key)
+{
+	return shm_holder.global_shared_memory.bpf_map_lookup_elem(fd, key,
+								   true);
+}
+
+long bpftime_map_update_elem_from_syscall(int fd, const void *key,
+					  const void *value, uint64_t flags)
+{
+	return shm_holder.global_shared_memory.bpf_map_update_elem(
+		fd, key, value, flags, true);
+}
+
+long bpftime_map_delete_elem_from_syscall(int fd, const void *key)
+{
+	return shm_holder.global_shared_memory.bpf_delete_elem(fd, key, true);
+}
+int bpftime_map_get_next_key_from_syscall(int fd, const void *key,
+					  void *next_key)
+{
+	return shm_holder.global_shared_memory.bpf_map_get_next_key(
+		fd, key, next_key, true);
 }
 
 int bpftime_uprobe_create(int pid, const char *name, uint64_t offset,

--- a/runtime/src/bpftime_shm.cpp
+++ b/runtime/src/bpftime_shm.cpp
@@ -67,9 +67,13 @@ int bpftime_tracepoint_create(int pid, int32_t tp_id)
 	return shm_holder.global_shared_memory.add_tracepoint(pid, tp_id);
 }
 
-int bpftime_attach_enable(int fd)
+int bpftime_perf_event_enable(int fd)
 {
-	return shm_holder.global_shared_memory.attach_enable(fd);
+	return shm_holder.global_shared_memory.perf_event_enable(fd);
+}
+int bpftime_perf_event_disable(int fd)
+{
+	return shm_holder.global_shared_memory.perf_event_disable(fd);
 }
 
 int bpftime_attach_perf_to_bpf(int perf_fd, int bpf_fd)

--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -18,8 +18,9 @@ void bpftime_destroy_global_shm()
 	using namespace bpftime;
 	// spdlog::info("Global shm destructed");
 	shm_holder.global_shared_memory.~bpftime_shm();
-	// Why not spdlog? because global variables that spdlog used were already destroyed..
-	puts("Global shm destructed");
+	// Why not spdlog? because global variables that spdlog used were
+	// already destroyed..
+	puts("INFO: Global shm destructed");
 }
 static __attribute__((destructor(65535))) void __destruct_shm()
 {
@@ -144,7 +145,7 @@ int bpftime_shm::attach_perf_to_bpf(int perf_fd, int bpf_fd)
 	return 0;
 }
 
-int bpftime_shm::attach_enable(int fd) const
+int bpftime_shm::perf_event_enable(int fd) const
 {
 	if (!is_perf_fd(fd)) {
 		errno = ENOENT;
@@ -152,8 +153,18 @@ int bpftime_shm::attach_enable(int fd) const
 	}
 	auto &handler = std::get<bpftime::bpf_perf_event_handler>(
 		manager->get_handler(fd));
-	handler.enable();
-	return 0;
+	return handler.enable();
+}
+
+int bpftime_shm::perf_event_disable(int fd) const
+{
+	if (!is_perf_fd(fd)) {
+		errno = ENOENT;
+		return -1;
+	}
+	auto &handler = std::get<bpftime::bpf_perf_event_handler>(
+		manager->get_handler(fd));
+	return handler.disable();
 }
 
 int bpftime_shm::add_software_perf_event_to_epoll(int swpe_fd, int epoll_fd,

--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -57,7 +57,8 @@ uint32_t bpftime_shm::bpf_map_value_size(int fd) const
 		std::get<bpftime::bpf_map_handler>(manager->get_handler(fd));
 	return handler.get_value_size();
 }
-const void *bpftime_shm::bpf_map_lookup_elem(int fd, const void *key) const
+const void *bpftime_shm::bpf_map_lookup_elem(int fd, const void *key,
+					     bool from_userspace) const
 {
 	if (!is_map_fd(fd)) {
 		errno = ENOENT;
@@ -65,11 +66,12 @@ const void *bpftime_shm::bpf_map_lookup_elem(int fd, const void *key) const
 	}
 	auto &handler =
 		std::get<bpftime::bpf_map_handler>(manager->get_handler(fd));
-	return handler.map_lookup_elem(key);
+	return handler.map_lookup_elem(key, from_userspace);
 }
 
-long bpftime_shm::bpf_update_elem(int fd, const void *key, const void *value,
-				  uint64_t flags) const
+long bpftime_shm::bpf_map_update_elem(int fd, const void *key,
+				      const void *value, uint64_t flags,
+				      bool from_userspace) const
 {
 	if (!is_map_fd(fd)) {
 		errno = ENOENT;
@@ -77,10 +79,11 @@ long bpftime_shm::bpf_update_elem(int fd, const void *key, const void *value,
 	}
 	auto &handler =
 		std::get<bpftime::bpf_map_handler>(manager->get_handler(fd));
-	return handler.map_update_elem(key, value, flags);
+	return handler.map_update_elem(key, value, flags, from_userspace);
 }
 
-long bpftime_shm::bpf_delete_elem(int fd, const void *key) const
+long bpftime_shm::bpf_delete_elem(int fd, const void *key,
+				  bool from_userspace) const
 {
 	if (!is_map_fd(fd)) {
 		errno = ENOENT;
@@ -88,11 +91,11 @@ long bpftime_shm::bpf_delete_elem(int fd, const void *key) const
 	}
 	auto &handler =
 		std::get<bpftime::bpf_map_handler>(manager->get_handler(fd));
-	return handler.map_delete_elem(key);
+	return handler.map_delete_elem(key, from_userspace);
 }
 
-int bpftime_shm::bpf_map_get_next_key(int fd, const void *key,
-				      void *next_key) const
+int bpftime_shm::bpf_map_get_next_key(int fd, const void *key, void *next_key,
+				      bool from_userspace) const
 {
 	if (!is_map_fd(fd)) {
 		errno = ENOENT;
@@ -100,7 +103,7 @@ int bpftime_shm::bpf_map_get_next_key(int fd, const void *key,
 	}
 	auto &handler =
 		std::get<bpftime::bpf_map_handler>(manager->get_handler(fd));
-	return handler.bpf_map_get_next_key(key, next_key);
+	return handler.bpf_map_get_next_key(key, next_key, from_userspace);
 }
 
 int bpftime_shm::add_uprobe(int pid, const char *name, uint64_t offset,

--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -9,7 +9,6 @@
 void bpftime_initialize_global_shm()
 {
 	using namespace bpftime;
-	spdlog::info("Global shm constructed");
 	// Use placement new, which will not allocate memory, but just
 	// call the constructor
 	new (&shm_holder.global_shared_memory) bpftime_shm;
@@ -371,7 +370,7 @@ bool bpftime_shm::is_exist_fake_fd(int fd) const
 
 bpftime_shm::bpftime_shm()
 {
-	spdlog::info("global_shm_open_type {} for {}",
+	spdlog::info("Global shm constructed. global_shm_open_type {} for {}",
 		     (int)global_shm_open_type, bpftime::get_global_shm_name());
 	if (global_shm_open_type == shm_open_type::SHM_CLIENT) {
 		spdlog::debug("start: bpftime_shm for client setup");

--- a/runtime/src/bpftime_shm_internal.hpp
+++ b/runtime/src/bpftime_shm_internal.hpp
@@ -88,7 +88,8 @@ class bpftime_shm {
 	int add_software_perf_event(int cpu, int32_t sample_type,
 				    int64_t config);
 	int attach_perf_to_bpf(int perf_fd, int bpf_fd);
-	int attach_enable(int fd) const;
+	int perf_event_enable(int fd) const;
+	int perf_event_disable(int fd) const;
 	int add_ringbuf_to_epoll(int ringbuf_fd, int epoll_fd,
 				 epoll_data_t extra_data);
 	int add_software_perf_event_to_epoll(int swpe_fd, int epoll_fd,

--- a/runtime/src/bpftime_shm_internal.hpp
+++ b/runtime/src/bpftime_shm_internal.hpp
@@ -72,14 +72,17 @@ class bpftime_shm {
 	// create a bpf map fd
 	int add_bpf_map(const char *name, bpftime::bpf_map_attr attr);
 	uint32_t bpf_map_value_size(int fd) const;
-	const void *bpf_map_lookup_elem(int fd, const void *key) const;
+	const void *bpf_map_lookup_elem(int fd, const void *key,
+					bool from_userspace) const;
 
-	long bpf_update_elem(int fd, const void *key, const void *value,
-			     uint64_t flags) const;
+	long bpf_map_update_elem(int fd, const void *key, const void *value,
+			     uint64_t flags, bool from_userspace) const;
 
-	long bpf_delete_elem(int fd, const void *key) const;
+	long bpf_delete_elem(int fd, const void *key,
+			     bool from_userspace) const;
 
-	int bpf_map_get_next_key(int fd, const void *key, void *next_key) const;
+	int bpf_map_get_next_key(int fd, const void *key, void *next_key,
+				 bool from_userspace) const;
 
 	// create an uprobe fd
 	int add_uprobe(int pid, const char *name, uint64_t offset,
@@ -112,7 +115,6 @@ union bpftime_shm_holder {
 	bpftime_shm global_shared_memory;
 	bpftime_shm_holder()
 	{
-		
 	}
 	~bpftime_shm_holder()
 	{

--- a/runtime/src/bpftime_shm_internal.hpp
+++ b/runtime/src/bpftime_shm_internal.hpp
@@ -118,6 +118,8 @@ union bpftime_shm_holder {
 	}
 };
 extern bpftime_shm_holder shm_holder;
-void initialize_global_shm();
+
 } // namespace bpftime
+extern "C" void bpftime_initialize_global_shm();
+extern "C" void bpftime_destroy_global_shm();
 #endif

--- a/runtime/src/handler/map_handler.cpp
+++ b/runtime/src/handler/map_handler.cpp
@@ -13,7 +13,35 @@ using boost::interprocess::sharable_lock;
 
 namespace bpftime
 {
-const void *bpf_map_handler::map_lookup_elem(const void *key) const
+std::string bpf_map_handler::get_container_name()
+{
+	return "ebpf_map_fd_" + std::string(name.c_str());
+}
+uint32_t bpf_map_handler::get_value_size() const
+{
+	auto result = value_size;
+	if ((type == BPF_MAP_TYPE_PERCPU_ARRAY) ||
+	    (type == BPF_MAP_TYPE_PERCPU_HASH)) {
+		result *= sysconf(_SC_NPROCESSORS_ONLN);
+	}
+	return result;
+}
+std::optional<ringbuf_map_impl *>
+bpf_map_handler::try_get_ringbuf_map_impl() const
+{
+	if (type != BPF_MAP_TYPE_RINGBUF)
+		return {};
+	return static_cast<ringbuf_map_impl *>(map_impl_ptr.get());
+}
+std::optional<array_map_impl *> bpf_map_handler::try_get_array_map_impl() const
+{
+	if (type != BPF_MAP_TYPE_ARRAY)
+		return {};
+	return static_cast<array_map_impl *>(map_impl_ptr.get());
+}
+
+const void *bpf_map_handler::map_lookup_elem(const void *key,
+					     bool from_userspace) const
 {
 	const auto do_lookup = [&](auto *impl) -> const void * {
 		if (impl->should_lock) {
@@ -24,6 +52,16 @@ const void *bpf_map_handler::map_lookup_elem(const void *key) const
 			return impl->elem_lookup(key);
 		}
 	};
+	const auto do_lookup_userspace = [&](auto *impl) -> const void * {
+		if (impl->should_lock) {
+			sharable_lock<interprocess_sharable_mutex> guard(
+				*map_mutex);
+			return impl->elem_lookup_userspace(key);
+		} else {
+			return impl->elem_lookup_userspace(key);
+		}
+	};
+
 	switch (type) {
 	case BPF_MAP_TYPE_HASH: {
 		auto impl = static_cast<hash_map_impl *>(map_impl_ptr.get());
@@ -45,12 +83,14 @@ const void *bpf_map_handler::map_lookup_elem(const void *key) const
 	case BPF_MAP_TYPE_PERCPU_ARRAY: {
 		auto impl = static_cast<per_cpu_array_map_impl *>(
 			map_impl_ptr.get());
-		return do_lookup(impl);
+		return from_userspace ? do_lookup_userspace(impl) :
+					do_lookup(impl);
 	}
 	case BPF_MAP_TYPE_PERCPU_HASH: {
 		auto impl = static_cast<per_cpu_hash_map_impl *>(
 			map_impl_ptr.get());
-		return do_lookup(impl);
+		return from_userspace ? do_lookup_userspace(impl) :
+					do_lookup(impl);
 	}
 
 	default:
@@ -60,7 +100,7 @@ const void *bpf_map_handler::map_lookup_elem(const void *key) const
 }
 
 long bpf_map_handler::map_update_elem(const void *key, const void *value,
-				      uint64_t flags) const
+				      uint64_t flags, bool from_userspace) const
 {
 	const auto do_update = [&](auto *impl) -> long {
 		if (impl->should_lock) {
@@ -69,6 +109,16 @@ long bpf_map_handler::map_update_elem(const void *key, const void *value,
 			return impl->elem_update(key, value, flags);
 		} else {
 			return impl->elem_update(key, value, flags);
+		}
+	};
+
+	const auto do_update_userspace = [&](auto *impl) -> long {
+		if (impl->should_lock) {
+			scoped_lock<interprocess_sharable_mutex> guard(
+				*map_mutex);
+			return impl->elem_update_userspace(key, value, flags);
+		} else {
+			return impl->elem_update_userspace(key, value, flags);
 		}
 	};
 	switch (type) {
@@ -92,12 +142,14 @@ long bpf_map_handler::map_update_elem(const void *key, const void *value,
 	case BPF_MAP_TYPE_PERCPU_ARRAY: {
 		auto impl = static_cast<per_cpu_array_map_impl *>(
 			map_impl_ptr.get());
-		return do_update(impl);
+		return from_userspace ? do_update_userspace(impl) :
+					do_update(impl);
 	}
 	case BPF_MAP_TYPE_PERCPU_HASH: {
 		auto impl = static_cast<per_cpu_hash_map_impl *>(
 			map_impl_ptr.get());
-		return do_update(impl);
+		return from_userspace ? do_update_userspace(impl) :
+					do_update(impl);
 	}
 	default:
 		assert(false && "Unsupported map type");
@@ -105,7 +157,8 @@ long bpf_map_handler::map_update_elem(const void *key, const void *value,
 	return 0;
 }
 
-int bpf_map_handler::bpf_map_get_next_key(const void *key, void *next_key) const
+int bpf_map_handler::bpf_map_get_next_key(const void *key, void *next_key,
+					  bool from_userspace) const
 {
 	const auto do_get_next_key = [&](auto *impl) -> int {
 		if (impl->should_lock) {
@@ -150,7 +203,8 @@ int bpf_map_handler::bpf_map_get_next_key(const void *key, void *next_key) const
 	return 0;
 }
 
-long bpf_map_handler::map_delete_elem(const void *key) const
+long bpf_map_handler::map_delete_elem(const void *key,
+				      bool from_userspace) const
 {
 	const auto do_delete = [&](auto *impl) -> long {
 		if (impl->should_lock) {
@@ -161,6 +215,16 @@ long bpf_map_handler::map_delete_elem(const void *key) const
 			return impl->elem_delete(key);
 		}
 	};
+	const auto do_delete_userspace = [&](auto *impl) -> long {
+		if (impl->should_lock) {
+			scoped_lock<interprocess_sharable_mutex> guard(
+				*map_mutex);
+			return impl->elem_delete_userspace(key);
+		} else {
+			return impl->elem_delete_userspace(key);
+		}
+	};
+
 	switch (type) {
 	case BPF_MAP_TYPE_HASH: {
 		auto impl = static_cast<hash_map_impl *>(map_impl_ptr.get());
@@ -182,12 +246,14 @@ long bpf_map_handler::map_delete_elem(const void *key) const
 	case BPF_MAP_TYPE_PERCPU_ARRAY: {
 		auto impl = static_cast<per_cpu_array_map_impl *>(
 			map_impl_ptr.get());
-		return do_delete(impl);
+		return from_userspace ? do_delete_userspace(impl) :
+					do_delete(impl);
 	}
 	case BPF_MAP_TYPE_PERCPU_HASH: {
 		auto impl = static_cast<per_cpu_hash_map_impl *>(
 			map_impl_ptr.get());
-		return do_delete(impl);
+		return from_userspace ? do_delete_userspace(impl) :
+					do_delete(impl);
 	}
 	default:
 		assert(false && "Unsupported map type");

--- a/runtime/src/handler/map_handler.hpp
+++ b/runtime/src/handler/map_handler.hpp
@@ -3,6 +3,7 @@
 #include "bpf_map/array_map.hpp"
 #include "bpf_map/ringbuf_map.hpp"
 #include "bpftime_shm.hpp"
+#include "spdlog/spdlog.h"
 #include <boost/interprocess/managed_shared_memory.hpp>
 #include <boost/interprocess/containers/string.hpp>
 #include <boost/interprocess/smart_ptr/unique_ptr.hpp>
@@ -97,6 +98,7 @@ class bpf_map_handler {
 		  key_size(key_size), value_size(value_size)
 
 	{
+		spdlog::info("Create map with type {}", type);
 		this->name = name;
 	}
 	bpf_map_handler(const bpf_map_handler &) = delete;

--- a/runtime/src/handler/map_handler.hpp
+++ b/runtime/src/handler/map_handler.hpp
@@ -11,6 +11,7 @@
 #include <boost/interprocess/sync/scoped_lock.hpp>
 #include <boost/interprocess/sync/sharable_lock.hpp>
 #include <optional>
+#include <unistd.h>
 namespace bpftime
 {
 using char_allocator = boost::interprocess::allocator<
@@ -98,7 +99,7 @@ class bpf_map_handler {
 		  key_size(key_size), value_size(value_size)
 
 	{
-		spdlog::info("Create map with type {}", type);
+		spdlog::debug("Create map with type {}", type);
 		this->name = name;
 	}
 	bpf_map_handler(const bpf_map_handler &) = delete;
@@ -129,10 +130,12 @@ class bpf_map_handler {
 	// *		Returns zero on success. On error, -1 is returned and
 	// *  		*errno* is set appropriately.
 	// *
-	const void *map_lookup_elem(const void *key) const;
-	long map_update_elem(const void *key, const void *value,
-			     uint64_t flags) const;
-	long map_delete_elem(const void *key) const;
+	const void *map_lookup_elem(const void *key,
+				    bool from_userspace = false) const;
+	long map_update_elem(const void *key, const void *value, uint64_t flags,
+			     bool from_userspace = false) const;
+	long map_delete_elem(const void *key,
+			     bool from_userspace = false) const;
 	// * BPF_MAP_GET_NEXT_KEY
 	// *	Description
 	// *		Look up an element by key in a specified map and return
@@ -156,31 +159,16 @@ class bpf_map_handler {
 	// *		May set *errno* to **ENOMEM**, **EFAULT**, **EPERM**, or
 	// *		**EINVAL** on error.
 	// *
-	int bpf_map_get_next_key(const void *key, void *next_key) const;
+	int bpf_map_get_next_key(const void *key, void *next_key,
+				 bool from_userspace = false) const;
 	void map_free(boost::interprocess::managed_shared_memory &memory);
 	int map_init(boost::interprocess::managed_shared_memory &memory);
-	uint32_t get_value_size() const
-	{
-		return value_size;
-	}
-	std::optional<ringbuf_map_impl *> try_get_ringbuf_map_impl() const
-	{
-		if (type != BPF_MAP_TYPE_RINGBUF)
-			return {};
-		return static_cast<ringbuf_map_impl *>(map_impl_ptr.get());
-	}
-	std::optional<array_map_impl *> try_get_array_map_impl() const
-	{
-		if (type != BPF_MAP_TYPE_ARRAY)
-			return {};
-		return static_cast<array_map_impl *>(map_impl_ptr.get());
-	}
+	uint32_t get_value_size() const;
+	std::optional<ringbuf_map_impl *> try_get_ringbuf_map_impl() const;
+	std::optional<array_map_impl *> try_get_array_map_impl() const;
 
     private:
-	std::string get_container_name()
-	{
-		return "ebpf_map_fd_" + std::string(name.c_str());
-	}
+	std::string get_container_name();
 	mutable sharable_mutex_ptr map_mutex;
 	// The underlying data structure of the map
 	general_map_impl_ptr map_impl_ptr;

--- a/runtime/src/handler/perf_event_handler.hpp
+++ b/runtime/src/handler/perf_event_handler.hpp
@@ -1,5 +1,6 @@
 #ifndef _PERF_EVENT_HANDLER
 #define _PERF_EVENT_HANDLER
+#include "spdlog/spdlog.h"
 #include <boost/interprocess/managed_shared_memory.hpp>
 #include <boost/interprocess/containers/string.hpp>
 #include <boost/interprocess/containers/vector.hpp>
@@ -107,6 +108,11 @@ struct bpf_perf_event_handler {
 		// TODO: implement enable logic.
 		// If This is a server, should inject the agent into the target
 		// process.
+		return 0;
+	}
+	int disable() const
+	{
+		spdlog::debug("Disabling perf event, but nothing todo");
 		return 0;
 	}
 	uint64_t offset;

--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -3,11 +3,9 @@
 #include "handler/perf_event_handler.hpp"
 #include "linux/perf_event.h"
 #include "spdlog/spdlog.h"
-#include <iostream>
 #include <linux/bpf.h>
 #include "syscall_server_utils.hpp"
 #include <optional>
-#include <ostream>
 #include <sys/epoll.h>
 #include <sys/mman.h>
 #include <unistd.h>
@@ -68,31 +66,31 @@ long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 		// we should write the bytes of the matched value to the pointer
 		// that user gave us. So here needs a memcpy to achive such
 		// thing.
-		auto value_ptr = bpftime_map_lookup_elem(
+		auto value_ptr = bpftime_map_lookup_elem_from_syscall(
 			attr->map_fd, (const void *)(uintptr_t)attr->key);
 		if (value_ptr == nullptr) {
 			errno = ENOENT;
 			return -1;
 		}
 		memcpy((void *)(uintptr_t)attr->value, value_ptr,
-		       bpftime_map_value_size(attr->map_fd));
+		       bpftime_map_value_size_from_syscall(attr->map_fd));
 		return 0;
 	}
 	case BPF_MAP_UPDATE_ELEM: {
 		spdlog::debug("Updating map");
-		return bpftime_map_update_elem(
+		return bpftime_map_update_elem_from_syscall(
 			attr->map_fd, (const void *)(uintptr_t)attr->key,
 			(const void *)(uintptr_t)attr->value,
 			(uint64_t)attr->flags);
 	}
 	case BPF_MAP_DELETE_ELEM: {
 		spdlog::debug("Deleting map");
-		return bpftime_map_delete_elem(
+		return bpftime_map_delete_elem_from_syscall(
 			attr->map_fd, (const void *)(uintptr_t)attr->key);
 	}
 	case BPF_MAP_GET_NEXT_KEY: {
 		spdlog::debug("Getting next key");
-		return (long)(uintptr_t)bpftime_map_get_next_key(
+		return (long)(uintptr_t)bpftime_map_get_next_key_from_syscall(
 			attr->map_fd, (const void *)(uintptr_t)attr->key,
 			(void *)(uintptr_t)attr->next_key);
 	}

--- a/runtime/syscall-server/syscall_context.hpp
+++ b/runtime/syscall-server/syscall_context.hpp
@@ -11,6 +11,7 @@ class syscall_context {
 	using syscall_fn = long (*)(long, ...);
 	using close_fn = int (*)(int);
 	using mmap64_fn = void *(*)(void *, size_t, int, int, int, off64_t);
+	using mmap_fn = void *(*)(void *, size_t, int, int, int, off_t);
 	using ioctl_fn = int (*)(int fd, unsigned long req, int);
 	using epoll_craete1_fn = int (*)(int);
 	using epoll_ctl_fn = int (*)(int, int, int, struct epoll_event *);
@@ -23,6 +24,8 @@ class syscall_context {
 	epoll_ctl_fn orig_epoll_ctl_fn = nullptr;
 	epoll_wait_fn orig_epoll_wait_fn = nullptr;
 	munmap_fn orig_munmap_fn = nullptr;
+	mmap_fn orig_mmap_fn = nullptr;
+	
 	std::unordered_set<uintptr_t> mocked_mmap_values;
 	void init_original_functions()
 	{
@@ -33,13 +36,26 @@ class syscall_context {
 			(epoll_craete1_fn)dlsym(RTLD_NEXT, "epoll_create1");
 		orig_ioctl_fn = (ioctl_fn)dlsym(RTLD_NEXT, "ioctl");
 		orig_syscall_fn = (syscall_fn)dlsym(RTLD_NEXT, "syscall");
-		orig_mmap64_fn = (mmap64_fn)dlsym(RTLD_NEXT, "mmap");
+		// orig_mmap64_fn = (mmap64_fn)dlsym(RTLD_NEXT, "mmap64");
 		orig_close_fn = (close_fn)dlsym(RTLD_NEXT, "close");
 		orig_munmap_fn = (munmap_fn)dlsym(RTLD_NEXT, "munmap");
+		orig_mmap64_fn = orig_mmap_fn =
+			(mmap_fn)dlsym(RTLD_NEXT, "mmap");
 		unsetenv("LD_PRELOAD");
+		spdlog::debug(
+			"Function addrs: {:x} {:x} {:x} {:x} {:x} {:x} {:x} {:x} {:x}",
+			(uintptr_t)orig_epoll_wait_fn,
+			(uintptr_t)orig_epoll_ctl_fn,
+			(uintptr_t)orig_epoll_create1_fn,
+			(uintptr_t)orig_ioctl_fn, (uintptr_t)orig_syscall_fn,
+			(uintptr_t)orig_mmap64_fn, (uintptr_t)orig_close_fn,
+			(uintptr_t)orig_munmap_fn, (uintptr_t)orig_mmap_fn);
 	}
 
+	void try_startup();
+
     public:
+	bool enable_mock = true;
 	syscall_context()
 	{
 		init_original_functions();
@@ -53,7 +69,10 @@ class syscall_context {
 	int handle_perfevent(perf_event_attr *attr, pid_t pid, int cpu,
 			     int group_fd, unsigned long flags);
 	void *handle_mmap64(void *addr, size_t length, int prot, int flags,
-			    int fd, off_t offset);
+			    int fd, off64_t offset);
+	void *handle_mmap(void *addr, size_t length, int prot, int flags,
+			  int fd, off_t offset);
+
 	int handle_ioctl(int fd, unsigned long req, int data);
 	int handle_epoll_create1(int);
 	int handle_epoll_ctl(int epfd, int op, int fd, epoll_event *evt);

--- a/runtime/syscall-server/syscall_server_main.cpp
+++ b/runtime/syscall-server/syscall_server_main.cpp
@@ -48,6 +48,13 @@ extern "C" void *mmap64(void *addr, size_t length, int prot, int flags, int fd,
 	return context.handle_mmap64(addr, length, prot, flags, fd, offset);
 }
 
+extern "C" void *mmap(void *addr, size_t length, int prot, int flags, int fd,
+			off_t offset)
+{
+	spdlog::debug("mmap {:x}", (uintptr_t)addr);
+	return context.handle_mmap(addr, length, prot, flags, fd, offset);
+}
+
 extern "C" int close(int fd)
 {
 	spdlog::debug("Closing {}", fd);

--- a/runtime/syscall-server/syscall_server_utils.cpp
+++ b/runtime/syscall-server/syscall_server_utils.cpp
@@ -9,15 +9,18 @@
 #include <sstream>
 #endif
 static bool already_setup = false;
+static bool disable_mock = true;
 using namespace bpftime;
 
 void start_up()
 {
 	if (already_setup)
 		return;
-	initialize_global_shm();
+	already_setup = true;
+	spdlog::info("Initialize syscall server");
 	spdlog::cfg::load_env_levels();
 	spdlog::set_pattern("[%Y-%m-%d %H:%M:%S][%^%l%$][%t] %v");
+	bpftime_initialize_global_shm();
 	auto &agent_config = bpftime_get_agent_config();
 	if (const char *custom_helpers = getenv("BPFTIME_HELPER_GROUPS");
 	    custom_helpers != nullptr) {
@@ -83,7 +86,6 @@ void start_up()
 	spdlog::info("Enabling {} helpers", helper_ids.size());
 	verifier::set_non_kernel_helpers(non_kernel_helpers);
 #endif
-	already_setup = true;
 }
 
 /*

--- a/runtime/syscall-server/syscall_server_utils.cpp
+++ b/runtime/syscall-server/syscall_server_utils.cpp
@@ -86,6 +86,7 @@ void start_up()
 	spdlog::info("Enabling {} helpers", helper_ids.size());
 	verifier::set_non_kernel_helpers(non_kernel_helpers);
 #endif
+	spdlog::info("bpftime-syscall-server started");
 }
 
 /*

--- a/runtime/test/include/test_minimal_bpf_host_ffi.h
+++ b/runtime/test/include/test_minimal_bpf_host_ffi.h
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include <assert.h>
 #include <cstdlib>
-#include "ebpf-core.h"
+#include "ebpf-vm.h"
 
 #define MAX_FFI_FUNCS 128
 #define MAX_ARGS 5

--- a/vm/include/ebpf_inst.h
+++ b/vm/include/ebpf_inst.h
@@ -26,6 +26,21 @@ struct ebpf_inst {
 	int16_t off; /* signed offset */
 	int32_t imm; /* signed immediate constant */
 };
+#define EBPF_SIZE_DW 0x18 /* double word (64-bit) */
+#define EBPF_ATOMIC 0xc0 /* atomic memory ops - op type in immediate */
+#define BPF_SIZE_W 0x00 /* 32-bit */
+#define EBPF_FETCH 0x01 /* not an opcode on its own, used to build others */
+#define EBPF_XCHG (0xe0 | EBPF_FETCH) /* atomic exchange */
+#define EBPF_CMPXCHG (0xf0 | EBPF_FETCH) /* atomic compare-and-write */
+#define EBPF_STX 0x03
+#define EBPF_ATOMIC_ADD 0x00
+#define EBPF_ATOMIC_OR 0x40
+#define EBPF_ATOMIC_AND 0x50
+#define EBPF_ATOMIC_XOR 0xa0
+
+#define EBPF_ATOMIC_OPCODE_32 (EBPF_ATOMIC | EBPF_SIZE_W | EBPF_STX)
+#define EBPF_ATOMIC_OPCODE_64 (EBPF_ATOMIC | EBPF_SIZE_DW | EBPF_STX)
+
 
 #define EBPF_CLS_MASK 0x07
 #define EBPF_ALU_OP_MASK 0xf0

--- a/vm/llvm-jit/example/main-bpf-conformance.cpp
+++ b/vm/llvm-jit/example/main-bpf-conformance.cpp
@@ -6,7 +6,7 @@
 #include <cstring>
 #include <iostream>
 #include <vector>
-#include "ebpf-core.h"
+#include "ebpf-vm.h"
 /**
  * @brief Read in a string of hex bytes and return a vector of bytes.
  *

--- a/vm/llvm-jit/example/main.cpp
+++ b/vm/llvm-jit/example/main.cpp
@@ -16,7 +16,7 @@
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Support/Error.h"
 #include "llvm_jit_context.h"
-#include "ebpf-core.h"
+#include "ebpf-vm.h"
 
 using namespace llvm;
 

--- a/vm/llvm-jit/src/ebpf_vm.cpp
+++ b/vm/llvm-jit/src/ebpf_vm.cpp
@@ -45,12 +45,12 @@ char *ebpf_error(const char *fmt, ...)
 	char *msg;
 	va_list ap;
 	va_start(ap, fmt);
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wformat-nonliteral"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 	if (vasprintf(&msg, fmt, ap) < 0) {
 		msg = NULL;
 	}
-#pragma clang diagnostic pop
+#pragma GCC diagnostic pop
 	va_end(ap);
 	return msg;
 }
@@ -289,7 +289,7 @@ int ebpf_exec(const struct ebpf_vm *vm, void *mem, size_t mem_len,
 }
 
 /* For testing, this changes the mapping between x86 and eBPF registers */
-void ebpf_set_register_offset(int x)
+extern "C" void ebpf_set_register_offset(int x)
 {
 	// DO NOTHING because llvm handles the map
 }

--- a/vm/simple-jit/ebpf_vm.c
+++ b/vm/simple-jit/ebpf_vm.c
@@ -926,6 +926,14 @@ int ebpf_exec(const struct ebpf_vm *vm, void *mem, size_t mem_len,
 					__ATOMIC_RELAXED);
 				break;
 			}
+			// case EBPF_CMPXCHG: {
+			// 	__atomic_compare_exchange(
+			// 		(uint32_t *)(uintptr_t)(reg[inst.dst_reg] +
+			// 					inst.off),
+			// 		(uint32_t *)&reg[0],
+			// 		(uint32_t *)&reg[inst.src_reg], false,
+			// 		__ATOMIC_RELAXED, __ATOMIC_RELAXED);
+			// }
 			}
 			break;
 		}
@@ -974,6 +982,14 @@ int ebpf_exec(const struct ebpf_vm *vm, void *mem, size_t mem_len,
 					__ATOMIC_RELAXED);
 				break;
 			}
+			// case EBPF_CMPXCHG: {
+			// 	__atomic_compare_exchange(
+			// 		(uint64_t *)(uintptr_t)(reg[inst.dst_reg] +
+			// 					inst.off),
+			// 		(uint64_t *)&reg[0],
+			// 		(uint64_t *)&reg[inst.src_reg], false,
+			// 		__ATOMIC_RELAXED, __ATOMIC_RELAXED);
+			// }
 			}
 			break;
 			break;

--- a/vm/simple-jit/ebpf_vm.c
+++ b/vm/simple-jit/ebpf_vm.c
@@ -30,887 +30,1054 @@
 
 typedef uint32_t u32;
 
+static bool validate(const struct ebpf_vm *vm, const struct ebpf_inst *insts,
+		     uint32_t num_insts, char **errmsg);
+static bool bounds_check(const struct ebpf_vm *vm, void *addr, int size,
+			 const char *type, uint16_t cur_pc, void *mem,
+			 size_t mem_len, void *stack);
 
-static bool
-validate(const struct ebpf_vm* vm, const struct ebpf_inst* insts, uint32_t num_insts, char** errmsg);
-static bool
-bounds_check(
-    const struct ebpf_vm* vm,
-    void* addr,
-    int size,
-    const char* type,
-    uint16_t cur_pc,
-    void* mem,
-    size_t mem_len,
-    void* stack);
-
-bool
-ebpf_toggle_bounds_check(struct ebpf_vm* vm, bool enable)
+bool ebpf_toggle_bounds_check(struct ebpf_vm *vm, bool enable)
 {
-    bool old = vm->bounds_check_enabled;
-    vm->bounds_check_enabled = enable;
-    return old;
+	bool old = vm->bounds_check_enabled;
+	vm->bounds_check_enabled = enable;
+	return old;
 }
 
-void
-ebpf_set_error_print(struct ebpf_vm* vm, int (*error_printf)(FILE* stream, const char* format, ...))
+void ebpf_set_error_print(struct ebpf_vm *vm,
+			  int (*error_printf)(FILE *stream, const char *format,
+					      ...))
 {
-    if (error_printf)
-        vm->error_printf = error_printf;
-    else
-        vm->error_printf = fprintf;
+	if (error_printf)
+		vm->error_printf = error_printf;
+	else
+		vm->error_printf = fprintf;
 }
 
-struct ebpf_vm*
-ebpf_create(void)
+struct ebpf_vm *ebpf_create(void)
 {
-    struct ebpf_vm* vm = calloc(1, sizeof(*vm));
-    if (vm == NULL) {
-        return NULL;
-    }
+	struct ebpf_vm *vm = calloc(1, sizeof(*vm));
+	if (vm == NULL) {
+		return NULL;
+	}
 	vm->map_by_fd = NULL;
 	vm->map_by_idx = NULL;
 	vm->map_val = NULL;
 	vm->var_addr = NULL;
 	vm->code_addr = NULL;
-    vm->ext_funcs = calloc(MAX_EXT_FUNCS, sizeof(*vm->ext_funcs));
-    if (vm->ext_funcs == NULL) {
-        ebpf_destroy(vm);
-        return NULL;
-    }
+	vm->ext_funcs = calloc(MAX_EXT_FUNCS, sizeof(*vm->ext_funcs));
+	if (vm->ext_funcs == NULL) {
+		ebpf_destroy(vm);
+		return NULL;
+	}
 
-    vm->ext_func_names = calloc(MAX_EXT_FUNCS, sizeof(*vm->ext_func_names));
-    if (vm->ext_func_names == NULL) {
-        ebpf_destroy(vm);
-        return NULL;
-    }
+	vm->ext_func_names = calloc(MAX_EXT_FUNCS, sizeof(*vm->ext_func_names));
+	if (vm->ext_func_names == NULL) {
+		ebpf_destroy(vm);
+		return NULL;
+	}
 
-    vm->bounds_check_enabled = true;
-    vm->error_printf = fprintf;
+	vm->bounds_check_enabled = true;
+	vm->error_printf = fprintf;
 
 #if defined(__x86_64__) || defined(_M_X64)
-    LOG_DEBUG("ebpf_create: x86_64\n");
-    vm->translate = ebpf_translate_x86_64;
+	LOG_DEBUG("ebpf_create: x86_64\n");
+	vm->translate = ebpf_translate_x86_64;
 #elif defined(__aarch64__) || defined(_M_ARM64)
-    LOG_DEBUG("ebpf_create: arm64\n");
-    vm->translate = ebpf_translate_arm64;
+	LOG_DEBUG("ebpf_create: arm64\n");
+	vm->translate = ebpf_translate_arm64;
 #elif defined(__arm__) || defined(_M_ARM)
-    LOG_DEBUG("ebpf_create: arm32\n");
-    vm->translate = ebpf_translate_arm32;
+	LOG_DEBUG("ebpf_create: arm32\n");
+	vm->translate = ebpf_translate_arm32;
 #else
-    printf("ebpf_create: null\n");
-    vm->translate = ebpf_translate_null;
+	printf("ebpf_create: null\n");
+	vm->translate = ebpf_translate_null;
 #endif
-    vm->unwind_stack_extension_index = -1;
-    return vm;
+	vm->unwind_stack_extension_index = -1;
+	return vm;
 }
 
-void
-ebpf_destroy(struct ebpf_vm* vm)
+void ebpf_destroy(struct ebpf_vm *vm)
 {
-    ebpf_unload_code(vm);
-    free(vm->ext_funcs);
-    free(vm->ext_func_names);
-    free(vm);
+	ebpf_unload_code(vm);
+	free(vm->ext_funcs);
+	free(vm->ext_func_names);
+	free(vm);
 }
 
-int
-ebpf_register(struct ebpf_vm* vm, unsigned int idx, const char* name, void* fn)
+int ebpf_register(struct ebpf_vm *vm, unsigned int idx, const char *name,
+		  void *fn)
 {
-    if (idx >= MAX_EXT_FUNCS) {
-        return -1;
-    }
+	if (idx >= MAX_EXT_FUNCS) {
+		return -1;
+	}
 
-    vm->ext_funcs[idx] = (ext_func)fn;
-    vm->ext_func_names[idx] = name;
-    LOG_DEBUG("ebpf_register: %s idx: %d func: %ld\n", name, idx, (long)fn);
-    return 0;
+	vm->ext_funcs[idx] = (ext_func)fn;
+	vm->ext_func_names[idx] = name;
+	LOG_DEBUG("ebpf_register: %s idx: %d func: %ld\n", name, idx, (long)fn);
+	return 0;
 }
 
-int
-ebpf_set_unwind_function_index(struct ebpf_vm* vm, unsigned int idx)
+int ebpf_set_unwind_function_index(struct ebpf_vm *vm, unsigned int idx)
 {
-    if (vm->unwind_stack_extension_index != -1) {
-        return -1;
-    }
+	if (vm->unwind_stack_extension_index != -1) {
+		return -1;
+	}
 
-    vm->unwind_stack_extension_index = idx;
-    return 0;
+	vm->unwind_stack_extension_index = idx;
+	return 0;
 }
 
-unsigned int
-ebpf_lookup_registered_function(struct ebpf_vm* vm, const char* name)
+unsigned int ebpf_lookup_registered_function(struct ebpf_vm *vm,
+					     const char *name)
 {
-    int i;
-    for (i = 0; i < MAX_EXT_FUNCS; i++) {
-        const char* other = vm->ext_func_names[i];
-        if (other && !strcmp(other, name)) {
-            return i;
-        }
-    }
-    return -1;
+	int i;
+	for (i = 0; i < MAX_EXT_FUNCS; i++) {
+		const char *other = vm->ext_func_names[i];
+		if (other && !strcmp(other, name)) {
+			return i;
+		}
+	}
+	return -1;
 }
 
-int
-ebpf_load(struct ebpf_vm* vm, const void* code, uint32_t code_len, char** errmsg)
+int ebpf_load(struct ebpf_vm *vm, const void *code, uint32_t code_len,
+	      char **errmsg)
 {
-    const struct ebpf_inst* source_inst = code;
-    *errmsg = NULL;
+	const struct ebpf_inst *source_inst = code;
+	*errmsg = NULL;
 
-    if (vm->insnsi) {
-        *errmsg = ebpf_error(
-            "code has already been loaded into this VM. Use ebpf_unload_code() if you need to reuse this VM");
-        return -1;
-    }
+	if (vm->insnsi) {
+		*errmsg = ebpf_error(
+			"code has already been loaded into this VM. Use ebpf_unload_code() if you need to reuse this VM");
+		return -1;
+	}
 
-    if (code_len % 8 != 0) {
-        *errmsg = ebpf_error("code_len must be a multiple of 8");
-        return -1;
-    }
+	if (code_len % 8 != 0) {
+		*errmsg = ebpf_error("code_len must be a multiple of 8");
+		return -1;
+	}
 
-    if (!validate(vm, code, code_len / 8, errmsg)) {
-        return -1;
-    }
+	if (!validate(vm, code, code_len / 8, errmsg)) {
+		return -1;
+	}
 
-    vm->insnsi = malloc(code_len);
-    if (vm->insnsi == NULL) {
-        *errmsg = ebpf_error("out of memory");
-        return -1;
-    }
+	vm->insnsi = malloc(code_len);
+	if (vm->insnsi == NULL) {
+		*errmsg = ebpf_error("out of memory");
+		return -1;
+	}
 
-    vm->num_insts = code_len / sizeof(vm->insnsi[0]);
-    // Store instructions in the vm.
-    for (uint32_t i = 0; i < vm->num_insts; i++) {
-        ebpf_store_instruction(vm, i, source_inst[i]);
-    }
+	vm->num_insts = code_len / sizeof(vm->insnsi[0]);
+	// Store instructions in the vm.
+	for (uint32_t i = 0; i < vm->num_insts; i++) {
+		ebpf_store_instruction(vm, i, source_inst[i]);
+	}
 
-    return 0;
+	return 0;
 }
 
-void
-ebpf_unload_code(struct ebpf_vm* vm)
+void ebpf_unload_code(struct ebpf_vm *vm)
 {
-    if (vm->jitted_function) {
-        munmap(vm->jitted_function, vm->jitted_size);
-        vm->jitted_function = NULL;
-        vm->jitted_size = 0;
-    }
-    if (vm->insnsi) {
-        free(vm->insnsi);
-        vm->insnsi = NULL;
-        vm->num_insts = 0;
-    }
+	if (vm->jitted_function) {
+		munmap(vm->jitted_function, vm->jitted_size);
+		vm->jitted_function = NULL;
+		vm->jitted_size = 0;
+	}
+	if (vm->insnsi) {
+		free(vm->insnsi);
+		vm->insnsi = NULL;
+		vm->num_insts = 0;
+	}
 }
 
 #define IS_ALIGNED(x, a) (((uintptr_t)(x) & ((a)-1)) == 0)
 
-inline static uint64_t
-ebpf_mem_load(uint64_t address, size_t size)
+inline static uint64_t ebpf_mem_load(uint64_t address, size_t size)
 {
-    if (!IS_ALIGNED(address, size)) {
-        // Fill the result with 0 to avoid leaking uninitialized memory.
-        uint64_t value = 0;
-        memcpy(&value, (void*)address, size);
-        return value;
-    }
+	if (!IS_ALIGNED(address, size)) {
+		// Fill the result with 0 to avoid leaking uninitialized memory.
+		uint64_t value = 0;
+		memcpy(&value, (void *)address, size);
+		return value;
+	}
 
-    switch (size) {
-    case 1:
-        return *(uint8_t*)address;
-    case 2:
-        return *(uint16_t*)address;
-    case 4:
-        return *(uint32_t*)address;
-    case 8:
-        return *(uint64_t*)address;
-    default:
-        abort();
-    }
+	switch (size) {
+	case 1:
+		return *(uint8_t *)address;
+	case 2:
+		return *(uint16_t *)address;
+	case 4:
+		return *(uint32_t *)address;
+	case 8:
+		return *(uint64_t *)address;
+	default:
+		abort();
+	}
 }
 
-inline static void
-ebpf_mem_store(uint64_t address, uint64_t value, size_t size)
+inline static void ebpf_mem_store(uint64_t address, uint64_t value, size_t size)
 {
-    if (!IS_ALIGNED(address, size)) {
-        memcpy((void*)address, &value, size);
-        return;
-    }
+	if (!IS_ALIGNED(address, size)) {
+		memcpy((void *)address, &value, size);
+		return;
+	}
 
-    switch (size) {
-    case 1:
-        *(uint8_t*)(uintptr_t)address = value;
-        break;
-    case 2:
-        *(uint16_t*)(uintptr_t)address = value;
-        break;
-    case 4:
-        *(uint32_t*)(uintptr_t)address = value;
-        break;
-    case 8:
-        *(uint64_t*)(uintptr_t)address = value;
-        break;
-    default:
-        abort();
-    }
+	switch (size) {
+	case 1:
+		*(uint8_t *)(uintptr_t)address = value;
+		break;
+	case 2:
+		*(uint16_t *)(uintptr_t)address = value;
+		break;
+	case 4:
+		*(uint32_t *)(uintptr_t)address = value;
+		break;
+	case 8:
+		*(uint64_t *)(uintptr_t)address = value;
+		break;
+	default:
+		abort();
+	}
 }
 
-int
-ebpf_exec(const struct ebpf_vm* vm, void* mem, size_t mem_len, uint64_t* bpf_return_value)
+int ebpf_exec(const struct ebpf_vm *vm, void *mem, size_t mem_len,
+	      uint64_t *bpf_return_value)
 {
-    uint16_t pc = 0;
-    const struct ebpf_inst* insts = vm->insnsi;
-    uint64_t* reg;
-    uint64_t _reg[16];
-    uint64_t stack[(EBPF_STACK_SIZE + 7) / 8];
+	uint16_t pc = 0;
+	const struct ebpf_inst *insts = vm->insnsi;
+	uint64_t *reg;
+	uint64_t _reg[16];
+	uint64_t stack[(EBPF_STACK_SIZE + 7) / 8];
 
-    if (!insts) {
-        /* Code must be loaded before we can execute */
-        return -1;
-    }
+	if (!insts) {
+		/* Code must be loaded before we can execute */
+		return -1;
+	}
 
 #if DEBUG
-    if (vm->regs)
-        reg = vm->regs;
-    else
-        reg = _reg;
+	if (vm->regs)
+		reg = vm->regs;
+	else
+		reg = _reg;
 #else
-    reg = _reg;
+	reg = _reg;
 #endif
 
-    reg[1] = (uintptr_t)mem;
-    reg[2] = (uint64_t)mem_len;
-    reg[10] = (uintptr_t)stack + sizeof(stack);
+	reg[1] = (uintptr_t)mem;
+	reg[2] = (uint64_t)mem_len;
+	reg[10] = (uintptr_t)stack + sizeof(stack);
 
-    while (1) {
-        const uint16_t cur_pc = pc;
-        struct ebpf_inst inst = ebpf_fetch_instruction(vm, pc++);
+	while (1) {
+		const uint16_t cur_pc = pc;
+		struct ebpf_inst inst = ebpf_fetch_instruction(vm, pc++);
 
-	    LOG_DEBUG("%08" PRIu64 "x, [%d] %d %d %d %d\n", *(uint64_t*)(uintptr_t)&inst, cur_pc,
-	       inst.dst_reg, inst.src_reg, inst.off, inst.imm);
+		LOG_DEBUG("%08" PRIu64 "x, [%d] %d %d %d %d\n",
+			  *(uint64_t *)(uintptr_t)&inst, cur_pc, inst.dst_reg,
+			  inst.src_reg, inst.off, inst.imm);
 
-        switch (inst.code) {
-        case EBPF_OP_ADD_IMM:
-            reg[inst.dst_reg] += inst.imm;
-            reg[inst.dst_reg] &= UINT32_MAX;
-            break;
-        case EBPF_OP_ADD_REG:
-            reg[inst.dst_reg] += reg[inst.src_reg];
-            reg[inst.dst_reg] &= UINT32_MAX;
-            break;
-        case EBPF_OP_SUB_IMM:
-            reg[inst.dst_reg] -= inst.imm;
-            reg[inst.dst_reg] &= UINT32_MAX;
-            break;
-        case EBPF_OP_SUB_REG:
-            reg[inst.dst_reg] -= reg[inst.src_reg];
-            reg[inst.dst_reg] &= UINT32_MAX;
-            break;
-        case EBPF_OP_MUL_IMM:
-            reg[inst.dst_reg] *= inst.imm;
-            reg[inst.dst_reg] &= UINT32_MAX;
-            break;
-        case EBPF_OP_MUL_REG:
-            reg[inst.dst_reg] *= reg[inst.src_reg];
-            reg[inst.dst_reg] &= UINT32_MAX;
-            break;
-        case EBPF_OP_DIV_IMM:
-            reg[inst.dst_reg] = (uint32_t)(inst.imm) ? (uint32_t)(reg[inst.dst_reg]) / (uint32_t)(inst.imm) : 0;
-            reg[inst.dst_reg] &= UINT32_MAX;
-            break;
-        case EBPF_OP_DIV_REG:
-            reg[inst.dst_reg] = reg[inst.src_reg] ? (uint32_t)(reg[inst.dst_reg]) / (uint32_t)(reg[inst.src_reg]) : 0;
-            reg[inst.dst_reg] &= UINT32_MAX;
-            break;
-        case EBPF_OP_OR_IMM:
-            reg[inst.dst_reg] |= inst.imm;
-            reg[inst.dst_reg] &= UINT32_MAX;
-            break;
-        case EBPF_OP_OR_REG:
-            reg[inst.dst_reg] |= reg[inst.src_reg];
-            reg[inst.dst_reg] &= UINT32_MAX;
-            break;
-        case EBPF_OP_AND_IMM:
-            reg[inst.dst_reg] &= inst.imm;
-            reg[inst.dst_reg] &= UINT32_MAX;
-            break;
-        case EBPF_OP_AND_REG:
-            reg[inst.dst_reg] &= reg[inst.src_reg];
-            reg[inst.dst_reg] &= UINT32_MAX;
-            break;
-        case EBPF_OP_LSH_IMM:
-            reg[inst.dst_reg] <<= inst.imm;
-            reg[inst.dst_reg] &= UINT32_MAX;
-            break;
-        case EBPF_OP_LSH_REG:
-            reg[inst.dst_reg] <<= reg[inst.src_reg];
-            reg[inst.dst_reg] &= UINT32_MAX;
-            break;
-        case EBPF_OP_RSH_IMM:
-            reg[inst.dst_reg] = (uint32_t)(reg[inst.dst_reg]) >> inst.imm;
-            reg[inst.dst_reg] &= UINT32_MAX;
-            break;
-        case EBPF_OP_RSH_REG:
-            reg[inst.dst_reg] = (uint32_t)(reg[inst.dst_reg]) >> reg[inst.src_reg];
-            reg[inst.dst_reg] &= UINT32_MAX;
-            break;
-        case EBPF_OP_NEG:
-            reg[inst.dst_reg] = -(int64_t)reg[inst.dst_reg];
-            reg[inst.dst_reg] &= UINT32_MAX;
-            break;
-        case EBPF_OP_MOD_IMM:
-            reg[inst.dst_reg] = (uint32_t)(inst.imm) ? (uint32_t)(reg[inst.dst_reg]) % (uint32_t)(inst.imm) : (uint32_t)(reg[inst.dst_reg]);
-            reg[inst.dst_reg] &= UINT32_MAX;
-            break;
-        case EBPF_OP_MOD_REG:
-            reg[inst.dst_reg] = (uint32_t)(reg[inst.src_reg]) ? (uint32_t)(reg[inst.dst_reg]) % (uint32_t)(reg[inst.src_reg]) : (uint32_t)(reg[inst.dst_reg]);
-            break;
-        case EBPF_OP_XOR_IMM:
-            reg[inst.dst_reg] ^= inst.imm;
-            reg[inst.dst_reg] &= UINT32_MAX;
-            break;
-        case EBPF_OP_XOR_REG:
-            reg[inst.dst_reg] ^= reg[inst.src_reg];
-            reg[inst.dst_reg] &= UINT32_MAX;
-            break;
-        case EBPF_OP_MOV_IMM:
-            reg[inst.dst_reg] = inst.imm;
-            reg[inst.dst_reg] &= UINT32_MAX;
-            break;
-        case EBPF_OP_MOV_REG:
-            reg[inst.dst_reg] = reg[inst.src_reg];
-            reg[inst.dst_reg] &= UINT32_MAX;
-            break;
-        case EBPF_OP_ARSH_IMM:
-            reg[inst.dst_reg] = (int32_t)reg[inst.dst_reg] >> inst.imm;
-            reg[inst.dst_reg] &= UINT32_MAX;
-            break;
-        case EBPF_OP_ARSH_REG:
-            reg[inst.dst_reg] = (int32_t)reg[inst.dst_reg] >> (uint32_t)(reg[inst.src_reg]);
-            reg[inst.dst_reg] &= UINT32_MAX;
-            break;
+		switch (inst.code) {
+		case EBPF_OP_ADD_IMM:
+			reg[inst.dst_reg] += inst.imm;
+			reg[inst.dst_reg] &= UINT32_MAX;
+			break;
+		case EBPF_OP_ADD_REG:
+			reg[inst.dst_reg] += reg[inst.src_reg];
+			reg[inst.dst_reg] &= UINT32_MAX;
+			break;
+		case EBPF_OP_SUB_IMM:
+			reg[inst.dst_reg] -= inst.imm;
+			reg[inst.dst_reg] &= UINT32_MAX;
+			break;
+		case EBPF_OP_SUB_REG:
+			reg[inst.dst_reg] -= reg[inst.src_reg];
+			reg[inst.dst_reg] &= UINT32_MAX;
+			break;
+		case EBPF_OP_MUL_IMM:
+			reg[inst.dst_reg] *= inst.imm;
+			reg[inst.dst_reg] &= UINT32_MAX;
+			break;
+		case EBPF_OP_MUL_REG:
+			reg[inst.dst_reg] *= reg[inst.src_reg];
+			reg[inst.dst_reg] &= UINT32_MAX;
+			break;
+		case EBPF_OP_DIV_IMM:
+			reg[inst.dst_reg] =
+				(uint32_t)(inst.imm) ?
+					(uint32_t)(reg[inst.dst_reg]) /
+						(uint32_t)(inst.imm) :
+					0;
+			reg[inst.dst_reg] &= UINT32_MAX;
+			break;
+		case EBPF_OP_DIV_REG:
+			reg[inst.dst_reg] =
+				reg[inst.src_reg] ?
+					(uint32_t)(reg[inst.dst_reg]) /
+						(uint32_t)(reg[inst.src_reg]) :
+					0;
+			reg[inst.dst_reg] &= UINT32_MAX;
+			break;
+		case EBPF_OP_OR_IMM:
+			reg[inst.dst_reg] |= inst.imm;
+			reg[inst.dst_reg] &= UINT32_MAX;
+			break;
+		case EBPF_OP_OR_REG:
+			reg[inst.dst_reg] |= reg[inst.src_reg];
+			reg[inst.dst_reg] &= UINT32_MAX;
+			break;
+		case EBPF_OP_AND_IMM:
+			reg[inst.dst_reg] &= inst.imm;
+			reg[inst.dst_reg] &= UINT32_MAX;
+			break;
+		case EBPF_OP_AND_REG:
+			reg[inst.dst_reg] &= reg[inst.src_reg];
+			reg[inst.dst_reg] &= UINT32_MAX;
+			break;
+		case EBPF_OP_LSH_IMM:
+			reg[inst.dst_reg] <<= inst.imm;
+			reg[inst.dst_reg] &= UINT32_MAX;
+			break;
+		case EBPF_OP_LSH_REG:
+			reg[inst.dst_reg] <<= reg[inst.src_reg];
+			reg[inst.dst_reg] &= UINT32_MAX;
+			break;
+		case EBPF_OP_RSH_IMM:
+			reg[inst.dst_reg] =
+				(uint32_t)(reg[inst.dst_reg]) >> inst.imm;
+			reg[inst.dst_reg] &= UINT32_MAX;
+			break;
+		case EBPF_OP_RSH_REG:
+			reg[inst.dst_reg] = (uint32_t)(reg[inst.dst_reg]) >>
+					    reg[inst.src_reg];
+			reg[inst.dst_reg] &= UINT32_MAX;
+			break;
+		case EBPF_OP_NEG:
+			reg[inst.dst_reg] = -(int64_t)reg[inst.dst_reg];
+			reg[inst.dst_reg] &= UINT32_MAX;
+			break;
+		case EBPF_OP_MOD_IMM:
+			reg[inst.dst_reg] =
+				(uint32_t)(inst.imm) ?
+					(uint32_t)(reg[inst.dst_reg]) %
+						(uint32_t)(inst.imm) :
+					(uint32_t)(reg[inst.dst_reg]);
+			reg[inst.dst_reg] &= UINT32_MAX;
+			break;
+		case EBPF_OP_MOD_REG:
+			reg[inst.dst_reg] =
+				(uint32_t)(reg[inst.src_reg]) ?
+					(uint32_t)(reg[inst.dst_reg]) %
+						(uint32_t)(reg[inst.src_reg]) :
+					(uint32_t)(reg[inst.dst_reg]);
+			break;
+		case EBPF_OP_XOR_IMM:
+			reg[inst.dst_reg] ^= inst.imm;
+			reg[inst.dst_reg] &= UINT32_MAX;
+			break;
+		case EBPF_OP_XOR_REG:
+			reg[inst.dst_reg] ^= reg[inst.src_reg];
+			reg[inst.dst_reg] &= UINT32_MAX;
+			break;
+		case EBPF_OP_MOV_IMM:
+			reg[inst.dst_reg] = inst.imm;
+			reg[inst.dst_reg] &= UINT32_MAX;
+			break;
+		case EBPF_OP_MOV_REG:
+			reg[inst.dst_reg] = reg[inst.src_reg];
+			reg[inst.dst_reg] &= UINT32_MAX;
+			break;
+		case EBPF_OP_ARSH_IMM:
+			reg[inst.dst_reg] =
+				(int32_t)reg[inst.dst_reg] >> inst.imm;
+			reg[inst.dst_reg] &= UINT32_MAX;
+			break;
+		case EBPF_OP_ARSH_REG:
+			reg[inst.dst_reg] = (int32_t)reg[inst.dst_reg] >>
+					    (uint32_t)(reg[inst.src_reg]);
+			reg[inst.dst_reg] &= UINT32_MAX;
+			break;
 
-        case EBPF_OP_LE:
-            if (inst.imm == 16) {
-                reg[inst.dst_reg] = htole16(reg[inst.dst_reg]);
-            } else if (inst.imm == 32) {
-                reg[inst.dst_reg] = htole32(reg[inst.dst_reg]);
-            } else if (inst.imm == 64) {
-                reg[inst.dst_reg] = htole64(reg[inst.dst_reg]);
-            }
-            break;
-        case EBPF_OP_BE:
-            if (inst.imm == 16) {
-                reg[inst.dst_reg] = htobe16(reg[inst.dst_reg]);
-            } else if (inst.imm == 32) {
-                reg[inst.dst_reg] = htobe32(reg[inst.dst_reg]);
-            } else if (inst.imm == 64) {
-                reg[inst.dst_reg] = htobe64(reg[inst.dst_reg]);
-            }
-            break;
+		case EBPF_OP_LE:
+			if (inst.imm == 16) {
+				reg[inst.dst_reg] = htole16(reg[inst.dst_reg]);
+			} else if (inst.imm == 32) {
+				reg[inst.dst_reg] = htole32(reg[inst.dst_reg]);
+			} else if (inst.imm == 64) {
+				reg[inst.dst_reg] = htole64(reg[inst.dst_reg]);
+			}
+			break;
+		case EBPF_OP_BE:
+			if (inst.imm == 16) {
+				reg[inst.dst_reg] = htobe16(reg[inst.dst_reg]);
+			} else if (inst.imm == 32) {
+				reg[inst.dst_reg] = htobe32(reg[inst.dst_reg]);
+			} else if (inst.imm == 64) {
+				reg[inst.dst_reg] = htobe64(reg[inst.dst_reg]);
+			}
+			break;
 
-        case EBPF_OP_ADD64_IMM:
-            reg[inst.dst_reg] += inst.imm;
-            break;
-        case EBPF_OP_ADD64_REG:
-            reg[inst.dst_reg] += reg[inst.src_reg];
-            break;
-        case EBPF_OP_SUB64_IMM:
-            reg[inst.dst_reg] -= inst.imm;
-            break;
-        case EBPF_OP_SUB64_REG:
-            reg[inst.dst_reg] -= reg[inst.src_reg];
-            break;
-        case EBPF_OP_MUL64_IMM:
-            reg[inst.dst_reg] *= inst.imm;
-            break;
-        case EBPF_OP_MUL64_REG:
-            reg[inst.dst_reg] *= reg[inst.src_reg];
-            break;
-        case EBPF_OP_DIV64_IMM:
-            reg[inst.dst_reg] = inst.imm ? reg[inst.dst_reg] / inst.imm : 0;
-            break;
-        case EBPF_OP_DIV64_REG:
-            reg[inst.dst_reg] = reg[inst.src_reg] ? reg[inst.dst_reg] / reg[inst.src_reg] : 0;
-            break;
-        case EBPF_OP_OR64_IMM:
-            reg[inst.dst_reg] |= inst.imm;
-            break;
-        case EBPF_OP_OR64_REG:
-            reg[inst.dst_reg] |= reg[inst.src_reg];
-            break;
-        case EBPF_OP_AND64_IMM:
-            reg[inst.dst_reg] &= inst.imm;
-            break;
-        case EBPF_OP_AND64_REG:
-            reg[inst.dst_reg] &= reg[inst.src_reg];
-            break;
-        case EBPF_OP_LSH64_IMM:
-            reg[inst.dst_reg] <<= inst.imm;
-            break;
-        case EBPF_OP_LSH64_REG:
-            reg[inst.dst_reg] <<= reg[inst.src_reg];
-            break;
-        case EBPF_OP_RSH64_IMM:
-            reg[inst.dst_reg] >>= inst.imm;
-            break;
-        case EBPF_OP_RSH64_REG:
-            reg[inst.dst_reg] >>= reg[inst.src_reg];
-            break;
-        case EBPF_OP_NEG64:
-            reg[inst.dst_reg] = -reg[inst.dst_reg];
-            break;
-        case EBPF_OP_MOD64_IMM:
-            reg[inst.dst_reg] = inst.imm ? reg[inst.dst_reg] % inst.imm : reg[inst.dst_reg];
-            break;
-        case EBPF_OP_MOD64_REG:
-            reg[inst.dst_reg] = reg[inst.src_reg] ? reg[inst.dst_reg] % reg[inst.src_reg] : reg[inst.dst_reg];
-            break;
-        case EBPF_OP_XOR64_IMM:
-            reg[inst.dst_reg] ^= inst.imm;
-            break;
-        case EBPF_OP_XOR64_REG:
-            reg[inst.dst_reg] ^= reg[inst.src_reg];
-            break;
-        case EBPF_OP_MOV64_IMM:
-            reg[inst.dst_reg] = inst.imm;
-            break;
-        case EBPF_OP_MOV64_REG:
-            reg[inst.dst_reg] = reg[inst.src_reg];
-            break;
-        case EBPF_OP_ARSH64_IMM:
-            reg[inst.dst_reg] = (int64_t)(uint64_t)reg[inst.dst_reg] >> inst.imm;
-            break;
-        case EBPF_OP_ARSH64_REG:
-            reg[inst.dst_reg] = (int64_t)(uint64_t)reg[inst.dst_reg] >> reg[inst.src_reg];
-            break;
+		case EBPF_OP_ADD64_IMM:
+			reg[inst.dst_reg] += inst.imm;
+			break;
+		case EBPF_OP_ADD64_REG:
+			reg[inst.dst_reg] += reg[inst.src_reg];
+			break;
+		case EBPF_OP_SUB64_IMM:
+			reg[inst.dst_reg] -= inst.imm;
+			break;
+		case EBPF_OP_SUB64_REG:
+			reg[inst.dst_reg] -= reg[inst.src_reg];
+			break;
+		case EBPF_OP_MUL64_IMM:
+			reg[inst.dst_reg] *= inst.imm;
+			break;
+		case EBPF_OP_MUL64_REG:
+			reg[inst.dst_reg] *= reg[inst.src_reg];
+			break;
+		case EBPF_OP_DIV64_IMM:
+			reg[inst.dst_reg] =
+				inst.imm ? reg[inst.dst_reg] / inst.imm : 0;
+			break;
+		case EBPF_OP_DIV64_REG:
+			reg[inst.dst_reg] =
+				reg[inst.src_reg] ?
+					reg[inst.dst_reg] / reg[inst.src_reg] :
+					0;
+			break;
+		case EBPF_OP_OR64_IMM:
+			reg[inst.dst_reg] |= inst.imm;
+			break;
+		case EBPF_OP_OR64_REG:
+			reg[inst.dst_reg] |= reg[inst.src_reg];
+			break;
+		case EBPF_OP_AND64_IMM:
+			reg[inst.dst_reg] &= inst.imm;
+			break;
+		case EBPF_OP_AND64_REG:
+			reg[inst.dst_reg] &= reg[inst.src_reg];
+			break;
+		case EBPF_OP_LSH64_IMM:
+			reg[inst.dst_reg] <<= inst.imm;
+			break;
+		case EBPF_OP_LSH64_REG:
+			reg[inst.dst_reg] <<= reg[inst.src_reg];
+			break;
+		case EBPF_OP_RSH64_IMM:
+			reg[inst.dst_reg] >>= inst.imm;
+			break;
+		case EBPF_OP_RSH64_REG:
+			reg[inst.dst_reg] >>= reg[inst.src_reg];
+			break;
+		case EBPF_OP_NEG64:
+			reg[inst.dst_reg] = -reg[inst.dst_reg];
+			break;
+		case EBPF_OP_MOD64_IMM:
+			reg[inst.dst_reg] =
+				inst.imm ? reg[inst.dst_reg] % inst.imm :
+					   reg[inst.dst_reg];
+			break;
+		case EBPF_OP_MOD64_REG:
+			reg[inst.dst_reg] =
+				reg[inst.src_reg] ?
+					reg[inst.dst_reg] % reg[inst.src_reg] :
+					reg[inst.dst_reg];
+			break;
+		case EBPF_OP_XOR64_IMM:
+			reg[inst.dst_reg] ^= inst.imm;
+			break;
+		case EBPF_OP_XOR64_REG:
+			reg[inst.dst_reg] ^= reg[inst.src_reg];
+			break;
+		case EBPF_OP_MOV64_IMM:
+			reg[inst.dst_reg] = inst.imm;
+			break;
+		case EBPF_OP_MOV64_REG:
+			reg[inst.dst_reg] = reg[inst.src_reg];
+			break;
+		case EBPF_OP_ARSH64_IMM:
+			reg[inst.dst_reg] =
+				(int64_t)(uint64_t)reg[inst.dst_reg] >>
+				inst.imm;
+			break;
+		case EBPF_OP_ARSH64_REG:
+			reg[inst.dst_reg] =
+				(int64_t)(uint64_t)reg[inst.dst_reg] >>
+				reg[inst.src_reg];
+			break;
 
-            /*
-             * HACK runtime bounds check
-             *
-             * Needed since we don't have a verifier yet.
-             */
-#define BOUNDS_CHECK_LOAD(size)                                                                                 \
-    do {                                                                                                        \
-        if (!bounds_check(vm, (char*)(uintptr_t)reg[inst.src_reg] + inst.off, size, "load", cur_pc, mem, mem_len, stack)) { \
-            return -1;                                                                                          \
-        }                                                                                                       \
-    } while (0)
-#define BOUNDS_CHECK_STORE(size)                                                                                 \
-    do {                                                                                                         \
-        if (!bounds_check(vm, (char*)(uintptr_t)reg[inst.dst_reg] + inst.off, size, "store", cur_pc, mem, mem_len, stack)) { \
-            return -1;                                                                                           \
-        }                                                                                                        \
-    } while (0)
+			/*
+			 * HACK runtime bounds check
+			 *
+			 * Needed since we don't have a verifier yet.
+			 */
+#define BOUNDS_CHECK_LOAD(size)                                                \
+	do {                                                                   \
+		if (!bounds_check(                                             \
+			    vm,                                                \
+			    (char *)(uintptr_t)reg[inst.src_reg] + inst.off,   \
+			    size, "load", cur_pc, mem, mem_len, stack)) {      \
+			return -1;                                             \
+		}                                                              \
+	} while (0)
+#define BOUNDS_CHECK_STORE(size)                                               \
+	do {                                                                   \
+		if (!bounds_check(                                             \
+			    vm,                                                \
+			    (char *)(uintptr_t)reg[inst.dst_reg] + inst.off,   \
+			    size, "store", cur_pc, mem, mem_len, stack)) {     \
+			return -1;                                             \
+		}                                                              \
+	} while (0)
 
-        case EBPF_OP_LDXW:
-            BOUNDS_CHECK_LOAD(4);
-            reg[inst.dst_reg] = ebpf_mem_load(reg[inst.src_reg] + inst.off, 4);
-            break;
-        case EBPF_OP_LDXH:
-            BOUNDS_CHECK_LOAD(2);
-            reg[inst.dst_reg] = ebpf_mem_load(reg[inst.src_reg] + inst.off, 2);
-            break;
-        case EBPF_OP_LDXB:
-            BOUNDS_CHECK_LOAD(1);
-            reg[inst.dst_reg] = ebpf_mem_load(reg[inst.src_reg] + inst.off, 1);
-            break;
-        case EBPF_OP_LDXDW:
-            BOUNDS_CHECK_LOAD(8);
-            reg[inst.dst_reg] = ebpf_mem_load(reg[inst.src_reg] + inst.off, 8);
-            break;
+		case EBPF_OP_LDXW:
+			BOUNDS_CHECK_LOAD(4);
+			reg[inst.dst_reg] =
+				ebpf_mem_load(reg[inst.src_reg] + inst.off, 4);
+			break;
+		case EBPF_OP_LDXH:
+			BOUNDS_CHECK_LOAD(2);
+			reg[inst.dst_reg] =
+				ebpf_mem_load(reg[inst.src_reg] + inst.off, 2);
+			break;
+		case EBPF_OP_LDXB:
+			BOUNDS_CHECK_LOAD(1);
+			reg[inst.dst_reg] =
+				ebpf_mem_load(reg[inst.src_reg] + inst.off, 1);
+			break;
+		case EBPF_OP_LDXDW:
+			BOUNDS_CHECK_LOAD(8);
+			reg[inst.dst_reg] =
+				ebpf_mem_load(reg[inst.src_reg] + inst.off, 8);
+			break;
 
-        case EBPF_OP_STW:
-            BOUNDS_CHECK_STORE(4);
-            ebpf_mem_store(reg[inst.dst_reg] + inst.off, inst.imm, 4);
-            break;
-        case EBPF_OP_STH:
-            BOUNDS_CHECK_STORE(2);
-            ebpf_mem_store(reg[inst.dst_reg] + inst.off, inst.imm, 2);
-            break;
-        case EBPF_OP_STB:
-            BOUNDS_CHECK_STORE(1);
-            ebpf_mem_store(reg[inst.dst_reg] + inst.off, inst.imm, 1);
-            break;
-        case EBPF_OP_STDW:
-            BOUNDS_CHECK_STORE(8);
-            ebpf_mem_store(reg[inst.dst_reg] + inst.off, inst.imm, 8);
-            break;
+		case EBPF_OP_STW:
+			BOUNDS_CHECK_STORE(4);
+			ebpf_mem_store(reg[inst.dst_reg] + inst.off, inst.imm,
+				       4);
+			break;
+		case EBPF_OP_STH:
+			BOUNDS_CHECK_STORE(2);
+			ebpf_mem_store(reg[inst.dst_reg] + inst.off, inst.imm,
+				       2);
+			break;
+		case EBPF_OP_STB:
+			BOUNDS_CHECK_STORE(1);
+			ebpf_mem_store(reg[inst.dst_reg] + inst.off, inst.imm,
+				       1);
+			break;
+		case EBPF_OP_STDW:
+			BOUNDS_CHECK_STORE(8);
+			ebpf_mem_store(reg[inst.dst_reg] + inst.off, inst.imm,
+				       8);
+			break;
 
-        case EBPF_OP_STXW:
-            BOUNDS_CHECK_STORE(4);
-            ebpf_mem_store(reg[inst.dst_reg] + inst.off, reg[inst.src_reg], 4);
-            break;
-        case EBPF_OP_STXH:
-            BOUNDS_CHECK_STORE(2);
-            ebpf_mem_store(reg[inst.dst_reg] + inst.off, reg[inst.src_reg], 2);
-            break;
-        case EBPF_OP_STXB:
-            BOUNDS_CHECK_STORE(1);
-            ebpf_mem_store(reg[inst.dst_reg] + inst.off, reg[inst.src_reg], 1);
-            break;
-        case EBPF_OP_STXDW:
-            BOUNDS_CHECK_STORE(8);
-            ebpf_mem_store(reg[inst.dst_reg] + inst.off, reg[inst.src_reg], 8);
-            break;
+		case EBPF_OP_STXW:
+			BOUNDS_CHECK_STORE(4);
+			ebpf_mem_store(reg[inst.dst_reg] + inst.off,
+				       reg[inst.src_reg], 4);
+			break;
+		case EBPF_OP_STXH:
+			BOUNDS_CHECK_STORE(2);
+			ebpf_mem_store(reg[inst.dst_reg] + inst.off,
+				       reg[inst.src_reg], 2);
+			break;
+		case EBPF_OP_STXB:
+			BOUNDS_CHECK_STORE(1);
+			ebpf_mem_store(reg[inst.dst_reg] + inst.off,
+				       reg[inst.src_reg], 1);
+			break;
+		case EBPF_OP_STXDW:
+			BOUNDS_CHECK_STORE(8);
+			ebpf_mem_store(reg[inst.dst_reg] + inst.off,
+				       reg[inst.src_reg], 8);
+			break;
 
-        case EBPF_OP_LDDW:
-            {    
-                struct ebpf_inst next_inst =
-                    ebpf_fetch_instruction(vm, pc++);
-                if (inst.src_reg == 0) {
-                    reg[inst.dst_reg] =
-                        (u32)(inst.imm) |
-                        ((uint64_t)next_inst.imm << 32);
-                } else if (inst.src_reg == 1) {
-                    reg[inst.dst_reg] = vm->map_by_fd(inst.imm);
-                } else if (inst.src_reg == 2) {
-                    reg[inst.dst_reg] =
-                        vm->map_val(vm->map_by_fd(inst.imm)) +
-                        (uint64_t)next_inst.imm;
-                } else if (inst.src_reg == 3) {
-                    reg[inst.dst_reg] = vm->var_addr(inst.imm);
-                } else if (inst.src_reg == 4) {
-                    reg[inst.dst_reg] = vm->code_addr(inst.imm);
-                } else if (inst.src_reg == 5) {
-                    reg[inst.dst_reg] = vm->map_by_idx(inst.imm);
-                } else if (inst.src_reg == 6) {
-                    reg[inst.dst_reg] =
-                        vm->map_val(vm->map_by_idx(inst.imm)) +
-                        (uint64_t)next_inst.imm;
-                }
-                break;
-            }
-        case EBPF_OP_JA:
-            pc += inst.off;
-            break;
-        case EBPF_OP_JEQ_IMM:
-            if (reg[inst.dst_reg] == (uint64_t)inst.imm) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JEQ_REG:
-            if (reg[inst.dst_reg] == reg[inst.src_reg]) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JEQ32_IMM:
-            if ((uint32_t)(reg[inst.dst_reg]) == (uint32_t)(inst.imm)) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JEQ32_REG:
-            if ((uint32_t)(reg[inst.dst_reg]) == reg[inst.src_reg]) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JGT_IMM:
-            if (reg[inst.dst_reg] > (uint32_t)(inst.imm)) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JGT_REG:
-            if (reg[inst.dst_reg] > reg[inst.src_reg]) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JGT32_IMM:
-            if ((uint32_t)(reg[inst.dst_reg]) > (uint32_t)(inst.imm)) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JGT32_REG:
-            if ((uint32_t)(reg[inst.dst_reg]) > (uint32_t)(reg[inst.src_reg])) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JGE_IMM:
-            if (reg[inst.dst_reg] >= (uint32_t)(inst.imm)) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JGE_REG:
-            if (reg[inst.dst_reg] >= reg[inst.src_reg]) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JGE32_IMM:
-            if ((uint32_t)(reg[inst.dst_reg]) >= (uint32_t)(inst.imm)) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JGE32_REG:
-            if ((uint32_t)(reg[inst.dst_reg]) >= (uint32_t)(reg[inst.src_reg])) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JLT_IMM:
-            if (reg[inst.dst_reg] < (uint32_t)(inst.imm)) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JLT_REG:
-            if (reg[inst.dst_reg] < reg[inst.src_reg]) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JLT32_IMM:
-            if ((uint32_t)(reg[inst.dst_reg]) < (uint32_t)(inst.imm)) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JLT32_REG:
-            if ((uint32_t)(reg[inst.dst_reg]) < (uint32_t)(reg[inst.src_reg])) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JLE_IMM:
-            if (reg[inst.dst_reg] <= (uint32_t)(inst.imm)) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JLE_REG:
-            if (reg[inst.dst_reg] <= reg[inst.src_reg]) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JLE32_IMM:
-            if ((uint32_t)(reg[inst.dst_reg]) <= (uint32_t)(inst.imm)) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JLE32_REG:
-            if ((uint32_t)(reg[inst.dst_reg]) <= (uint32_t)(reg[inst.src_reg])) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JSET_IMM:
-            if (reg[inst.dst_reg] & inst.imm) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JSET_REG:
-            if (reg[inst.dst_reg] & reg[inst.src_reg]) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JSET32_IMM:
-            if ((uint32_t)(reg[inst.dst_reg]) & (uint32_t)(inst.imm)) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JSET32_REG:
-            if ((uint32_t)(reg[inst.dst_reg]) & (uint32_t)(reg[inst.src_reg])) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JNE_IMM:
-            if (reg[inst.dst_reg] != (uint64_t)inst.imm) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JNE_REG:
-            if (reg[inst.dst_reg] != reg[inst.src_reg]) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JNE32_IMM:
-            if ((uint32_t)(reg[inst.dst_reg]) != (uint32_t)(inst.imm)) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JNE32_REG:
-            if ((uint32_t)(reg[inst.dst_reg]) != (uint32_t)(reg[inst.src_reg])) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JSGT_IMM:
-            if ((int64_t)reg[inst.dst_reg] > inst.imm) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JSGT_REG:
-            if ((int64_t)reg[inst.dst_reg] > (int64_t)reg[inst.src_reg]) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JSGT32_IMM:
-            if ((int32_t)(reg[inst.dst_reg]) > (int32_t)(inst.imm)) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JSGT32_REG:
-            if ((int32_t)(reg[inst.dst_reg]) > (int32_t)(reg[inst.src_reg])) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JSGE_IMM:
-            if ((int64_t)reg[inst.dst_reg] >= inst.imm) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JSGE_REG:
-            if ((int64_t)reg[inst.dst_reg] >= (int64_t)reg[inst.src_reg]) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JSGE32_IMM:
-            if ((int32_t)(reg[inst.dst_reg]) >= (int32_t)(inst.imm)) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JSGE32_REG:
-            if ((int32_t)(reg[inst.dst_reg]) >= (int32_t)(reg[inst.src_reg])) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JSLT_IMM:
-            if ((int64_t)reg[inst.dst_reg] < inst.imm) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JSLT_REG:
-            if ((int64_t)reg[inst.dst_reg] < (int64_t)reg[inst.src_reg]) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JSLT32_IMM:
-            if ((int32_t)(reg[inst.dst_reg]) < (int32_t)(inst.imm)) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JSLT32_REG:
-            if ((int32_t)(reg[inst.dst_reg]) < (int32_t)(reg[inst.src_reg])) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JSLE_IMM:
-            if ((int64_t)reg[inst.dst_reg] <= inst.imm) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JSLE_REG:
-            if ((int64_t)reg[inst.dst_reg] <= (int64_t)reg[inst.src_reg]) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JSLE32_IMM:
-            if ((int32_t)(reg[inst.dst_reg]) <= (int32_t)(inst.imm)) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_JSLE32_REG:
-            if ((int32_t)(reg[inst.dst_reg]) <= (int32_t)(reg[inst.src_reg])) {
-                pc += inst.off;
-            }
-            break;
-        case EBPF_OP_EXIT:
-            *bpf_return_value = reg[0];
-            return 0;
-        case EBPF_OP_CALL:
-            LOG_DEBUG("call: %p", vm->ext_funcs[inst.imm]);
-            reg[0] = vm->ext_funcs[inst.imm](reg[1], reg[2], reg[3], reg[4], reg[5]);
-            // Unwind the stack if unwind extension returns success.
-            if (inst.imm == vm->unwind_stack_extension_index && reg[0] == 0) {
-                *bpf_return_value = reg[0];
-                return 0;
-            }
-            break;
-        }
-    }
+		case EBPF_OP_LDDW: {
+			struct ebpf_inst next_inst =
+				ebpf_fetch_instruction(vm, pc++);
+			if (inst.src_reg == 0) {
+				reg[inst.dst_reg] =
+					(u32)(inst.imm) |
+					((uint64_t)next_inst.imm << 32);
+			} else if (inst.src_reg == 1) {
+				reg[inst.dst_reg] = vm->map_by_fd(inst.imm);
+			} else if (inst.src_reg == 2) {
+				reg[inst.dst_reg] =
+					vm->map_val(vm->map_by_fd(inst.imm)) +
+					(uint64_t)next_inst.imm;
+			} else if (inst.src_reg == 3) {
+				reg[inst.dst_reg] = vm->var_addr(inst.imm);
+			} else if (inst.src_reg == 4) {
+				reg[inst.dst_reg] = vm->code_addr(inst.imm);
+			} else if (inst.src_reg == 5) {
+				reg[inst.dst_reg] = vm->map_by_idx(inst.imm);
+			} else if (inst.src_reg == 6) {
+				reg[inst.dst_reg] =
+					vm->map_val(vm->map_by_idx(inst.imm)) +
+					(uint64_t)next_inst.imm;
+			}
+			break;
+		}
+		case EBPF_OP_JA:
+			pc += inst.off;
+			break;
+		case EBPF_OP_JEQ_IMM:
+			if (reg[inst.dst_reg] == (uint64_t)inst.imm) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JEQ_REG:
+			if (reg[inst.dst_reg] == reg[inst.src_reg]) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JEQ32_IMM:
+			if ((uint32_t)(reg[inst.dst_reg]) ==
+			    (uint32_t)(inst.imm)) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JEQ32_REG:
+			if ((uint32_t)(reg[inst.dst_reg]) ==
+			    reg[inst.src_reg]) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JGT_IMM:
+			if (reg[inst.dst_reg] > (uint32_t)(inst.imm)) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JGT_REG:
+			if (reg[inst.dst_reg] > reg[inst.src_reg]) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JGT32_IMM:
+			if ((uint32_t)(reg[inst.dst_reg]) >
+			    (uint32_t)(inst.imm)) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JGT32_REG:
+			if ((uint32_t)(reg[inst.dst_reg]) >
+			    (uint32_t)(reg[inst.src_reg])) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JGE_IMM:
+			if (reg[inst.dst_reg] >= (uint32_t)(inst.imm)) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JGE_REG:
+			if (reg[inst.dst_reg] >= reg[inst.src_reg]) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JGE32_IMM:
+			if ((uint32_t)(reg[inst.dst_reg]) >=
+			    (uint32_t)(inst.imm)) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JGE32_REG:
+			if ((uint32_t)(reg[inst.dst_reg]) >=
+			    (uint32_t)(reg[inst.src_reg])) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JLT_IMM:
+			if (reg[inst.dst_reg] < (uint32_t)(inst.imm)) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JLT_REG:
+			if (reg[inst.dst_reg] < reg[inst.src_reg]) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JLT32_IMM:
+			if ((uint32_t)(reg[inst.dst_reg]) <
+			    (uint32_t)(inst.imm)) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JLT32_REG:
+			if ((uint32_t)(reg[inst.dst_reg]) <
+			    (uint32_t)(reg[inst.src_reg])) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JLE_IMM:
+			if (reg[inst.dst_reg] <= (uint32_t)(inst.imm)) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JLE_REG:
+			if (reg[inst.dst_reg] <= reg[inst.src_reg]) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JLE32_IMM:
+			if ((uint32_t)(reg[inst.dst_reg]) <=
+			    (uint32_t)(inst.imm)) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JLE32_REG:
+			if ((uint32_t)(reg[inst.dst_reg]) <=
+			    (uint32_t)(reg[inst.src_reg])) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JSET_IMM:
+			if (reg[inst.dst_reg] & inst.imm) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JSET_REG:
+			if (reg[inst.dst_reg] & reg[inst.src_reg]) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JSET32_IMM:
+			if ((uint32_t)(reg[inst.dst_reg]) &
+			    (uint32_t)(inst.imm)) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JSET32_REG:
+			if ((uint32_t)(reg[inst.dst_reg]) &
+			    (uint32_t)(reg[inst.src_reg])) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JNE_IMM:
+			if (reg[inst.dst_reg] != (uint64_t)inst.imm) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JNE_REG:
+			if (reg[inst.dst_reg] != reg[inst.src_reg]) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JNE32_IMM:
+			if ((uint32_t)(reg[inst.dst_reg]) !=
+			    (uint32_t)(inst.imm)) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JNE32_REG:
+			if ((uint32_t)(reg[inst.dst_reg]) !=
+			    (uint32_t)(reg[inst.src_reg])) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JSGT_IMM:
+			if ((int64_t)reg[inst.dst_reg] > inst.imm) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JSGT_REG:
+			if ((int64_t)reg[inst.dst_reg] >
+			    (int64_t)reg[inst.src_reg]) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JSGT32_IMM:
+			if ((int32_t)(reg[inst.dst_reg]) >
+			    (int32_t)(inst.imm)) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JSGT32_REG:
+			if ((int32_t)(reg[inst.dst_reg]) >
+			    (int32_t)(reg[inst.src_reg])) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JSGE_IMM:
+			if ((int64_t)reg[inst.dst_reg] >= inst.imm) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JSGE_REG:
+			if ((int64_t)reg[inst.dst_reg] >=
+			    (int64_t)reg[inst.src_reg]) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JSGE32_IMM:
+			if ((int32_t)(reg[inst.dst_reg]) >=
+			    (int32_t)(inst.imm)) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JSGE32_REG:
+			if ((int32_t)(reg[inst.dst_reg]) >=
+			    (int32_t)(reg[inst.src_reg])) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JSLT_IMM:
+			if ((int64_t)reg[inst.dst_reg] < inst.imm) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JSLT_REG:
+			if ((int64_t)reg[inst.dst_reg] <
+			    (int64_t)reg[inst.src_reg]) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JSLT32_IMM:
+			if ((int32_t)(reg[inst.dst_reg]) <
+			    (int32_t)(inst.imm)) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JSLT32_REG:
+			if ((int32_t)(reg[inst.dst_reg]) <
+			    (int32_t)(reg[inst.src_reg])) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JSLE_IMM:
+			if ((int64_t)reg[inst.dst_reg] <= inst.imm) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JSLE_REG:
+			if ((int64_t)reg[inst.dst_reg] <=
+			    (int64_t)reg[inst.src_reg]) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JSLE32_IMM:
+			if ((int32_t)(reg[inst.dst_reg]) <=
+			    (int32_t)(inst.imm)) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_JSLE32_REG:
+			if ((int32_t)(reg[inst.dst_reg]) <=
+			    (int32_t)(reg[inst.src_reg])) {
+				pc += inst.off;
+			}
+			break;
+		case EBPF_OP_EXIT:
+			*bpf_return_value = reg[0];
+			return 0;
+		case EBPF_OP_CALL:
+			LOG_DEBUG("call: %p", vm->ext_funcs[inst.imm]);
+			reg[0] = vm->ext_funcs[inst.imm](reg[1], reg[2], reg[3],
+							 reg[4], reg[5]);
+			// Unwind the stack if unwind extension returns success.
+			if (inst.imm == vm->unwind_stack_extension_index &&
+			    reg[0] == 0) {
+				*bpf_return_value = reg[0];
+				return 0;
+			}
+			break;
+
+			// 32b atomic ops
+		case EBPF_ATOMIC | EBPF_SIZE_W | EBPF_STX: {
+			switch (inst.imm) {
+			case EBPF_ATOMIC_ADD: {
+				// Add
+				__atomic_fetch_add(
+					(uint32_t *)(uintptr_t)(reg[inst.dst_reg] +
+								inst.off),
+					reg[inst.src_reg], __ATOMIC_RELAXED);
+				break;
+			}
+			case EBPF_ATOMIC_OR: {
+				// Or
+				__atomic_fetch_or(
+					(uint32_t *)(uintptr_t)(reg[inst.dst_reg] +
+								inst.off),
+					reg[inst.src_reg], __ATOMIC_RELAXED);
+				break;
+			}
+			case EBPF_ATOMIC_AND: {
+				// And
+				__atomic_fetch_and(
+					(uint32_t *)(uintptr_t)(reg[inst.dst_reg] +
+								inst.off),
+					reg[inst.src_reg], __ATOMIC_RELAXED);
+				break;
+			}
+			case EBPF_ATOMIC_XOR: {
+				// Xor
+				__atomic_fetch_xor(
+					(uint32_t *)(uintptr_t)(reg[inst.dst_reg] +
+								inst.off),
+					reg[inst.src_reg], __ATOMIC_RELAXED);
+				break;
+			}
+			case EBPF_XCHG: {
+				// XCHG
+				__atomic_exchange(
+					(uint32_t *)(uintptr_t)(reg[inst.dst_reg] +
+								inst.off),
+					(uint32_t *)&reg[inst.src_reg],
+					(uint32_t *)&reg[inst.src_reg],
+					__ATOMIC_RELAXED);
+				break;
+			}
+			}
+			break;
+		}
+			// 64b atomic ops
+		case EBPF_ATOMIC | EBPF_SIZE_DW | EBPF_STX: {
+			switch (inst.imm) {
+			case EBPF_ATOMIC_ADD: {
+				// Add
+				__atomic_fetch_add(
+					(uint64_t *)(uintptr_t)(reg[inst.dst_reg] +
+								inst.off),
+					reg[inst.src_reg], __ATOMIC_RELAXED);
+				break;
+			}
+			case EBPF_ATOMIC_OR: {
+				// Or
+				__atomic_fetch_or(
+					(uint64_t *)(uintptr_t)(reg[inst.dst_reg] +
+								inst.off),
+					reg[inst.src_reg], __ATOMIC_RELAXED);
+				break;
+			}
+			case EBPF_ATOMIC_AND: {
+				// And
+				__atomic_fetch_and(
+					(uint64_t *)(uintptr_t)(reg[inst.dst_reg] +
+								inst.off),
+					reg[inst.src_reg], __ATOMIC_RELAXED);
+				break;
+			}
+			case EBPF_ATOMIC_XOR: {
+				// Xor
+				__atomic_fetch_xor(
+					(uint64_t *)(uintptr_t)(reg[inst.dst_reg] +
+								inst.off),
+					reg[inst.src_reg], __ATOMIC_RELAXED);
+				break;
+			}
+			case EBPF_XCHG: {
+				// XCHG
+				__atomic_exchange(
+					(uint64_t *)(uintptr_t)(reg[inst.dst_reg] +
+								inst.off),
+					(uint64_t *)&reg[inst.src_reg],
+					(uint64_t *)&reg[inst.src_reg],
+					__ATOMIC_RELAXED);
+				break;
+			}
+			}
+			break;
+			break;
+		}
+		}
+	}
 }
 
-static bool
-validate(const struct ebpf_vm* vm, const struct ebpf_inst* insts, uint32_t num_insts, char** errmsg)
+static bool validate(const struct ebpf_vm *vm, const struct ebpf_inst *insts,
+		     uint32_t num_insts, char **errmsg)
 {
-    if (num_insts >= EBPF_MAX_INSTS) {
-        *errmsg = ebpf_error("too many instructions (max %u)", EBPF_MAX_INSTS);
-        return false;
-    }
+	if (num_insts >= EBPF_MAX_INSTS) {
+		*errmsg = ebpf_error("too many instructions (max %u)",
+				     EBPF_MAX_INSTS);
+		return false;
+	}
 
-    for (size_t i = 0; i < num_insts; i++) {
-        struct ebpf_inst inst = insts[i];
-        bool store = false;
+	for (size_t i = 0; i < num_insts; i++) {
+		struct ebpf_inst inst = insts[i];
+		bool store = false;
 
-        LOG_DEBUG("validate: %08" PRIu64 "x, [%zd] %d %d %d %d\n", *(uint64_t*)(uintptr_t)&inst, i, 
-	       inst.dst_reg, inst.src_reg, inst.off, inst.imm);
-        switch (inst.code) {
-        case EBPF_OP_ADD_IMM:
-        case EBPF_OP_ADD_REG:
-        case EBPF_OP_SUB_IMM:
-        case EBPF_OP_SUB_REG:
-        case EBPF_OP_MUL_IMM:
-        case EBPF_OP_MUL_REG:
-        case EBPF_OP_DIV_REG:
-        case EBPF_OP_OR_IMM:
-        case EBPF_OP_OR_REG:
-        case EBPF_OP_AND_IMM:
-        case EBPF_OP_AND_REG:
-        case EBPF_OP_LSH_IMM:
-        case EBPF_OP_LSH_REG:
-        case EBPF_OP_RSH_IMM:
-        case EBPF_OP_RSH_REG:
-        case EBPF_OP_NEG:
-        case EBPF_OP_MOD_REG:
-        case EBPF_OP_XOR_IMM:
-        case EBPF_OP_XOR_REG:
-        case EBPF_OP_MOV_IMM:
-        case EBPF_OP_MOV_REG:
-        case EBPF_OP_ARSH_IMM:
-        case EBPF_OP_ARSH_REG:
-            break;
+		LOG_DEBUG("validate: %08" PRIu64 "x, [%zd] %d %d %d %d\n",
+			  *(uint64_t *)(uintptr_t)&inst, i, inst.dst_reg,
+			  inst.src_reg, inst.off, inst.imm);
+		switch (inst.code) {
+		case EBPF_OP_ADD_IMM:
+		case EBPF_OP_ADD_REG:
+		case EBPF_OP_SUB_IMM:
+		case EBPF_OP_SUB_REG:
+		case EBPF_OP_MUL_IMM:
+		case EBPF_OP_MUL_REG:
+		case EBPF_OP_DIV_REG:
+		case EBPF_OP_OR_IMM:
+		case EBPF_OP_OR_REG:
+		case EBPF_OP_AND_IMM:
+		case EBPF_OP_AND_REG:
+		case EBPF_OP_LSH_IMM:
+		case EBPF_OP_LSH_REG:
+		case EBPF_OP_RSH_IMM:
+		case EBPF_OP_RSH_REG:
+		case EBPF_OP_NEG:
+		case EBPF_OP_MOD_REG:
+		case EBPF_OP_XOR_IMM:
+		case EBPF_OP_XOR_REG:
+		case EBPF_OP_MOV_IMM:
+		case EBPF_OP_MOV_REG:
+		case EBPF_OP_ARSH_IMM:
+		case EBPF_OP_ARSH_REG:
+			break;
 
-        case EBPF_OP_LE:
-        case EBPF_OP_BE:
-            if (inst.imm != 16 && inst.imm != 32 && inst.imm != 64) {
-                *errmsg = ebpf_error("invalid endian immediate at PC %d", i);
-                return false;
-            }
-            break;
+		case EBPF_OP_LE:
+		case EBPF_OP_BE:
+			if (inst.imm != 16 && inst.imm != 32 &&
+			    inst.imm != 64) {
+				*errmsg = ebpf_error(
+					"invalid endian immediate at PC %d", i);
+				return false;
+			}
+			break;
 
-        case EBPF_OP_ADD64_IMM:
-        case EBPF_OP_ADD64_REG:
-        case EBPF_OP_SUB64_IMM:
-        case EBPF_OP_SUB64_REG:
-        case EBPF_OP_MUL64_IMM:
-        case EBPF_OP_MUL64_REG:
-        case EBPF_OP_DIV64_REG:
-        case EBPF_OP_OR64_IMM:
-        case EBPF_OP_OR64_REG:
-        case EBPF_OP_AND64_IMM:
-        case EBPF_OP_AND64_REG:
-        case EBPF_OP_LSH64_IMM:
-        case EBPF_OP_LSH64_REG:
-        case EBPF_OP_RSH64_IMM:
-        case EBPF_OP_RSH64_REG:
-        case EBPF_OP_NEG64:
-        case EBPF_OP_MOD64_REG:
-        case EBPF_OP_XOR64_IMM:
-        case EBPF_OP_XOR64_REG:
-        case EBPF_OP_MOV64_IMM:
-        case EBPF_OP_MOV64_REG:
-        case EBPF_OP_ARSH64_IMM:
-        case EBPF_OP_ARSH64_REG:
-            break;
+		case EBPF_OP_ADD64_IMM:
+		case EBPF_OP_ADD64_REG:
+		case EBPF_OP_SUB64_IMM:
+		case EBPF_OP_SUB64_REG:
+		case EBPF_OP_MUL64_IMM:
+		case EBPF_OP_MUL64_REG:
+		case EBPF_OP_DIV64_REG:
+		case EBPF_OP_OR64_IMM:
+		case EBPF_OP_OR64_REG:
+		case EBPF_OP_AND64_IMM:
+		case EBPF_OP_AND64_REG:
+		case EBPF_OP_LSH64_IMM:
+		case EBPF_OP_LSH64_REG:
+		case EBPF_OP_RSH64_IMM:
+		case EBPF_OP_RSH64_REG:
+		case EBPF_OP_NEG64:
+		case EBPF_OP_MOD64_REG:
+		case EBPF_OP_XOR64_IMM:
+		case EBPF_OP_XOR64_REG:
+		case EBPF_OP_MOV64_IMM:
+		case EBPF_OP_MOV64_REG:
+		case EBPF_OP_ARSH64_IMM:
+		case EBPF_OP_ARSH64_REG:
+			break;
 
-        case EBPF_OP_LDXW:
-        case EBPF_OP_LDXH:
-        case EBPF_OP_LDXB:
-        case EBPF_OP_LDXDW:
-            break;
+		case EBPF_OP_LDXW:
+		case EBPF_OP_LDXH:
+		case EBPF_OP_LDXB:
+		case EBPF_OP_LDXDW:
+			break;
 
-        case EBPF_OP_STW:
-        case EBPF_OP_STH:
-        case EBPF_OP_STB:
-        case EBPF_OP_STDW:
-        case EBPF_OP_STXW:
-        case EBPF_OP_STXH:
-        case EBPF_OP_STXB:
-        case EBPF_OP_STXDW:
-            store = true;
-            break;
+		case EBPF_OP_STW:
+		case EBPF_OP_STH:
+		case EBPF_OP_STB:
+		case EBPF_OP_STDW:
+		case EBPF_OP_STXW:
+		case EBPF_OP_STXH:
+		case EBPF_OP_STXB:
+		case EBPF_OP_STXDW:
+			store = true;
+			break;
 
-        case EBPF_OP_LDDW:
-        if (inst.src_reg == 1 && vm->map_by_fd == NULL) {
+		case EBPF_OP_LDDW:
+			if (inst.src_reg == 1 && vm->map_by_fd == NULL) {
 				*errmsg = ebpf_error(
 					"Missing map_by_fd definition for instruction at %d",
 					i);
@@ -954,235 +1121,241 @@ validate(const struct ebpf_vm* vm, const struct ebpf_inst* insts, uint32_t num_i
 					(int)inst.src_reg, i);
 				return false;
 			}
-            if (i + 1 >= num_insts || insts[i + 1].code != 0) {
-                *errmsg = ebpf_error("incomplete lddw at PC %d", i);
-                return false;
-            }
-            i++; /* Skip next instruction */
-            break;
+			if (i + 1 >= num_insts || insts[i + 1].code != 0) {
+				*errmsg = ebpf_error("incomplete lddw at PC %d",
+						     i);
+				return false;
+			}
+			i++; /* Skip next instruction */
+			break;
 
-        case EBPF_OP_JA:
-        case EBPF_OP_JEQ_REG:
-        case EBPF_OP_JEQ_IMM:
-        case EBPF_OP_JGT_REG:
-        case EBPF_OP_JGT_IMM:
-        case EBPF_OP_JGE_REG:
-        case EBPF_OP_JGE_IMM:
-        case EBPF_OP_JLT_REG:
-        case EBPF_OP_JLT_IMM:
-        case EBPF_OP_JLE_REG:
-        case EBPF_OP_JLE_IMM:
-        case EBPF_OP_JSET_REG:
-        case EBPF_OP_JSET_IMM:
-        case EBPF_OP_JNE_REG:
-        case EBPF_OP_JNE_IMM:
-        case EBPF_OP_JSGT_IMM:
-        case EBPF_OP_JSGT_REG:
-        case EBPF_OP_JSGE_IMM:
-        case EBPF_OP_JSGE_REG:
-        case EBPF_OP_JSLT_IMM:
-        case EBPF_OP_JSLT_REG:
-        case EBPF_OP_JSLE_IMM:
-        case EBPF_OP_JSLE_REG:
-        case EBPF_OP_JEQ32_IMM:
-        case EBPF_OP_JEQ32_REG:
-        case EBPF_OP_JGT32_IMM:
-        case EBPF_OP_JGT32_REG:
-        case EBPF_OP_JGE32_IMM:
-        case EBPF_OP_JGE32_REG:
-        case EBPF_OP_JSET32_REG:
-        case EBPF_OP_JSET32_IMM:
-        case EBPF_OP_JNE32_IMM:
-        case EBPF_OP_JNE32_REG:
-        case EBPF_OP_JSGT32_IMM:
-        case EBPF_OP_JSGT32_REG:
-        case EBPF_OP_JSGE32_IMM:
-        case EBPF_OP_JSGE32_REG:
-        case EBPF_OP_JLT32_IMM:
-        case EBPF_OP_JLT32_REG:
-        case EBPF_OP_JLE32_IMM:
-        case EBPF_OP_JLE32_REG:
-        case EBPF_OP_JSLT32_IMM:
-        case EBPF_OP_JSLT32_REG:
-        case EBPF_OP_JSLE32_IMM:
-        case EBPF_OP_JSLE32_REG:
-            if (inst.off == -1) {
-                *errmsg = ebpf_error("infinite loop at PC %d", i);
-                return false;
-            }
-            int new_pc = i + 1 + inst.off;
-            if (new_pc < 0 || (uint32_t )new_pc >= num_insts) {
-                *errmsg = ebpf_error("jump out of bounds at PC %d", i);
-                return false;
-            } else if (insts[new_pc].code == 0) {
-                *errmsg = ebpf_error("jump to middle of lddw at PC %d", i);
-                return false;
-            }
-            break;
+		case EBPF_OP_JA:
+		case EBPF_OP_JEQ_REG:
+		case EBPF_OP_JEQ_IMM:
+		case EBPF_OP_JGT_REG:
+		case EBPF_OP_JGT_IMM:
+		case EBPF_OP_JGE_REG:
+		case EBPF_OP_JGE_IMM:
+		case EBPF_OP_JLT_REG:
+		case EBPF_OP_JLT_IMM:
+		case EBPF_OP_JLE_REG:
+		case EBPF_OP_JLE_IMM:
+		case EBPF_OP_JSET_REG:
+		case EBPF_OP_JSET_IMM:
+		case EBPF_OP_JNE_REG:
+		case EBPF_OP_JNE_IMM:
+		case EBPF_OP_JSGT_IMM:
+		case EBPF_OP_JSGT_REG:
+		case EBPF_OP_JSGE_IMM:
+		case EBPF_OP_JSGE_REG:
+		case EBPF_OP_JSLT_IMM:
+		case EBPF_OP_JSLT_REG:
+		case EBPF_OP_JSLE_IMM:
+		case EBPF_OP_JSLE_REG:
+		case EBPF_OP_JEQ32_IMM:
+		case EBPF_OP_JEQ32_REG:
+		case EBPF_OP_JGT32_IMM:
+		case EBPF_OP_JGT32_REG:
+		case EBPF_OP_JGE32_IMM:
+		case EBPF_OP_JGE32_REG:
+		case EBPF_OP_JSET32_REG:
+		case EBPF_OP_JSET32_IMM:
+		case EBPF_OP_JNE32_IMM:
+		case EBPF_OP_JNE32_REG:
+		case EBPF_OP_JSGT32_IMM:
+		case EBPF_OP_JSGT32_REG:
+		case EBPF_OP_JSGE32_IMM:
+		case EBPF_OP_JSGE32_REG:
+		case EBPF_OP_JLT32_IMM:
+		case EBPF_OP_JLT32_REG:
+		case EBPF_OP_JLE32_IMM:
+		case EBPF_OP_JLE32_REG:
+		case EBPF_OP_JSLT32_IMM:
+		case EBPF_OP_JSLT32_REG:
+		case EBPF_OP_JSLE32_IMM:
+		case EBPF_OP_JSLE32_REG:
+			if (inst.off == -1) {
+				*errmsg =
+					ebpf_error("infinite loop at PC %d", i);
+				return false;
+			}
+			int new_pc = i + 1 + inst.off;
+			if (new_pc < 0 || (uint32_t)new_pc >= num_insts) {
+				*errmsg = ebpf_error(
+					"jump out of bounds at PC %d", i);
+				return false;
+			} else if (insts[new_pc].code == 0) {
+				*errmsg = ebpf_error(
+					"jump to middle of lddw at PC %d", i);
+				return false;
+			}
+			break;
 
-        case EBPF_OP_CALL:
-            if (inst.imm < 0 || inst.imm >= MAX_EXT_FUNCS) {
-                *errmsg = ebpf_error("invalid call immediate at PC %d", i);
-                return false;
-            }
-            LOG_DEBUG("func: %p\n", vm->ext_funcs[inst.imm]);
-            if (!vm->ext_funcs[inst.imm]) {
-                *errmsg = ebpf_error("call to nonexistent function %u at PC %d", inst.imm, i);
-                return false;
-            }
-            break;
+		case EBPF_OP_CALL:
+			if (inst.imm < 0 || inst.imm >= MAX_EXT_FUNCS) {
+				*errmsg = ebpf_error(
+					"invalid call immediate at PC %d", i);
+				return false;
+			}
+			LOG_DEBUG("func: %p\n", vm->ext_funcs[inst.imm]);
+			if (!vm->ext_funcs[inst.imm]) {
+				*errmsg = ebpf_error(
+					"call to nonexistent function %u at PC %d",
+					inst.imm, i);
+				return false;
+			}
+			break;
+		case EBPF_ATOMIC_OPCODE_32:
+		case EBPF_ATOMIC_OPCODE_64: {
+			if (inst.imm != EBPF_ATOMIC_ADD &&
+			    inst.imm != EBPF_ATOMIC_OR &&
+			    inst.imm != EBPF_ATOMIC_AND &&
+			    inst.imm != EBPF_ATOMIC_XOR &&
+			    inst.imm != EBPF_XCHG &&
+			    inst.imm != EBPF_ATOMIC_ADD) {
+				*errmsg = ebpf_error(
+					"Unsupported atomic operations on imm %d at PC %d",
+					inst.imm, (int)inst.imm);
+				return false;
+			}
+			break;
+		}
+		case EBPF_OP_EXIT:
+			break;
 
-        case EBPF_OP_EXIT:
-            break;
+		case EBPF_OP_DIV_IMM:
+		case EBPF_OP_MOD_IMM:
+		case EBPF_OP_DIV64_IMM:
+		case EBPF_OP_MOD64_IMM:
+			break;
 
-        case EBPF_OP_DIV_IMM:
-        case EBPF_OP_MOD_IMM:
-        case EBPF_OP_DIV64_IMM:
-        case EBPF_OP_MOD64_IMM:
-            break;
+		default:
+			*errmsg = ebpf_error("unknown opcode 0x%02x at PC %d",
+					     inst.code, i);
+			return false;
+		}
 
-        default:
-            *errmsg = ebpf_error("unknown opcode 0x%02x at PC %d", inst.code, i);
-            return false;
-        }
+		if (inst.src_reg > 10) {
+			*errmsg = ebpf_error("invalid source register at PC %d",
+					     i);
+			return false;
+		}
 
-        if (inst.src_reg > 10) {
-            *errmsg = ebpf_error("invalid source register at PC %d", i);
-            return false;
-        }
+		if (inst.dst_reg > 9 && !(store && inst.dst_reg == 10)) {
+			*errmsg = ebpf_error(
+				"invalid destination register at PC %d", i);
+			return false;
+		}
+	}
 
-        if (inst.dst_reg > 9 && !(store && inst.dst_reg == 10)) {
-            *errmsg = ebpf_error("invalid destination register at PC %d", i);
-            return false;
-        }
-    }
-
-    return true;
+	return true;
 }
 
-static bool
-bounds_check(
-    const struct ebpf_vm* vm,
-    void* addr,
-    int size,
-    const char* type,
-    uint16_t cur_pc,
-    void* mem,
-    size_t mem_len,
-    void* stack)
+static bool bounds_check(const struct ebpf_vm *vm, void *addr, int size,
+			 const char *type, uint16_t cur_pc, void *mem,
+			 size_t mem_len, void *stack)
 {
-    if (!vm->bounds_check_enabled)
-        return true;
-    if (mem && (addr >= mem && ((char*)addr + size) <= ((char*)mem + mem_len))) {
-        /* Context access */
-        return true;
-    } else if (addr >= stack && ((char*)addr + size) <= ((char*)stack + EBPF_STACK_SIZE)) {
-        /* Stack access */
-        return true;
-    } else {
-        vm->error_printf(
-            stderr,
-            "ebpf error: out of bounds memory %s at PC %u, addr %p, size %d\nmem %p/%zd stack %p/%d\n",
-            type,
-            cur_pc,
-            addr,
-            size,
-            mem,
-            mem_len,
-            stack,
-            EBPF_STACK_SIZE);
-        return false;
-    }
+	if (!vm->bounds_check_enabled)
+		return true;
+	if (mem &&
+	    (addr >= mem && ((char *)addr + size) <= ((char *)mem + mem_len))) {
+		/* Context access */
+		return true;
+	} else if (addr >= stack &&
+		   ((char *)addr + size) <= ((char *)stack + EBPF_STACK_SIZE)) {
+		/* Stack access */
+		return true;
+	} else {
+		vm->error_printf(
+			stderr,
+			"ebpf error: out of bounds memory %s at PC %u, addr %p, size %d\nmem %p/%zd stack %p/%d\n",
+			type, cur_pc, addr, size, mem, mem_len, stack,
+			EBPF_STACK_SIZE);
+		return false;
+	}
 }
 
-char*
-ebpf_error(const char* fmt, ...)
+char *ebpf_error(const char *fmt, ...)
 {
-    char* msg;
-    va_list ap;
-    va_start(ap, fmt);
+	char *msg;
+	va_list ap;
+	va_start(ap, fmt);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
-    if (vasprintf(&msg, fmt, ap) < 0) {
-        msg = NULL;
-    }
+	if (vasprintf(&msg, fmt, ap) < 0) {
+		msg = NULL;
+	}
 #pragma GCC diagnostic pop
-    va_end(ap);
-    return msg;
+	va_end(ap);
+	return msg;
 }
 
 #if DEBUG
-void
-ebpf_set_registers(struct ebpf_vm* vm, uint64_t* regs)
+void ebpf_set_registers(struct ebpf_vm *vm, uint64_t *regs)
 {
-    vm->regs = regs;
+	vm->regs = regs;
 }
 
-uint64_t*
-ebpf_get_registers(const struct ebpf_vm* vm)
+uint64_t *ebpf_get_registers(const struct ebpf_vm *vm)
 {
-    return vm->regs;
+	return vm->regs;
 }
 #else
-void
-ebpf_set_registers(struct ebpf_vm* vm, uint64_t* regs)
+void ebpf_set_registers(struct ebpf_vm *vm, uint64_t *regs)
 {
-    (void)vm;
-    (void)regs;
-    fprintf(stderr, "ebpf warning: registers are not exposed in release mode. Please recompile in debug mode\n");
+	(void)vm;
+	(void)regs;
+	fprintf(stderr,
+		"ebpf warning: registers are not exposed in release mode. Please recompile in debug mode\n");
 }
 
-uint64_t*
-ebpf_get_registers(const struct ebpf_vm* vm)
+uint64_t *ebpf_get_registers(const struct ebpf_vm *vm)
 {
-    (void)vm;
-    fprintf(stderr, "ebpf warning: registers are not exposed in release mode. Please recompile in debug mode\n");
-    return NULL;
+	(void)vm;
+	fprintf(stderr,
+		"ebpf warning: registers are not exposed in release mode. Please recompile in debug mode\n");
+	return NULL;
 }
 
 #endif
 
-typedef struct _ebpf_encoded_inst
-{
-    union
-    {
-        uint64_t value;
-        struct ebpf_inst inst;
-    };
+typedef struct _ebpf_encoded_inst {
+	union {
+		uint64_t value;
+		struct ebpf_inst inst;
+	};
 } ebpf_encoded_inst;
 
-struct ebpf_inst
-ebpf_fetch_instruction(const struct ebpf_vm* vm, uint16_t pc)
+struct ebpf_inst ebpf_fetch_instruction(const struct ebpf_vm *vm, uint16_t pc)
 {
-    // XOR instruction with base address of vm.
-    // This makes ROP attack more difficult.
-    ebpf_encoded_inst encode_inst;
-    encode_inst.inst = vm->insnsi[pc];
-    // encode_inst.value ^= (uint64_t)vm->insnsi;
-    // encode_inst.value ^= vm->pointer_secret;
-    return encode_inst.inst;
+	// XOR instruction with base address of vm.
+	// This makes ROP attack more difficult.
+	ebpf_encoded_inst encode_inst;
+	encode_inst.inst = vm->insnsi[pc];
+	// encode_inst.value ^= (uint64_t)vm->insnsi;
+	// encode_inst.value ^= vm->pointer_secret;
+	return encode_inst.inst;
 }
 
-void
-ebpf_store_instruction(const struct ebpf_vm* vm, uint16_t pc, struct ebpf_inst inst)
+void ebpf_store_instruction(const struct ebpf_vm *vm, uint16_t pc,
+			    struct ebpf_inst inst)
 {
-    // XOR instruction with base address of vm.
-    // This makes ROP attack more difficult.
-    ebpf_encoded_inst encode_inst;
-    encode_inst.inst = inst;
-    // encode_inst.value ^= (uint64_t)vm->insnsi;
-    // encode_inst.value ^= vm->pointer_secret;
-    vm->insnsi[pc] = encode_inst.inst;
+	// XOR instruction with base address of vm.
+	// This makes ROP attack more difficult.
+	ebpf_encoded_inst encode_inst;
+	encode_inst.inst = inst;
+	// encode_inst.value ^= (uint64_t)vm->insnsi;
+	// encode_inst.value ^= vm->pointer_secret;
+	vm->insnsi[pc] = encode_inst.inst;
 }
 
-int
-ebpf_set_pointer_secret(struct ebpf_vm* vm, uint64_t secret)
+int ebpf_set_pointer_secret(struct ebpf_vm *vm, uint64_t secret)
 {
-    if (vm->insnsi) {
-        return -1;
-    }
-    vm->pointer_secret = secret;
-    return 0;
+	if (vm->insnsi) {
+		return -1;
+	}
+	vm->pointer_secret = secret;
+	return 0;
 }
 
 void ebpf_set_lddw_helpers(struct ebpf_vm *vm, uint64_t (*map_by_fd)(uint32_t),


### PR DESCRIPTION
Did lots of things, which make bpftrace work under bpftime.

At least the following trace will work:
- [x] `bpftrace -e 'tracepoint:syscalls:sys_enter_clock_nanosleep { printf("PID %d sleeping...\n", pid); }'`
- [x] `bpftrace -e 'tracepoint:raw_syscalls:sys_enter { @[comm] = count(); }'`

# Updates
- per cpu array/hash map
- global syscall tracepoints (hook the enter and exit of all syscalls, tracepoint/raw_syscalls/sys_{enter,exit})
- Splitted map lookup/update/delete for bpf helper and syscall. per cpu maps behaves differently when being examined from kernel and userspace
- helper ringbuf_output
- atomic operations support for ubpf and llvmjit. Newer bpftrace used this

# Usage
## a. Console1:
```console
root@mnfe-pve:~/bpftime# bpftime load -- /root/bpftrace/build/src/bpftrace -e 'tracepoint:raw_syscalls:sys_enter { @[comm] = count(); }'
[2023-10-14 23:36:25.519] [info] manager constructed
[2023-10-14 23:36:25.608] [info] Initialize syscall server
[2023-10-14 23:36:25][info][1763968] Global shm constructed. global_shm_open_type 0 for bpftime_maps_shm
[2023-10-14 23:36:25][info][1763968] Enabling helper groups ffi, kernel, shm_map by default
[2023-10-14 23:36:25][info][1763968] bpftime-syscall-server started
Attaching 1 probe...
```
## b.Console2 (or more):
```console
bpftime start -s /bin/ls
bpftime start -s /bin/pwd
bpftime start -s /bin/whoami
```
## c. Press Ctrl + C in console1
```console
Attaching 1 probe...
^C

@[pwd]: 5
@[ls]: 19
@[whoami]: 24
INFO: Global shm destructed
```