### PR TITLE
runtime: fix a double-free bug

### DIFF
--- a/runtime/src/attach/bpf_attach_ctx.cpp
+++ b/runtime/src/attach/bpf_attach_ctx.cpp
@@ -387,11 +387,13 @@ int bpf_attach_ctx::detach(const bpftime_prog *prog)
 
 bpf_attach_ctx::~bpf_attach_ctx()
 {
+	spdlog::debug("Destructor: bpf_attach_ctx");
 	std::vector<int> id_to_remove = {};
 	for (auto &m : hook_entry_table) {
 		id_to_remove.push_back(m.second.id);
 	}
 	for (auto i : id_to_remove) {
+		spdlog::debug("Destroy attach of {}", i);
 		destory_attach(i);
 	}
 }
@@ -411,6 +413,8 @@ int bpf_attach_ctx::destory_attach(int id)
 	if (entry == hook_entry_table.end()) {
 		return -1;
 	}
+	spdlog::debug("Revert attach of id {}, type {}", id,
+		      (int)entry->second.type);
 	switch (entry->second.type) {
 	case BPFTIME_REPLACE: {
 		if (entry->second.hook_func != nullptr) {
@@ -423,22 +427,28 @@ int bpf_attach_ctx::destory_attach(int id)
 	}
 	case BPFTIME_UPROBE: {
 		if (entry->second.uretprobe_id == id) {
+			spdlog::debug("Revert uretprobe");
 			hook_entry_index.erase(entry->second.uretprobe_id);
 			entry->second.uretprobe_id = -1;
 			entry->second.ret_progs.clear();
 		}
 		if (entry->second.id == id) {
+			spdlog::debug("Revert uprobe");
 			hook_entry_index.erase(entry->second.id);
 			entry->second.id = -1;
 			entry->second.progs.clear();
 		}
 		if (entry->second.listener != nullptr && entry->second.id < 0 &&
 		    entry->second.uretprobe_id < 0) {
+			spdlog::debug("Freeing listener");
 			// detach the listener when no one is using it
 			gum_interceptor_detach(interceptor,
 					       entry->second.listener);
-			gum_free(entry->second.listener);
+			spdlog::debug("Frida detached");
+			// No need to manually free, because frida uses RefCounting GC
+			// gum_free(entry->second.listener);
 			hook_entry_table.erase(function->second);
+			spdlog::debug("Listener freed");
 		}
 		return 0;
 	}
@@ -724,6 +734,8 @@ int bpf_attach_ctx::create_uprobe(void *function, int id, bool retprobe)
 	auto entry_ptr = &entry->second;
 	entry->second.listener = (GumInvocationListener *)g_object_new(
 		uprobe_listener_get_type(), NULL);
+	spdlog::debug("Created listener instance {:x} for hook_entry id {}",
+		      (uintptr_t)entry->second.listener, id);
 
 	// gum_make_call_listener(frida_uprobe_listener_on_enter,
 	// 		       frida_uprobe_listener_on_leave,

--- a/runtime/src/attach/bpf_attach_ctx.cpp
+++ b/runtime/src/attach/bpf_attach_ctx.cpp
@@ -396,6 +396,7 @@ bpf_attach_ctx::~bpf_attach_ctx()
 		spdlog::debug("Destroy attach of {}", i);
 		destory_attach(i);
 	}
+	gum_object_unref(interceptor);
 }
 int bpf_attach_ctx::revert_func(void *target_function)
 {
@@ -447,6 +448,7 @@ int bpf_attach_ctx::destory_attach(int id)
 			spdlog::debug("Frida detached");
 			// No need to manually free, because frida uses RefCounting GC
 			// gum_free(entry->second.listener);
+			gum_object_unref(entry->second.listener);
 			hook_entry_table.erase(function->second);
 			spdlog::debug("Listener freed");
 		}

--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -4,6 +4,7 @@
 #include <bpftime_shm_internal.hpp>
 #include <cstdio>
 #include <sys/epoll.h>
+#include <unistd.h>
 #include <variant>
 
 void bpftime_initialize_global_shm()
@@ -20,7 +21,7 @@ void bpftime_destroy_global_shm()
 	shm_holder.global_shared_memory.~bpftime_shm();
 	// Why not spdlog? because global variables that spdlog used were
 	// already destroyed..
-	puts("INFO: Global shm destructed");
+	printf("INFO [%d]: Global shm destructed\n", (int)getpid());
 }
 static __attribute__((destructor(65535))) void __destruct_shm()
 {

--- a/runtime/src/handler/perf_event_handler.cpp
+++ b/runtime/src/handler/perf_event_handler.cpp
@@ -9,6 +9,10 @@
 #include <boost/interprocess/allocators/allocator.hpp>
 #include <unistd.h>
 #include <spdlog/fmt/bin_to_hex.h>
+
+#pragma GCC diagnostic ignored "-Wstrict-aliasing"
+
+
 #define READ_ONCE_U64(x) (*(volatile uint64_t *)&x)
 #define WRITE_ONCE_U64(x, v) (*(volatile uint64_t *)&x) = (v)
 

--- a/runtime/test/CMakeLists.txt
+++ b/runtime/test/CMakeLists.txt
@@ -101,7 +101,7 @@ foreach(file ${test_sources})
 
   if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     # Enable sanitizers if we are debugging
-    target_link_options(${test_name}_Tests PRIVATE -fsanitize=undefined -fsanitize=address)
+    target_link_options(${test_name}_Tests PRIVATE -fsanitize=undefined)
   endif()
 
   #

--- a/runtime/test/CMakeLists.txt
+++ b/runtime/test/CMakeLists.txt
@@ -22,10 +22,10 @@ set(test_sources
 
   src/test_shm_hash_maps.cpp
   src/test_shm_progs_attach.cpp
+
   # src/test_shm_client.cpp
   # src/test_shm_server.cpp
   # src/test_ffi.cpp
-
   src/test_helpers.cpp
 )
 
@@ -95,7 +95,13 @@ foreach(file ${test_sources})
       runtime
       bpftime-object
     )
+
     # message("Unknown testing library ${test_name}_Tests. Please setup your desired unit testing library by using `target_link_libraries`.")
+  endif()
+
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    # Enable sanitizers if we are debugging
+    target_link_options(${test_name}_Tests PRIVATE -fsanitize=undefined -fsanitize=address)
   endif()
 
   #

--- a/runtime/test/src/test_attach_hook.cpp
+++ b/runtime/test/src/test_attach_hook.cpp
@@ -9,7 +9,8 @@
 
 using namespace bpftime;
 
-const shm_open_type bpftime::global_shm_open_type = shm_open_type::SHM_NO_CREATE;
+const shm_open_type bpftime::global_shm_open_type =
+	shm_open_type::SHM_NO_CREATE;
 
 // This is the hook function.
 int my_hook_function()
@@ -29,18 +30,19 @@ unsigned char orig_bytes[256];
 
 int main()
 {
-	int res = my_function();
+	int res [[maybe_unused]] = my_function();
 	assert(res == 67);
 
 	bpf_attach_ctx probe_ctx;
 
-	probe_ctx.replace_func((void*)my_hook_function, (void*)my_function, NULL);
+	probe_ctx.replace_func((void *)my_hook_function, (void *)my_function,
+			       NULL);
 
 	// Now calling the function will actually call the hook function.
 	res = my_function();
 	assert(res == 11);
 
-	probe_ctx.revert_func((void*)my_function);
+	probe_ctx.revert_func((void *)my_function);
 
 	// Now calling the function will call the original function.
 	res = my_function();

--- a/runtime/test/src/test_attach_uprobe.cpp
+++ b/runtime/test/src/test_attach_uprobe.cpp
@@ -12,7 +12,8 @@
 #include "bpftime_shm.hpp"
 
 using namespace bpftime;
-const shm_open_type bpftime::global_shm_open_type = shm_open_type::SHM_NO_CREATE;
+const shm_open_type bpftime::global_shm_open_type =
+	shm_open_type::SHM_NO_CREATE;
 
 // This is the original function to hook.
 int my_function(int parm1, const char *str, char c)
@@ -28,8 +29,9 @@ bpftime_prog *get_prog(const char *name, bpftime_object *obj)
 	bpftime_prog *prog = bpftime_object_find_program_by_name(obj, name);
 	assert(prog);
 	// add ffi support
-	int res = bpftime_helper_group::get_kernel_utils_helper_group()
-			  .add_helper_group_to_prog(prog);
+	int res [[maybe_unused]] =
+		bpftime_helper_group::get_kernel_utils_helper_group()
+			.add_helper_group_to_prog(prog);
 	assert(res == 0);
 	res = prog->bpftime_prog_load(false);
 	assert(res == 0);

--- a/runtime/test/src/test_shm_progs_attach.cpp
+++ b/runtime/test/src/test_shm_progs_attach.cpp
@@ -12,11 +12,13 @@
 #include <ostream>
 #include <string>
 #include <linux/bpf.h>
+#include <unistd.h>
 
 using namespace boost::interprocess;
 using namespace bpftime;
 
-const shm_open_type bpftime::global_shm_open_type = shm_open_type::SHM_NO_CREATE;
+const shm_open_type bpftime::global_shm_open_type =
+	shm_open_type::SHM_NO_CREATE;
 
 const char *HANDLER_NAME = "my_handler";
 const char *SHM_NAME = "my_shm_attach_test";
@@ -106,6 +108,7 @@ void attach_replace(bpftime::handler_manager &manager_ref,
 
 int main(int argc, const char **argv)
 {
+	spdlog::set_level(spdlog::level::debug);
 	if (argc == 1) {
 		std::cout << "parent process start" << std::endl;
 		shm_remove remover(SHM_NAME);
@@ -139,11 +142,15 @@ int main(int argc, const char **argv)
 
 		std::cout << "Starting sub process" << std::endl;
 		system((std::string(argv[0]) + " sub").c_str());
+		std::cout << "Subprocess exited, from server" << std::endl;
 		assert(segment.find<handler_manager>(HANDLER_NAME).first ==
 		       nullptr);
+		std::cout << "Server exiting.." << std::endl;
+		bpftime_object_close(obj);
 	} else {
 		int res = 0;
-		std::cout << "Subprocess started" << std::endl;
+		std::cout << "Subprocess started, pid=" << getpid()
+			  << std::endl;
 
 		// test for no attach
 		res = my_function(1, "hello aaa", 'c');


### PR DESCRIPTION
Use `gum_object_unref` to release the listener object, instead of `gum_free`, when destroying `bpf_attach_ctx`

Closes #32 

Also fixed many warnings when compiling use Release profile