### PR TITLE
Use cmake to build bpftime-daemon

### DIFF
--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -19,7 +19,7 @@ jobs:
       run: |
         sudo apt install -y --no-install-recommends \
         libelf1 libelf-dev zlib1g-dev make git libboost1.74-all-dev \
-        binutils-dev libyaml-cpp-dev  gcc-12 g++-12
+        binutils-dev libyaml-cpp-dev  gcc-12 g++-12 llvm
 
     - name: build runtime
       run:  CC=gcc-12 CXX=g++-12 make build

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -15,7 +15,7 @@ jobs:
           submodules: 'recursive'
       - name: Install dependencies
         run: | 
-          sudo apt-get install binutils-dev libboost1.74-all-dev libelf-dev zlib1g-dev libyaml-cpp-dev gcc-12 g++-12
+          sudo apt-get install binutils-dev libboost1.74-all-dev libelf-dev zlib1g-dev libyaml-cpp-dev gcc-12 g++-12 llvm
       - name: Build and install runtime
         run: |
           CC=gcc-12 CXX=g++-12 make release

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -14,7 +14,7 @@ jobs:
           submodules: 'recursive'
       - name: Install dependencies
         run: | 
-          sudo apt-get install binutils-dev libboost1.74-all-dev libelf-dev zlib1g-dev libyaml-cpp-dev gcc-12 g++-12
+          sudo apt-get install binutils-dev libboost1.74-all-dev libelf-dev zlib1g-dev libyaml-cpp-dev gcc-12 g++-12 llvm
       - name: Build and install runtime
         run: |
           CC=gcc-12 CXX=g++-12 make release

--- a/.github/workflows/test-runtime.yml
+++ b/.github/workflows/test-runtime.yml
@@ -18,7 +18,7 @@ jobs:
           submodules: 'recursive'
       - name: Install dependencies
         run: | 
-          sudo apt-get install binutils-dev libboost1.74-all-dev libelf-dev zlib1g-dev libyaml-cpp-dev gcc-12 g++-12
+          sudo apt-get install binutils-dev libboost1.74-all-dev libelf-dev zlib1g-dev libyaml-cpp-dev gcc-12 g++-12 llvm
       - name: Build the target
         run: |
           CC=gcc-12 CXX=g++-12 make build-unit-test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,27 +65,6 @@ include(cmake/libbpf.cmake)
 # install frida
 include(cmake/frida.cmake)
 
-# Define a helper function
-function(add_ebpf_program_target target_name source_file output_file)
-  # opensnoop.bpf.o
-  execute_process(COMMAND bash -c "uname -m | sed 's/x86_64/x86/' \
-| sed 's/arm.*/arm/' \
-| sed 's/aarch64/arm64/' \
-| sed 's/ppc64le/powerpc/' \
-| sed 's/mips.*/mips/' \
-| sed 's/riscv64/riscv/' \
-| sed 's/loongarch64/loongarch/'"
-    OUTPUT_VARIABLE UNAME_ARCH
-    COMMAND_ERROR_IS_FATAL ANY
-  )
-  string(STRIP ${UNAME_ARCH} UNAME_ARCH_STRIPPED)
-  add_custom_target(${target_name} ALL
-    COMMAND clang -O2 -target bpf -c -g -D__TARGET_ARCH_${UNAME_ARCH_STRIPPED} -I${CMAKE_SOURCE_DIR}/third_party/vmlinux/${UNAME_ARCH_STRIPPED} -I${LIBBPF_INCLUDE_DIRS}/uapi -I${LIBBPF_INCLUDE_DIRS} ${source_file} -o ${output_file}
-    BYPRODUCTS ${output_file}
-    SOURCES ${source_file}
-  )
-  add_dependencies(${target_name} copy_headers)
-endfunction()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE YES)
 

--- a/cmake/libbpf.cmake
+++ b/cmake/libbpf.cmake
@@ -1,4 +1,3 @@
-
 #
 # Setup libbpf
 #
@@ -61,3 +60,41 @@ foreach(file ${HEADER_FILES})
 endforeach()
 
 add_dependencies(copy_headers libbpf)
+
+# # Setup bpftool
+set(BPFTOOL_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party/bpftool)
+set(BPFTOOL_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/bpftool)
+ExternalProject_Add(bpftool
+  PREFIX bpftool
+  SOURCE_DIR ${BPFTOOL_DIR}/src
+  CONFIGURE_COMMAND "mkdir" "-p" "${BPFTOOL_INSTALL_DIR}"
+  BUILD_COMMAND "make" "EXTRA_CFLAGS=-g -O2 -Wall -Werror " "-j"
+  INSTALL_COMMAND "cp" "${BPFTOOL_DIR}/src/bpftool" "${BPFTOOL_INSTALL_DIR}/bpftool"
+  BUILD_IN_SOURCE TRUE
+  BUILD_BYPRODUCTS ${BPFTOOL_DIR}/src/bpftool
+  INSTALL_BYPRODUCTS ${BPFTOOL_INSTALL_DIR}/bpftool
+)
+
+function(add_bpf_skel_)
+
+# Define a helper function
+function(add_ebpf_program_target target_name source_file output_file)
+  # opensnoop.bpf.o
+  execute_process(COMMAND bash -c "uname -m | sed 's/x86_64/x86/' \
+| sed 's/arm.*/arm/' \
+| sed 's/aarch64/arm64/' \
+| sed 's/ppc64le/powerpc/' \
+| sed 's/mips.*/mips/' \
+| sed 's/riscv64/riscv/' \
+| sed 's/loongarch64/loongarch/'"
+    OUTPUT_VARIABLE UNAME_ARCH
+    COMMAND_ERROR_IS_FATAL ANY
+  )
+  string(STRIP ${UNAME_ARCH} UNAME_ARCH_STRIPPED)
+  add_custom_target(${target_name} ALL
+    COMMAND clang -O2 -target bpf -c -g -D__TARGET_ARCH_${UNAME_ARCH_STRIPPED} -I${CMAKE_SOURCE_DIR}/third_party/vmlinux/${UNAME_ARCH_STRIPPED} -I${LIBBPF_INCLUDE_DIRS}/uapi -I${LIBBPF_INCLUDE_DIRS} ${source_file} -o ${output_file}
+    BYPRODUCTS ${output_file}
+    SOURCES ${source_file}
+  )
+  add_dependencies(${target_name} copy_headers)
+endfunction()

--- a/cmake/libbpf.cmake
+++ b/cmake/libbpf.cmake
@@ -75,7 +75,15 @@ ExternalProject_Add(bpftool
   INSTALL_BYPRODUCTS ${BPFTOOL_INSTALL_DIR}/bpftool
 )
 
-function(add_bpf_skel_)
+function(add_bpf_skel_generating_target target_name bpf_program output_skel)
+  add_custom_target(${target_name} ALL
+    COMMAND "${BPFTOOL_INSTALL_DIR}/bpftool" "gen" "skeleton" "${bpf_program}" > "${output_skel}"
+    BYPRODUCTS ${output_skel}
+    SOURCES ${bpf_program}
+    DEPENDS bpftool
+
+    )
+endfunction()
 
 # Define a helper function
 function(add_ebpf_program_target target_name source_file output_file)

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -166,7 +166,7 @@ add_subdirectory(object)
 add_subdirectory(agent)
 add_subdirectory(syscall-server)
 add_subdirectory(agent-transformer)
-
+add_subdirectory(bpftime-daemon)
 
 #
 # Unit testing setup

--- a/runtime/bpftime-daemon/CMakeLists.txt
+++ b/runtime/bpftime-daemon/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(bpftime_daemon bpf-mocker.cpp)
+
+set_property(TARGET bpftime_daemon PROPERTY CXX_STANDARD 20)

--- a/runtime/bpftime-daemon/CMakeLists.txt
+++ b/runtime/bpftime-daemon/CMakeLists.txt
@@ -1,3 +1,14 @@
-add_executable(bpftime_daemon bpf-mocker.cpp)
+# Create a target that builds the ebpf program
+add_ebpf_program_target(bpftime_daemon_ebpf_target ${CMAKE_CURRENT_SOURCE_DIR}/bpf-mocker.bpf.c ${CMAKE_CURRENT_BINARY_DIR}/bpf-mocker.bpf.o)
 
+# Create a target that generated the bpf skeleton
+add_bpf_skel_generating_target(bpftime_daemon_ebpf_skel ${CMAKE_CURRENT_BINARY_DIR}/bpf-mocker.bpf.o ${CMAKE_CURRENT_BINARY_DIR}/bpf-mocker.skel.h)
+
+add_dependencies(bpftime_daemon_ebpf_skel bpftime_daemon_ebpf_target)
+
+add_executable(bpftime_daemon bpf-mocker.cpp)
+add_dependencies(bpftime_daemon bpftime_daemon_ebpf_skel libbpf)
+
+target_include_directories(bpftime_daemon PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${LIBBPF_INCLUDE_DIRS} ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(bpftime_daemon PRIVATE ${LIBBPF_LIBRARIES} elf z)
 set_property(TARGET bpftime_daemon PROPERTY CXX_STANDARD 20)


### PR DESCRIPTION
This PR adds CMakeLists that build bpftime-daemon. 
The target name is bpftime_daemon. 
See `runtime/bpftime-daemon/CMakeLists.txt` for detailed usage.

This PR also adds targets that build bpftool and skeleton header