### PR TITLE
Update examples CI

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -7,8 +7,33 @@ on:
     branches: "*"
 
 jobs: 
+  build-runtime:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'
+      - name: Install dependencies
+        run: | 
+          sudo apt-get install binutils-dev libboost1.74-all-dev libelf-dev zlib1g-dev libyaml-cpp-dev gcc-12 g++-12 llvm
+      - name: Build and install runtime
+        run: |
+          CC=gcc-12 CXX=g++-12 make release -j
+      - name: Build and install CLI
+        run: |
+          cd tools/cli-rs
+          RUSTFLAGS="-C target-feature=+crt-static" cargo build --release --target x86_64-unknown-linux-gnu
+          mkdir -p ~/.bpftime
+          cp ./target/x86_64-unknown-linux-gnu/release/bpftime ~/.bpftime
+      - name: Upload build results
+        uses: actions/upload-artifact@v3
+        with:
+          name: runtime-package
+          path: |
+            /home/runner/.bpftime
   build-and-test:
     runs-on: ubuntu-22.04
+    needs: [build-runtime]
     strategy:
       fail-fast: false
       matrix:
@@ -42,18 +67,18 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'
+      - name: Download prebuilt runtime
+        uses: actions/download-artifact@v3
+        with:
+          name: runtime-package
+          path: /home/runner/.bpftime
+      - name: Show downloaded artifacts
+        run: |
+          ls ~/.bpftime
       - name: Install dependencies
-        run: | 
-          sudo apt-get install binutils-dev libboost1.74-all-dev libelf-dev zlib1g-dev libyaml-cpp-dev gcc-12 g++-12 llvm
-      - name: Build and install runtime
         run: |
-          CC=gcc-12 CXX=g++-12 make release -j
-      - name: Build and install CLI
-        run: |
-          cd tools/cli-rs
-          RUSTFLAGS="-C target-feature=+crt-static" cargo build --release --target x86_64-unknown-linux-gnu
-          mkdir -p ~/.bpftime
-          cp ./target/x86_64-unknown-linux-gnu/release/bpftime ~/.bpftime
+          sudo apt-get update -y
+          sudo apt-get install -y zlib1g-dev libelf-dev
       - name: Build test assets
         run: |
           make -C example/${{matrix.examples.path}} -j

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [build-runtime]
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         examples: 
           - path: libbpf-tools/opensnoop
@@ -72,6 +72,9 @@ jobs:
         with:
           name: runtime-package
           path: /home/runner/.bpftime
+      - name: Set permissions
+        run: |
+          chmod +x ~/.bpftime/*
       - name: Show downloaded artifacts
         run: |
           ls ~/.bpftime

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -97,7 +97,7 @@ jobs:
           timeout -s 2 30s sudo -E /home/runner/.bpftime/bpftime -i /home/runner/.bpftime load ./${{matrix.examples.executable}} || if [ $? = 124 ]; then exit 0; else exit $?; fi &
           sleep 3s
           ID1=$!
-          timeout -s 2 15s /home/runner/.bpftime/bpftime -i /home/runner/.bpftime start -s ${{matrix.examples.victim}} || if [ $? = 124 ]; then exit 0; else exit $?; fi
+          timeout -s 2 15s sudo -E /home/runner/.bpftime/bpftime -i /home/runner/.bpftime start -s ${{matrix.examples.victim}} || if [ $? = 124 ]; then exit 0; else exit $?; fi
           fg $ID1 || true
       - name: Test CLI - attach by running (uprobe)
         if: '!matrix.examples.syscall_trace'
@@ -107,5 +107,5 @@ jobs:
           timeout -s 2 30s sudo -E /home/runner/.bpftime/bpftime -i /home/runner/.bpftime load ./${{matrix.examples.executable}} || if [ $? = 124 ]; then exit 0; else exit $?; fi &
           sleep 3s
           ID1=$!
-          timeout -s 2 15s /home/runner/.bpftime/bpftime -i /home/runner/.bpftime start ${{matrix.examples.victim}} || if [ $? = 124 ]; then exit 0; else exit $?; fi
+          timeout -s 2 15s sudo -E /home/runner/.bpftime/bpftime -i /home/runner/.bpftime start ${{matrix.examples.victim}} || if [ $? = 124 ]; then exit 0; else exit $?; fi
           fg $ID1 || true


### PR DESCRIPTION
Update examples CI, use only one job to build the runtime. Other matrix jobs receive the prebuilt runtime through artifacts