### PR TITLE
Update examples CI (automatic test)

### DIFF
--- a/.github/script/run_example.py
+++ b/.github/script/run_example.py
@@ -49,7 +49,7 @@ def main():
         server.kill()
         server.wait()
         exit(1)
-    time.sleep(3)
+    time.sleep(15)
     # Start the agent
     agent = subprocess.Popen(
         " ".join(

--- a/.github/script/run_example.py
+++ b/.github/script/run_example.py
@@ -8,7 +8,7 @@ import fcntl
 import os
 import time
 SERVER_TIMEOUT = 30
-AGENT_TIMEOUT = 50
+AGENT_TIMEOUT = 30
 SERVER_START_SIGNAL = "bpftime-syscall-server started"
 
 

--- a/.github/script/run_example.py
+++ b/.github/script/run_example.py
@@ -1,0 +1,99 @@
+import sys
+import subprocess
+import datetime
+import select
+from io import StringIO
+import signal
+import fcntl
+import os
+import time
+SERVER_TIMEOUT = 15
+AGENT_TIMEOUT = 15
+SERVER_START_SIGNAL = "bpftime-syscall-server started"
+
+
+def set_non_blocking(fd):
+    flags = fcntl.fcntl(fd, fcntl.F_GETFL)
+    fcntl.fcntl(fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+
+
+def main():
+    executable, victim, expected_str, bpftime_cli, syscall_trace = sys.argv[1:]
+    # Run the syscall-server
+    server = subprocess.Popen(
+        " ".join([bpftime_cli, "load", executable]),
+        stdout=subprocess.PIPE,
+        text=False,
+        stderr=sys.stderr,
+        bufsize=0,
+        shell=True,
+    )
+    set_non_blocking(server.stdout)
+    server_ok = False
+    server_start_time = datetime.datetime.now()
+    while (
+        datetime.datetime.now() - server_start_time
+    ).total_seconds() < SERVER_TIMEOUT:
+        if server.poll() is not None:
+            break
+        ready, _, _ = select.select([server.stdout], [], [], 0.01)
+        if ready:
+            line = server.stdout.readline().decode()
+            print("SERVER:", line, end="")
+            if SERVER_START_SIGNAL in line:
+                print("MONITOR: Server started!")
+                server_ok = True
+                break
+    if not server_ok:
+        print("Failed to start server!")
+        server.kill()
+        server.wait()
+        exit(1)
+    time.sleep(3)
+    # Start the agent
+    agent = subprocess.Popen(
+        " ".join(
+            [bpftime_cli, "start"] + (["-s", victim]
+            if syscall_trace == "1"
+            else [victim])
+        ),
+        stdout=sys.stdout,
+        text=False,
+        stderr=sys.stderr,
+        env={"SPDLOG_LEVEL": "info"},
+        shell=True,
+    )
+    agent_start_time = datetime.datetime.now()
+    agent_ok = False
+    buf = StringIO()
+    while (datetime.datetime.now() - agent_start_time).total_seconds() < AGENT_TIMEOUT:
+        # Check if server has expected output
+        if server.poll() is not None:
+            break
+        ready, _, _ = select.select([server.stdout], [], [], 0.01)
+        c = server.stdout.read()
+        if c:
+            c = c.decode()
+            buf.write(c)
+            print(c, end="")
+            if c == "\n":
+                buf.seek(0)
+            if expected_str in buf.getvalue():
+                # print("SERVER:", line, end="")
+                # if expected_str in line:
+                print(f"MONITOR: string `{expected_str}` found!")
+                agent_ok = True
+                break
+    agent.kill()
+    agent.wait()
+    server.kill()
+    server.wait()
+    if not agent_ok:
+        print("Failed to test, expected string not found!")
+        exit(1)
+    else:
+        exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/script/run_example.py
+++ b/.github/script/run_example.py
@@ -25,8 +25,8 @@ def main():
         expected_str,
         bpftime_cli,
         syscall_trace,
-        *bashreadline_patch,
     ) = sys.argv[1:]
+    bashreadline_patch = "readline" in executable
     # Run the syscall-server
     server = subprocess.Popen(
         " ".join([bpftime_cli, "load", executable]),

--- a/.github/script/run_example.py
+++ b/.github/script/run_example.py
@@ -28,7 +28,7 @@ def main():
         bufsize=0,
         shell=True,
     )
-    set_non_blocking(server.stdout)
+    #set_non_blocking(server.stdout)
     server_ok = False
     server_start_time = datetime.datetime.now()
     while (

--- a/.github/script/run_example.py
+++ b/.github/script/run_example.py
@@ -57,15 +57,19 @@ def main():
         server.kill()
         server.wait()
         exit(1)
-    time.sleep(5)
+    time.sleep(10)
     # Start the agent
     agent = subprocess.Popen(
-        [bpftime_cli, "start"] + (["-s", victim] if syscall_trace == "1" else [victim]),
+        " ".join(
+            [bpftime_cli, "start"]
+            + (["-s", victim] if syscall_trace == "1" else [victim])
+        ),
         stdout=sys.stdout,
         text=False,
         stderr=sys.stderr,
         stdin=subprocess.PIPE,
         env={"SPDLOG_LEVEL": "info"},
+        shell=True,
     )
     agent_start_time = datetime.datetime.now()
     agent_ok = False

--- a/.github/script/run_example.py
+++ b/.github/script/run_example.py
@@ -7,8 +7,8 @@ import signal
 import fcntl
 import os
 import time
-SERVER_TIMEOUT = 15
-AGENT_TIMEOUT = 15
+SERVER_TIMEOUT = 30
+AGENT_TIMEOUT = 50
 SERVER_START_SIGNAL = "bpftime-syscall-server started"
 
 

--- a/.github/script/run_example.py
+++ b/.github/script/run_example.py
@@ -28,7 +28,7 @@ def main():
         bufsize=0,
         shell=True,
     )
-    #set_non_blocking(server.stdout)
+    set_non_blocking(server.stdout)
     server_ok = False
     server_start_time = datetime.datetime.now()
     while (

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -56,7 +56,7 @@ jobs:
           - path: opensnoop
             executable: ./opensnoop
             victim: ./victim
-            syscall_trace: false
+            syscall_trace: true
             expected_str: "   0 test.txt"
           - path: sslsniff
             executable: ./sslsniff

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -99,11 +99,9 @@ jobs:
         if: matrix.examples.syscall_trace
         shell: "sudo /bin/bash -e {0}"
         run: |
-          cd example/${{matrix.examples.path}}
-          sudo -E python3 ../../.github/script/run_example.py ${{matrix.examples.executable}} ${{matrix.examples.victim}} "${{matrix.examples.expected_str}}" "/home/runner/.bpftime/bpftime -i /home/runner/.bpftime" 1
+          sudo -E python3 .github/script/run_example.py ${{matrix.examples.path}}/${{matrix.examples.executable}} ${{matrix.examples.path}}/${{matrix.examples.victim}} "${{matrix.examples.expected_str}}" "/home/runner/.bpftime/bpftime -i /home/runner/.bpftime" 1
       - name: Test CLI - attach by running (uprobe)
         if: '!matrix.examples.syscall_trace'
         shell: "sudo /bin/bash -e {0}"
         run: |
-          cd example/${{matrix.examples.path}}
-          sudo -E python3 ../../.github/script/run_example.py ${{matrix.examples.executable}} ${{matrix.examples.victim}} "${{matrix.examples.expected_str}}" "/home/runner/.bpftime/bpftime -i /home/runner/.bpftime" 0
+          sudo -E python3 .github/script/run_example.py ${{matrix.examples.path}}/${{matrix.examples.executable}} ${{matrix.examples.path}}/${{matrix.examples.victim}} "${{matrix.examples.expected_str}}" "/home/runner/.bpftime/bpftime -i /home/runner/.bpftime" 0

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -99,9 +99,11 @@ jobs:
         if: matrix.examples.syscall_trace
         shell: "sudo /bin/bash -e {0}"
         run: |
-          sudo -E python3 .github/script/run_example.py ${{matrix.examples.path}}/${{matrix.examples.executable}} ${{matrix.examples.path}}/${{matrix.examples.victim}} "${{matrix.examples.expected_str}}" "/home/runner/.bpftime/bpftime -i /home/runner/.bpftime" 1
+          cd example/
+          sudo -E python3 /home/runner/work/bpftime/bpftime/.github/script/run_example.py ${{matrix.examples.executable}} ${{matrix.examples.victim}} "${{matrix.examples.expected_str}}" "/home/runner/.bpftime/bpftime -i /home/runner/.bpftime" 1
       - name: Test CLI - attach by running (uprobe)
         if: '!matrix.examples.syscall_trace'
         shell: "sudo /bin/bash -e {0}"
         run: |
-          sudo -E python3 .github/script/run_example.py ${{matrix.examples.path}}/${{matrix.examples.executable}} ${{matrix.examples.path}}/${{matrix.examples.victim}} "${{matrix.examples.expected_str}}" "/home/runner/.bpftime/bpftime -i /home/runner/.bpftime" 0
+          cd example/${{matrix.examples.path}}
+          sudo -E python3 /home/runner/work/bpftime/bpftime/.github/script/run_example.py ${{matrix.examples.executable}} ${{matrix.examples.victim}} "${{matrix.examples.expected_str}}" "/home/runner/.bpftime/bpftime -i /home/runner/.bpftime" 0

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -99,7 +99,7 @@ jobs:
         if: matrix.examples.syscall_trace
         shell: "sudo /bin/bash -e {0}"
         run: |
-          cd example/
+          cd example/${{matrix.examples.path}}
           sudo -E python3 /home/runner/work/bpftime/bpftime/.github/script/run_example.py ${{matrix.examples.executable}} ${{matrix.examples.victim}} "${{matrix.examples.expected_str}}" "/home/runner/.bpftime/bpftime -i /home/runner/.bpftime" 1
       - name: Test CLI - attach by running (uprobe)
         if: '!matrix.examples.syscall_trace'

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -100,10 +100,10 @@ jobs:
         shell: "sudo /bin/bash -e {0}"
         run: |
           cd example/${{matrix.examples.path}}
-          sudo -E python3 /home/runner/work/bpftime/bpftime/.github/script/run_example.py ${{matrix.examples.executable}} ${{matrix.examples.victim}} "${{matrix.examples.expected_str}}" "/home/runner/.bpftime/bpftime -i /home/runner/.bpftime" 1
+          sudo -E python3 /home/runner/work/bpftime/bpftime/.github/script/run_example.py ${{matrix.examples.executable}} "${{matrix.examples.victim}}" "${{matrix.examples.expected_str}}" "/home/runner/.bpftime/bpftime -i /home/runner/.bpftime" 1
       - name: Test CLI - attach by running (uprobe)
         if: '!matrix.examples.syscall_trace'
         shell: "sudo /bin/bash -e {0}"
         run: |
           cd example/${{matrix.examples.path}}
-          sudo -E python3 /home/runner/work/bpftime/bpftime/.github/script/run_example.py ${{matrix.examples.executable}} ${{matrix.examples.victim}} "${{matrix.examples.expected_str}}" "/home/runner/.bpftime/bpftime -i /home/runner/.bpftime" 0
+          sudo -E python3 /home/runner/work/bpftime/bpftime/.github/script/run_example.py ${{matrix.examples.executable}} "${{matrix.examples.victim}}" "${{matrix.examples.expected_str}}" "/home/runner/.bpftime/bpftime -i /home/runner/.bpftime" 0

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -100,10 +100,10 @@ jobs:
         shell: "sudo /bin/bash -e {0}"
         run: |
           cd example/${{matrix.examples.path}}
-          sudo -E python3 ./.github/script/run_example.py ${{matrix.examples.executable}} ${{matrix.examples.victim}} "${{matrix.examples.expected_str}}" /home/runner/.bpftime/bpftime 1
+          sudo -E python3 ../../.github/script/run_example.py ${{matrix.examples.executable}} ${{matrix.examples.victim}} "${{matrix.examples.expected_str}}" /home/runner/.bpftime/bpftime 1
       - name: Test CLI - attach by running (uprobe)
         if: '!matrix.examples.syscall_trace'
         shell: "sudo /bin/bash -e {0}"
         run: |
           cd example/${{matrix.examples.path}}
-          sudo -E python3 ./.github/script/run_example.py ${{matrix.examples.executable}} ${{matrix.examples.victim}} "${{matrix.examples.expected_str}}" /home/runner/.bpftime/bpftime 0
+          sudo -E python3 ../../.github/script/run_example.py ${{matrix.examples.executable}} ${{matrix.examples.victim}} "${{matrix.examples.expected_str}}" /home/runner/.bpftime/bpftime 0

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -39,32 +39,32 @@ jobs:
       matrix:
         examples: 
           - path: libbpf-tools/opensnoop
-            executable: opensnoop
+            executable: ./opensnoop
             victim: ./victim
             syscall_trace: true
             expected_str: "   0 test.txt"
           - path: libbpf-tools/statsnoop
-            executable: statsnoop
+            executable: ./statsnoop
             victim: ./victim
             syscall_trace: true
             expected_str: "victim               0    0    /sys" 
           - path: malloc
-            executable: malloc
+            executable: ./malloc
             victim: ./victim
             syscall_trace: false
             expected_str: "malloc calls: "
           - path: opensnoop
-            executable: opensnoop
+            executable: ./opensnoop
             victim: ./victim
             syscall_trace: false
             expected_str: "   0 test.txt"
           - path: sslsniff
-            executable: sslsniff
+            executable: ./sslsniff
             victim: /bin/wget https://www.google.com
             syscall_trace: false
             expected_str: "----- DATA -----"
           - path: libbpf-tools/bashreadline
-            executable: readline
+            executable: ./readline
             victim: /bin/bash
             syscall_trace: false
             expected_str: ""

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -42,26 +42,32 @@ jobs:
             executable: opensnoop
             victim: ./victim
             syscall_trace: true
+            expected_str: "   0 test.txt"
           - path: libbpf-tools/statsnoop
             executable: statsnoop
             victim: ./victim
-            syscall_trace: true 
+            syscall_trace: true
+            expected_str: "victim               0    0    /sys" 
           - path: malloc
             executable: malloc
             victim: ./victim
             syscall_trace: false
+            expected_str: "malloc calls: "
           - path: opensnoop
             executable: opensnoop
             victim: ./victim
             syscall_trace: false
+            expected_str: "   0 test.txt"
           - path: sslsniff
             executable: sslsniff
             victim: /bin/wget https://www.google.com
             syscall_trace: false
+            expected_str: "----- DATA -----"
           - path: libbpf-tools/bashreadline
             executable: readline
             victim: /bin/bash
             syscall_trace: false
+            expected_str: ""
 
     steps:
       - uses: actions/checkout@v2
@@ -94,18 +100,10 @@ jobs:
         shell: "sudo /bin/bash -e {0}"
         run: |
           cd example/${{matrix.examples.path}}
-          timeout -s 2 30s sudo -E /home/runner/.bpftime/bpftime -i /home/runner/.bpftime load ./${{matrix.examples.executable}} || if [ $? = 124 ]; then exit 0; else exit $?; fi &
-          sleep 3s
-          ID1=$!
-          timeout -s 2 15s sudo -E /home/runner/.bpftime/bpftime -i /home/runner/.bpftime start -s ${{matrix.examples.victim}} || if [ $? = 124 ]; then exit 0; else exit $?; fi
-          fg $ID1 || true
+          sudo -E python3 ./.github/script/run_example.py ${{matrix.examples.executable}} ${{matrix.examples.victim}} "${{matrix.examples.expected_str}}" /home/runner/.bpftime/bpftime 1
       - name: Test CLI - attach by running (uprobe)
         if: '!matrix.examples.syscall_trace'
         shell: "sudo /bin/bash -e {0}"
         run: |
           cd example/${{matrix.examples.path}}
-          timeout -s 2 30s sudo -E /home/runner/.bpftime/bpftime -i /home/runner/.bpftime load ./${{matrix.examples.executable}} || if [ $? = 124 ]; then exit 0; else exit $?; fi &
-          sleep 3s
-          ID1=$!
-          timeout -s 2 15s sudo -E /home/runner/.bpftime/bpftime -i /home/runner/.bpftime start ${{matrix.examples.victim}} || if [ $? = 124 ]; then exit 0; else exit $?; fi
-          fg $ID1 || true
+          sudo -E python3 ./.github/script/run_example.py ${{matrix.examples.executable}} ${{matrix.examples.victim}} "${{matrix.examples.expected_str}}" /home/runner/.bpftime/bpftime 0

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -67,7 +67,7 @@ jobs:
             executable: ./readline
             victim: /bin/bash
             syscall_trace: false
-            expected_str: ""
+            expected_str: "info"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -100,10 +100,10 @@ jobs:
         shell: "sudo /bin/bash -e {0}"
         run: |
           cd example/${{matrix.examples.path}}
-          sudo -E python3 ../../.github/script/run_example.py ${{matrix.examples.executable}} ${{matrix.examples.victim}} "${{matrix.examples.expected_str}}" /home/runner/.bpftime/bpftime 1
+          sudo -E python3 ../../.github/script/run_example.py ${{matrix.examples.executable}} ${{matrix.examples.victim}} "${{matrix.examples.expected_str}}" "/home/runner/.bpftime/bpftime -i /home/runner/.bpftime" 1
       - name: Test CLI - attach by running (uprobe)
         if: '!matrix.examples.syscall_trace'
         shell: "sudo /bin/bash -e {0}"
         run: |
           cd example/${{matrix.examples.path}}
-          sudo -E python3 ../../.github/script/run_example.py ${{matrix.examples.executable}} ${{matrix.examples.victim}} "${{matrix.examples.expected_str}}" /home/runner/.bpftime/bpftime 0
+          sudo -E python3 ../../.github/script/run_example.py ${{matrix.examples.executable}} ${{matrix.examples.victim}} "${{matrix.examples.expected_str}}" "/home/runner/.bpftime/bpftime -i /home/runner/.bpftime" 0

--- a/example/libbpf-tools/bashreadline/readline.c
+++ b/example/libbpf-tools/bashreadline/readline.c
@@ -37,6 +37,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_size)
 	strftime(ts, sizeof(ts), "%H:%m:%S", tm);
 
 	printf("%-9s %-7d %s\n", ts, e->pid, e->str);
+	fflush(stdout);
 }
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)

--- a/example/libbpf-tools/opensnoop/opensnoop.c
+++ b/example/libbpf-tools/opensnoop/opensnoop.c
@@ -16,6 +16,7 @@
 #include <bpf/bpf.h>
 #include "opensnoop.h"
 #include "opensnoop.skel.h"
+#include <stdio.h>
 
 /* Tune the buffer size and wakeup rate. These settings cope with roughly
  * 50k opens/sec.
@@ -229,6 +230,7 @@ void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 		sps_cnt += 9;
 	}
 	printf("%s\n", e->fname);
+	fflush(stdout);
 
 }
 

--- a/example/libbpf-tools/statsnoop/statsnoop.c
+++ b/example/libbpf-tools/statsnoop/statsnoop.c
@@ -4,6 +4,7 @@
 // Based on statsnoop(8) from BCC by Brendan Gregg.
 // 09-May-2021   Hengqi Chen   Created this.
 #include <argp.h>
+#include <stdio.h>
 #include <errno.h>
 #include <linux/limits.h>
 #include <signal.h>
@@ -118,6 +119,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 	}
 	printf("%-7d %-20s %-4d %-4d %-s\n", e->pid, e->comm, fd, err,
 	       e->pathname);
+	fflush(stdout);
 }
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
@@ -151,7 +153,6 @@ int main(int argc, char **argv)
 
 	obj->rodata->target_pid = target_pid;
 	obj->rodata->trace_failed_only = trace_failed_only;
-
 
 	err = statsnoop_bpf__load(obj);
 	if (err) {

--- a/example/malloc/malloc.c
+++ b/example/malloc/malloc.c
@@ -69,6 +69,7 @@ static int print_stat(struct malloc_bpf *obj)
 		}
 		prev_key = &key;
 	}
+	fflush(stdout);
 	return err;
 }
 

--- a/example/opensnoop/opensnoop.c
+++ b/example/opensnoop/opensnoop.c
@@ -16,6 +16,7 @@
 #include <bpf/bpf.h>
 #include "opensnoop.h"
 #include "opensnoop.skel.h"
+#include <stdio.h>
 
 /* Tune the buffer size and wakeup rate. These settings cope with roughly
  * 50k opens/sec.
@@ -225,6 +226,7 @@ static int handle_event_rb(void *ctx, void *data, size_t data_sz)
 		sps_cnt += 9;
 	}
 	printf("%s\n", e->fname);
+	fflush(stdout);
 	return 0;
 }
 

--- a/example/sslsniff/sslsniff.c
+++ b/example/sslsniff/sslsniff.c
@@ -404,6 +404,7 @@ void print_event(struct probe_SSL_data_t *event, const char *evt) {
 			printf("\n%s\n%s\n%s\n\n", s_mark, buf, e_mark);
 		}
 	}
+	fflush(stdout);
 }
 
 static void handle_event(void *ctx, int cpu, void *data, __u32 data_size) {
@@ -413,6 +414,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_size) {
 	} else {
 		print_event(e, "perf_SSL_rw");
 	}
+	fflush(stdout);
 }
 
 int main(int argc, char **argv) {
@@ -502,7 +504,7 @@ int main(int argc, char **argv) {
 		printf(" %-7s", "LAT(ms)");
 	}
 	printf("\n");
-
+	fflush(stdout);
 	while (!exiting) {
 		err = perf_buffer__poll(pb, PERF_POLL_TIMEOUT_MS);
 		if (err < 0 && err != -EINTR) {

--- a/tools/cli-rs/src/main.rs
+++ b/tools/cli-rs/src/main.rs
@@ -1,6 +1,7 @@
 use std::{
     ffi::{CStr, CString},
     path::{Path, PathBuf},
+    process::exit,
     sync::atomic::{AtomicU32, Ordering},
 };
 
@@ -147,6 +148,7 @@ fn run_command(
 
     if !status.success() {
         bail!("Exited with code: {:?}", status.code());
+        exit(status.code().unwrap_or(0));
     }
     Ok(())
 }


### PR DESCRIPTION
This PR implements automatic testing of examples CI, using a python program.

Test process:
- Run server, monitoring the stdout until `bpftime-syscall-server started` appeared, with timeout of at most 15 seconds
- Wait for 10 seconds
- Run victim, monitoring stdout of server until the test-specified signal string appeared, with timeout of at most 15 seconds

Note:
- bashreadline is not supported now