### PR TITLE
daemon: enable uprobe white list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,8 @@ gdb.py
 test.txt
 test.gdb
 index.html*
-dump*
-test*
+/dump*
+/test*
 ### VisualStudioCode ###
 .vscode/settings.json
 .vscode/runtime.json

--- a/daemon/kernel/bpf_tracer.bpf.c
+++ b/daemon/kernel/bpf_tracer.bpf.c
@@ -334,14 +334,12 @@ static int process_bpf_syscall_exit(struct bpf_args_t *ap, int ret)
 						    .kernel_id = id };
 			set_bpf_fd_data(ret, &data);
 			bpf_printk("bpftime: bpf_link_create");
-			if (submit_bpf_events) {
-				bpf_printk("bpftime: Submitting link creation");
-				struct event *event =
-					get_ringbuf_sys_exit_bpf_event(ap, ret);
-				if (!event)
-					return 0;
-				bpf_ringbuf_submit(event, 0);
-			}
+			bpf_printk("bpftime: Submitting link creation");
+			struct event *event =
+				get_ringbuf_sys_exit_bpf_event(ap, ret);
+			if (!event)
+				return 0;
+			bpf_ringbuf_submit(event, 0);
 			break;
 		}
 		case BPF_BTF_LOAD: {

--- a/daemon/kernel/bpf_tracer.bpf.c
+++ b/daemon/kernel/bpf_tracer.bpf.c
@@ -14,6 +14,27 @@ struct open_args_t {
 	int flags;
 };
 
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, 10240);
+	__type(key, u64);
+	__type(value, u32);
+} whitelist_hook_addr SEC(".maps");
+
+const volatile int enable_whitelist = 0;
+
+__always_inline int can_hook_uprobe_at(u64 addr)
+{
+	int ok = 0;
+	if (!enable_whitelist)
+		ok = 1;
+	else {
+		ok = bpf_map_lookup_elem(&whitelist_hook_addr, &addr) != NULL;
+	}
+	bpf_printk("Testing: addr=%llx, ok=%d", (unsigned long long)addr, ok);
+	return ok;
+}
+
 // track open syscall args
 struct {
 	__uint(type, BPF_MAP_TYPE_HASH);
@@ -375,28 +396,38 @@ process_perf_event_open_enter(struct trace_event_raw_sys_enter *ctx)
 		return 0;
 	}
 	bpf_probe_read_user(&new_attr, sizeof(new_attr), attr);
+
 	if (new_attr.type == uprobe_perf_type) {
 		// found uprobe
 		if (enable_replace_uprobe) {
-			new_attr.probe_offset = 0;
-			long size = bpf_probe_read_user_str(
-				old_uprobe_path, sizeof(old_uprobe_path),
-				(void *)new_attr.uprobe_path);
-			if (size <= 0) {
-				// no uprobe path
+			if (can_hook_uprobe_at(new_attr.probe_offset)) {
+				u64 old_offset = new_attr.probe_offset;
+				new_attr.probe_offset = 0;
+				long size = bpf_probe_read_user_str(
+					old_uprobe_path,
+					sizeof(old_uprobe_path),
+					(void *)new_attr.uprobe_path);
+				if (size <= 0) {
+					// no uprobe path
+					return 0;
+				}
+				if (size > PATH_LENTH) {
+					size = PATH_LENTH;
+				}
+				bpf_probe_write_user(
+					(void *)new_attr.uprobe_path,
+					&new_uprobe_path, (size_t)size);
+				bpf_probe_write_user(attr, &new_attr,
+						     sizeof(new_attr));
+				// This probe creation request should be
+				// executed in userspace
+				bpf_printk(
+					"Send perf event at offset %lx to userspace",
+					old_offset);
+				return 1;
+			} else {
 				return 0;
 			}
-			if (size > PATH_LENTH) {
-				size = PATH_LENTH;
-			}
-			bpf_probe_write_user((void *)new_attr.uprobe_path,
-					     &new_uprobe_path, (size_t)size);
-			bpf_probe_write_user(attr, &new_attr, sizeof(new_attr));
-
-			char buf[64];
-			bpf_probe_read_user_str(buf, sizeof(buf),
-						(void *)new_attr.uprobe_path);
-			bpf_printk("Writting new uprobe path: %s", buf);
 		}
 		return 0;
 	}
@@ -410,6 +441,10 @@ struct perf_event_args_t {
 
 	// we may modify the offset and name, so we keep it here
 	char name_or_path[NAME_MAX];
+	// original offset, if we modified
+	u64 orig_offset;
+	// Whether to send thie creation to bpftime_daemon?
+	int send_to_daemon;
 };
 
 struct {
@@ -436,11 +471,16 @@ int tracepoint__syscalls__sys_enter_perf_event_open(
 	args.cpu = (int)ctx->args[2];
 	bpf_probe_read_user_str(args.name_or_path, PATH_LENTH,
 				(const void *)args.attr.uprobe_path);
+	args.orig_offset = args.attr.probe_offset;
 	bpf_printk("Received path: %s", args.name_or_path);
 	u64 pid_tgid = bpf_get_current_pid_tgid();
+	if (process_perf_event_open_enter(ctx) == 1) {
+		args.send_to_daemon = 1;
+	} else {
+		args.send_to_daemon = 0;
+	}
 	bpf_map_update_elem(&perf_event_open_param_start, &pid_tgid, &args, 0);
 
-	process_perf_event_open_enter(ctx);
 	return 0;
 }
 
@@ -460,25 +500,32 @@ int tracepoint__syscalls__sys_exit_perf_event_open(
 	if (!ap)
 		return 0; /* missed entry */
 
-	set_bpf_fd_data(ctx->ret, &data);
+	if (ap->send_to_daemon) {
+		set_bpf_fd_data(ctx->ret, &data);
 
-	/* event data */
-	event = fill_basic_event_info();
-	if (!event) {
-		return 0;
+		/* event data */
+		event = fill_basic_event_info();
+		if (!event) {
+			return 0;
+		}
+		event->type = SYS_PERF_EVENT_OPEN;
+
+		bpf_probe_read(&event->perf_event_data.attr,
+			       sizeof(event->perf_event_data.attr), &ap->attr);
+		event->perf_event_data.pid = ap->pid;
+		event->perf_event_data.cpu = ap->cpu;
+		event->perf_event_data.ret = ctx->ret;
+		bpf_probe_read(event->perf_event_data.name_or_path, PATH_LENTH,
+			       ap->name_or_path);
+
+		/* emit event */
+		bpf_ringbuf_submit(event, 0);
+		bpf_printk("Accept perf event creation at program %s to daemon",
+			   ap->name_or_path);
+	} else {
+		bpf_printk("Reject perf event creation at program %s to daemon",
+			   ap->name_or_path);
 	}
-	event->type = SYS_PERF_EVENT_OPEN;
-
-	bpf_probe_read(&event->perf_event_data.attr,
-		       sizeof(event->perf_event_data.attr), &ap->attr);
-	event->perf_event_data.pid = ap->pid;
-	event->perf_event_data.cpu = ap->cpu;
-	event->perf_event_data.ret = ctx->ret;
-	bpf_probe_read(event->perf_event_data.name_or_path, PATH_LENTH,
-		       ap->name_or_path);
-
-	/* emit event */
-	bpf_ringbuf_submit(event, 0);
 cleanup:
 	bpf_map_delete_elem(&perf_event_open_param_start, &pid_tgid);
 	return 0;
@@ -613,7 +660,7 @@ int handle_exec(struct trace_event_raw_sched_process_exec *ctx)
 {
 	struct task_struct *task;
 	unsigned fname_off;
-	struct event e = {0};
+	struct event e = { 0 };
 	pid_t pid;
 	u64 ts;
 

--- a/daemon/user/bpftime_driver.cpp
+++ b/daemon/user/bpftime_driver.cpp
@@ -177,9 +177,8 @@ int bpftime_driver::bpftime_progs_create_server(int kernel_id, int server_pid)
 			      kernel_id);
 		return -1;
 	}
-	res = bpftime_progs_create(kernel_id,
-				   buffer.data(), buffer.size(), info.name,
-				   info.type);
+	res = bpftime_progs_create(kernel_id, buffer.data(), buffer.size(),
+				   info.name, info.type);
 	if (res < 0) {
 		spdlog::error("Failed to create prog for id {}", kernel_id);
 		return -1;
@@ -275,8 +274,7 @@ int bpftime_driver::bpftime_attach_perf_to_bpf_server(int server_pid,
 		}
 	}
 
-	int res = bpftime_attach_perf_to_bpf(
-		perf_id, kernel_bpf_id);
+	int res = bpftime_attach_perf_to_bpf(perf_id, kernel_bpf_id);
 	if (res < 0) {
 		spdlog::error("Failed to attach perf to bpf");
 		return -1;

--- a/daemon/user/daemon_config.hpp
+++ b/daemon/user/daemon_config.hpp
@@ -34,7 +34,7 @@ struct daemon_config {
 	// should bpftime be involve
 	bool is_driving_bpftime = true;
 	// should trace and submit bpf related detail events
-	bool submit_bpf_events = true;
+	bool submit_bpf_events = false;
 	// specify whether uprobe should work similar to kernel uprobe and auto
 	// attach to the target process
 	bool enable_auto_attach = false;

--- a/daemon/user/daemon_config.hpp
+++ b/daemon/user/daemon_config.hpp
@@ -1,8 +1,11 @@
 #ifndef BPFTIME_DAEMON_CONFIG_HPP
 #define BPFTIME_DAEMON_CONFIG_HPP
 
+#include <cstdint>
+#include <set>
 #include <unistd.h>
 #include <string>
+#include <vector>
 
 #define PATH_LENTH 255
 
@@ -38,6 +41,12 @@ struct daemon_config {
 	// minimal duration of a process to be traced by uprobe
 	// skip short lived process to reduce overhead
 	int duration_ms = 1000;
+	// Only uprobes in the list will be run in userspace
+	std::set<uint64_t> whitelist_uprobes;
+	bool whitelist_enabled() const
+	{
+		return !whitelist_uprobes.empty();
+	}
 };
 
 #endif // BPFTIME_DAEMON_CONFIG_HPP

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,2 +1,3 @@
 simple_uretprobe_test*
 malloc-perf*
+go-trace-test*

--- a/runtime/src/attach/attach_manager/frida_attach_manager.cpp
+++ b/runtime/src/attach/attach_manager/frida_attach_manager.cpp
@@ -76,6 +76,8 @@ int frida_attach_manager::attach_at(void *func_addr, callback_variant &&cb)
 					       (attach_type)cb.index(),
 					       interceptor))
 			      .first;
+		spdlog::debug("Created frida attach entry for func addr {:x}",
+			      (uintptr_t)func_addr);
 	} else if (itr->second->has_replace_or_filter()) {
 		spdlog::error(
 			"Function {} was already attached with replace or filter, cannot attach anything else");

--- a/runtime/src/attach/bpf_attach_ctx.cpp
+++ b/runtime/src/attach/bpf_attach_ctx.cpp
@@ -301,6 +301,11 @@ int bpf_attach_ctx::init_attach_ctx_from_handlers(
 						"Expected that a certain function could only be attached one replace, at perf event {}",
 						i);
 					return -E2BIG;
+				} else if (progs.empty()) {
+					spdlog::error(
+						"Perf event {} doesn't have any attached & enabled programs",
+						i);
+					return -ENOENT;
 				}
 				err = attach_manager->attach_replace_at(
 					func_addr,

--- a/runtime/src/attach/bpf_attach_ctx.cpp
+++ b/runtime/src/attach/bpf_attach_ctx.cpp
@@ -273,6 +273,11 @@ int bpf_attach_ctx::init_attach_ctx_from_handlers(
 						"Expected that a certain function could only be attached one filter, at perf event {}",
 						i);
 					return -E2BIG;
+				} else if (progs.empty()) {
+					spdlog::error(
+						"Perf event {} doesn't have any attached & enabled programs",
+						i);
+					return -ENOENT;
 				}
 				err = attach_manager->attach_filter_at(
 					func_addr,

--- a/runtime/src/attach/bpf_attach_ctx.cpp
+++ b/runtime/src/attach/bpf_attach_ctx.cpp
@@ -189,7 +189,30 @@ int bpf_attach_ctx::init_attach_ctx_from_handlers(
 				return res;
 			}
 			for (auto v : prog_handler.attach_fds) {
-				handler_prog_fds[v].emplace_back(i, prog);
+				if (std::holds_alternative<
+					    bpf_perf_event_handler>(
+					    manager->get_handler(v))) {
+					const auto &perf_handler =
+						std::get<bpf_perf_event_handler>(
+							manager->get_handler(
+								v));
+					if (perf_handler.enabled) {
+						handler_prog_fds[v].emplace_back(
+							i, prog);
+						spdlog::debug(
+							"Program fd {} attached to perf event handler {}",
+							i, v);
+					} else {
+						spdlog::info(
+							"Ignore perf {} attached by prog fd {}. It's not enabled",
+							v, i);
+					}
+
+				} else {
+					spdlog::warn(
+						"Program fd {} attached to a non-perf event handler {}",
+						i, v);
+				}
 			}
 			spdlog::debug("Load prog fd={} name={}", i,
 				      prog_handler.name);
@@ -207,13 +230,6 @@ int bpf_attach_ctx::init_attach_ctx_from_handlers(
 			spdlog::error("Unsupported handler type for handler {}",
 				      handler.index());
 			return -1;
-		}
-	}
-	for (const auto &[k, v] : handler_prog_fds) {
-		for (auto y : v) {
-			spdlog::debug(
-				"Program fd {} attached to perf event handler {}",
-				y.first, k);
 		}
 	}
 	// Second, we create bpf perf event handlers

--- a/runtime/src/bpf_map/shared/hash_map_kernel_user.hpp
+++ b/runtime/src/bpf_map/shared/hash_map_kernel_user.hpp
@@ -27,7 +27,7 @@ class hash_map_kernel_user_impl {
 	void init_map_fd();
 
     public:
-	const static bool should_lock = true;
+	const static bool should_lock = false;
 	hash_map_kernel_user_impl(managed_shared_memory &memory, int km_id);
 	~hash_map_kernel_user_impl();
 

--- a/runtime/src/bpf_map/shared/percpu_array_map_kernel_user.hpp
+++ b/runtime/src/bpf_map/shared/percpu_array_map_kernel_user.hpp
@@ -18,7 +18,7 @@ class percpu_array_map_kernel_user_impl {
 	bytes_vec value_data;
 
     public:
-	const static bool should_lock = true;
+	const static bool should_lock = false;
 	void *elem_lookup(const void *key);
 
 	long elem_update(const void *key, const void *value, uint64_t flags);

--- a/runtime/src/handler/perf_event_handler.cpp
+++ b/runtime/src/handler/perf_event_handler.cpp
@@ -59,6 +59,9 @@ bpf_perf_event_handler::bpf_perf_event_handler(
 		type = bpf_event_type::BPF_TYPE_UPROBE;
 	}
 	this->_module_name = module_name;
+	spdlog::info(
+		"Created uprobe/uretprobe perf event handler, module name {}, offset {:x}",
+		module_name, offset);
 }
 
 // create tracepoint

--- a/runtime/src/handler/perf_event_handler.cpp
+++ b/runtime/src/handler/perf_event_handler.cpp
@@ -39,8 +39,8 @@ namespace bpftime
 // attach to replace or filter self define types
 bpf_perf_event_handler::bpf_perf_event_handler(
 	bpf_event_type type, uint64_t offset, int pid, const char *module_name,
-	boost::interprocess::managed_shared_memory &mem)
-	: type(type), offset(offset), pid(pid),
+	boost::interprocess::managed_shared_memory &mem, bool default_enabled)
+	: type(type), enabled(default_enabled), offset(offset), pid(pid),
 	  _module_name(char_allocator(mem.get_segment_manager()))
 {
 	this->_module_name = module_name;

--- a/runtime/src/handler/perf_event_handler.hpp
+++ b/runtime/src/handler/perf_event_handler.hpp
@@ -92,16 +92,25 @@ using software_perf_event_weak_ptr = boost::interprocess::managed_weak_ptr<
 // perf event handler
 struct bpf_perf_event_handler {
 	bpf_event_type type;
+	mutable bool enabled = false;
 	int enable() const
 	{
+		enabled = true;
 		// TODO: implement enable logic.
 		// If This is a server, should inject the agent into the target
 		// process.
+
+		spdlog::info(
+			"Enabling perf event for module name: {}, offset {:x}",
+			_module_name.c_str(), offset);
 		return 0;
 	}
 	int disable() const
 	{
-		spdlog::debug("Disabling perf event, but nothing todo");
+		spdlog::info(
+			"Disabling perf event for module name: {}, offset {:x}",
+			_module_name.c_str(), offset);
+		enabled = false;
 		return 0;
 	}
 	uint64_t offset;

--- a/runtime/src/handler/perf_event_handler.hpp
+++ b/runtime/src/handler/perf_event_handler.hpp
@@ -131,7 +131,8 @@ struct bpf_perf_event_handler {
 	// attach to replace or filter self define types
 	bpf_perf_event_handler(bpf_event_type type, uint64_t offset, int pid,
 			       const char *module_name,
-			       boost::interprocess::managed_shared_memory &mem);
+			       boost::interprocess::managed_shared_memory &mem,
+			       bool default_enabled = false);
 	// create uprobe/uretprobe with new perf event attr
 	bpf_perf_event_handler(bool is_retprobe, uint64_t offset, int pid,
 			       const char *module_name, size_t ref_ctr_off,

--- a/runtime/test/bpf/.gitignore
+++ b/runtime/test/bpf/.gitignore
@@ -1,3 +1,4 @@
 *.o
 *.btf
 *.a
+/.output

--- a/runtime/test/src/test_shm_progs_attach.cpp
+++ b/runtime/test/src/test_shm_progs_attach.cpp
@@ -18,8 +18,6 @@
 using namespace boost::interprocess;
 using namespace bpftime;
 
-
-
 const char *HANDLER_NAME = "my_handler";
 const char *SHM_NAME = "my_shm_attach_test";
 
@@ -64,9 +62,11 @@ void attach_uprobe(bpftime::handler_manager &manager_ref,
 		   bpf_attach_ctx &ctx)
 {
 	std::uint64_t offset = 0;
-	void *module_base_self = ctx.get_attach_manager().get_module_base_addr("");
+	void *module_base_self =
+		ctx.get_attach_manager().get_module_base_addr("");
 	void *my_uprobe_function_addr =
-		ctx.get_attach_manager().find_function_addr_by_name("my_uprobe_function");
+		ctx.get_attach_manager().find_function_addr_by_name(
+			"my_uprobe_function");
 	offset = (uintptr_t)my_uprobe_function_addr -
 		 (uintptr_t)module_base_self;
 	printf("my_uprobe_function_addr: %p, offset: %lu\n",
@@ -84,15 +84,17 @@ void attach_replace(bpftime::handler_manager &manager_ref,
 		    managed_shared_memory &segment, bpftime_prog *prog,
 		    bpf_attach_ctx &ctx)
 {
-	void *module_base_self = ctx.get_attach_manager().get_module_base_addr("");
+	void *module_base_self =
+		ctx.get_attach_manager().get_module_base_addr("");
 	void *my_function_addr = (void *)my_function;
 	std::uint64_t offset =
 		(uintptr_t)my_function_addr - (uintptr_t)module_base_self;
 	manager_ref.set_handler(
 		0,
-		bpf_prog_handler(segment, prog->get_insns().data(),
-				 prog->get_insns().size(), prog->prog_name(),
-				 (int)bpftime::bpf_prog_type::BPF_PROG_TYPE_UNSPEC),
+		bpf_prog_handler(
+			segment, prog->get_insns().data(),
+			prog->get_insns().size(), prog->prog_name(),
+			(int)bpftime::bpf_prog_type::BPF_PROG_TYPE_UNSPEC),
 		segment);
 	auto &prog_handler = std::get<bpf_prog_handler>(manager_ref[0]);
 	// the attach fd is 3
@@ -100,9 +102,8 @@ void attach_replace(bpftime::handler_manager &manager_ref,
 	// attach replace
 	manager_ref.set_handler(
 		3,
-		bpf_perf_event_handler(
-			bpf_event_type::BPF_TYPE_REPLACE,
-			offset, -1, "", segment),
+		bpf_perf_event_handler(bpf_event_type::BPF_TYPE_REPLACE, offset,
+				       -1, "", segment, true),
 		segment);
 }
 

--- a/runtime/unit-test/attach/test_filter_attach.cpp
+++ b/runtime/unit-test/attach/test_filter_attach.cpp
@@ -7,8 +7,10 @@
 using namespace bpftime;
 
 extern "C" uint64_t bpftime_set_retval(uint64_t retval);
-extern "C" uint64_t __bpftime_func_to_filter(uint64_t a, uint64_t b)
-{
+__attribute__((__noinline__)) extern "C" uint64_t
+__bpftime_func_to_filter(uint64_t a, uint64_t b)
+{ // Forbid inline
+	asm("");
 	return (a << 32) | b;
 }
 

--- a/runtime/unit-test/attach/test_replace_attach.cpp
+++ b/runtime/unit-test/attach/test_replace_attach.cpp
@@ -5,8 +5,11 @@
 #endif
 
 using namespace bpftime;
-extern "C" uint64_t __bpftime_func_to_replace(uint64_t a, uint64_t b)
+__attribute__((__noinline__)) extern "C" uint64_t
+__bpftime_func_to_replace(uint64_t a, uint64_t b)
 {
+	// Forbid inline
+	asm("");
 	return (a << 32) | b;
 }
 TEST_CASE("Test attaching replace programs and revert")

--- a/runtime/unit-test/attach/test_uprobe_uretprobe.cpp
+++ b/runtime/unit-test/attach/test_uprobe_uretprobe.cpp
@@ -12,8 +12,11 @@
 
 using namespace bpftime;
 
-extern "C" uint64_t __test_simple_add(uint64_t a, uint64_t b)
+__attribute__((__noinline__)) extern "C" uint64_t __test_simple_add(uint64_t a,
+								    uint64_t b)
 {
+	// Forbid inline
+	asm("");
 	return a * 2 + b;
 }
 

--- a/runtime/unit-test/attach_with_ebpf/test_attach_filter_with_ebpf.cpp
+++ b/runtime/unit-test/attach_with_ebpf/test_attach_filter_with_ebpf.cpp
@@ -6,10 +6,11 @@
 using namespace bpftime;
 
 // This is the original function to hook.
-extern "C" int __bpftime_attach_filter_with_ebpf__my_function(const char *str,
-							      char c,
-							      long long parm1)
+__attribute__((__noinline__)) extern "C" int
+__bpftime_attach_filter_with_ebpf__my_function(const char *str, char c,
+					       long long parm1)
 {
+	asm("");
 	// buggy code: not check str is NULL
 	int i = str[0];
 	spdlog::info("origin func: Args: %s, %c, %d", str, c, i);

--- a/vm/llvm-jit/src/bpf_jit.cpp
+++ b/vm/llvm-jit/src/bpf_jit.cpp
@@ -42,6 +42,7 @@ extern "C" void __aeabi_unwind_cpp_pr1();
 
 ebpf_jit_fn bpf_jit_context::compile()
 {
+	spdlog::info("Compiling using LLJIT");
 	// Create a JIT builder
 	auto jit = ExitOnErr(LLJITBuilder().create());
 	auto &mainDylib = jit->getMainJITDylib();


### PR DESCRIPTION
This PR updated bpftime-daemon (both kernel ebpf program and userspace program), and make deepflow's attach to runtime.casgstatus work in userspace.

- Adds uprobe whitelist support. If enabled, only attaches to the specified address will be executed in userspace. Pass `-w ADDR` argument to `bpftime_daemon` to enable this. Multiple arguments is also supported. `-w 0x1234 -w 0x2345`

## How to test
1. Run `bpftime_daemon`
2. Run the go program to be traced
3. Run `deepflow/rust_example`
4. Use **bpftime attach** to attach to the process