### PR TITLE
runtime: fix incorrect implementation in`bpftime_get_current_pid_tgid`

### DIFF
--- a/runtime/src/bpf_helper.cpp
+++ b/runtime/src/bpf_helper.cpp
@@ -73,8 +73,11 @@ uint64_t bpftime_ktime_get_coarse_ns(uint64_t, uint64_t, uint64_t, uint64_t,
 uint64_t bpftime_get_current_pid_tgid(uint64_t, uint64_t, uint64_t, uint64_t,
 				      uint64_t)
 {
-	static int pid = getpid();
-	return ((uint64_t)pid << 32) | pid;
+	static int tgid = getpid();
+	static thread_local int tid = -1;
+	if (tid == -1)
+		tid = gettid();
+	return ((uint64_t)tgid << 32) | tid;
 }
 
 uint64_t bpf_get_current_uid_gid(uint64_t, uint64_t, uint64_t, uint64_t,


### PR DESCRIPTION
- bpf_get_current_pid_tgid returns the `PID` of the running task (a.k.a, thread) and the thread group id of it.
Kernel treats indentifion ID of each thread as its PID, and all threads belonging to the same process shares the same thread group id. So the TGID kernel thinks could be retrived from userspace using `getpid` (which returns thread group id of the current thread, in fact). and the PID kernel thinks could be retrived using `gettid` from the userspace.
