### PR TITLE
runtime: remove usage of weak_ptr in attach manager

### DIFF
--- a/runtime/src/attach/attach_manager/frida_attach_manager.cpp
+++ b/runtime/src/attach/attach_manager/frida_attach_manager.cpp
@@ -102,7 +102,7 @@ int frida_attach_manager::attach_at(void *func_addr, callback_variant &&cb)
 			.first;
 	inner_attach->user_attaches.push_back(
 		inserted_attach_entry->second.get());
-	inserted_attach_entry->second->internal_attache = inner_attach.get();
+	inserted_attach_entry->second->internal_attach = inner_attach.get();
 	return result;
 }
 
@@ -141,7 +141,7 @@ int frida_attach_manager::destroy_attach(int id)
 {
 	void *drop_func_addr = nullptr;
 	if (auto itr = attaches.find(id); itr != attaches.end()) {
-		auto p = itr->second->internal_attache;
+		auto p = itr->second->internal_attach;
 
 		auto &user_attaches = p->user_attaches;
 		auto tail =

--- a/runtime/src/attach/attach_manager/frida_attach_manager.hpp
+++ b/runtime/src/attach/attach_manager/frida_attach_manager.hpp
@@ -22,7 +22,7 @@ class frida_attach_entry {
 	base_attach_manager::callback_variant cb;
 	void *function;
 
-	std::weak_ptr<class frida_internal_attach_entry> internal_attaches;
+	class frida_internal_attach_entry *internal_attache;
 	friend class frida_attach_manager;
 	friend class frida_internal_attach_entry;
 
@@ -44,7 +44,7 @@ class frida_attach_entry {
 class frida_internal_attach_entry {
 	void *function;
 	GumInterceptor *interceptor;
-	std::vector<std::weak_ptr<frida_attach_entry> > user_attaches;
+	std::vector<frida_attach_entry *> user_attaches;
 	GumInvocationListener *frida_gum_invocation_listener = nullptr;
 
 	friend class frida_attach_manager;
@@ -96,8 +96,8 @@ class frida_attach_manager final : public base_attach_manager {
     private:
 	GumInterceptor *interceptor;
 	int next_id = 1;
-	std::unordered_map<int, std::shared_ptr<frida_attach_entry> > attaches;
-	std::unordered_map<void *, std::shared_ptr<frida_internal_attach_entry> >
+	std::unordered_map<int, std::unique_ptr<frida_attach_entry> > attaches;
+	std::unordered_map<void *, std::unique_ptr<frida_internal_attach_entry> >
 		internal_attaches;
 
 	friend class frida_internal_attach_entry;

--- a/runtime/src/attach/attach_manager/frida_attach_manager.hpp
+++ b/runtime/src/attach/attach_manager/frida_attach_manager.hpp
@@ -22,7 +22,7 @@ class frida_attach_entry {
 	base_attach_manager::callback_variant cb;
 	void *function;
 
-	class frida_internal_attach_entry *internal_attache;
+	class frida_internal_attach_entry *internal_attach;
 	friend class frida_attach_manager;
 	friend class frida_internal_attach_entry;
 

--- a/runtime/unit-test/attach/test_replace_attach.cpp
+++ b/runtime/unit-test/attach/test_replace_attach.cpp
@@ -1,16 +1,22 @@
 #include <catch2/catch_test_macros.hpp>
 #include <attach/attach_manager/frida_attach_manager.hpp>
+#include <spdlog/spdlog.h>
 #if !defined(__x86_64__) && defined(_M_X64)
 #error Only supports x86_64
 #endif
 
 using namespace bpftime;
-__attribute__((__noinline__)) extern "C" uint64_t
+__attribute__((__noinline__, optnone, noinline)) extern "C" uint64_t
 __bpftime_func_to_replace(uint64_t a, uint64_t b)
 {
 	// Forbid inline
 	asm("");
 	return (a << 32) | b;
+}
+__attribute__((__noinline__, optnone, noinline)) static uint64_t
+call_replace_func(uint64_t a, uint64_t b)
+{
+	return __bpftime_func_to_replace(a, b);
 }
 TEST_CASE("Test attaching replace programs and revert")
 {
@@ -30,7 +36,7 @@ TEST_CASE("Test attaching replace programs and revert")
 					       return regs.si + regs.di;
 				       });
 	REQUIRE(id >= 0);
-	REQUIRE(__bpftime_func_to_replace(a, b) == a + b);
+	REQUIRE(call_replace_func(a, b) == a + b);
 	REQUIRE(invoke_times == 1);
 	// Revert it
 	invoke_times = 0;

--- a/runtime/unit-test/attach_with_ebpf/test_attach_filter_with_ebpf.cpp
+++ b/runtime/unit-test/attach_with_ebpf/test_attach_filter_with_ebpf.cpp
@@ -6,14 +6,14 @@
 using namespace bpftime;
 
 // This is the original function to hook.
-__attribute__((__noinline__)) extern "C" int
+__attribute__((__noinline__, optnone)) extern "C" int
 __bpftime_attach_filter_with_ebpf__my_function(const char *str, char c,
 					       long long parm1)
 {
 	asm("");
 	// buggy code: not check str is NULL
 	int i = str[0];
-	spdlog::info("origin func: Args: %s, %c, %d", str, c, i);
+	spdlog::info("origin func: Args: {}, {}, {}", str, c, i);
 	return (int)parm1;
 }
 


### PR DESCRIPTION
This PR replaces the using of `shared_ptr` with `unique_ptr`, and replaces the usage of `weak_ptr` with raw pointers, in attach manager