### PR TITLE
example: add mountsnoop from libbpf-tools

### DIFF
--- a/.github/script/run_example.py
+++ b/.github/script/run_example.py
@@ -70,7 +70,7 @@ async def main():
         )
 
         await asyncio.wait_for(server_started_signal.wait(), SERVER_TIMEOUT)
-        await asyncio.sleep(2)
+        await asyncio.sleep(5)
         print("Server started!")
 
         # Start the agent

--- a/.github/script/run_example.py
+++ b/.github/script/run_example.py
@@ -96,6 +96,8 @@ async def main():
         should_exit.set()
         server.send_signal(signal.SIGINT)
         agent.send_signal(signal.SIGINT)
+        server.send_signal(signal.SIGKILL)
+        agent.send_signal(signal.SIGKILL)
         await asyncio.gather(server_out, agent_out)
         await asyncio.gather(server.communicate(), agent.communicate())
 

--- a/.github/script/run_example.py
+++ b/.github/script/run_example.py
@@ -92,18 +92,14 @@ async def main():
             return
         await asyncio.wait_for(expected_str_signal.wait(), AGENT_TIMEOUT)
         print("Test successfully")
-        try:
-            for task in asyncio.all_tasks():
-                task.cancel()
-            asyncio.get_event_loop().close()
-        except:
-            pass
     finally:
         should_exit.set()
-        server.send_signal(signal.SIGINT)
-        agent.send_signal(signal.SIGINT)
         try:
+            server.send_signal(signal.SIGINT)
+            agent.send_signal(signal.SIGINT)
             await asyncio.gather(server_out, agent_out)
+            for task in asyncio.all_tasks():
+                task.cancel()
             await asyncio.gather(server.communicate(), agent.communicate())
         except:
             pass

--- a/.github/script/run_example.py
+++ b/.github/script/run_example.py
@@ -92,15 +92,19 @@ async def main():
             return
         await asyncio.wait_for(expected_str_signal.wait(), AGENT_TIMEOUT)
         print("Test successfully")
+        try:
+            for task in asyncio.all_tasks():
+                task.cancel()
+            asyncio.get_event_loop().close()
+        except:
+            pass
     finally:
         should_exit.set()
         server.send_signal(signal.SIGINT)
         agent.send_signal(signal.SIGINT)
-        server.send_signal(signal.SIGKILL)
-        agent.send_signal(signal.SIGKILL)
         await asyncio.gather(server_out, agent_out)
         await asyncio.gather(server.communicate(), agent.communicate())
-
+        
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/.github/script/run_example.py
+++ b/.github/script/run_example.py
@@ -102,9 +102,11 @@ async def main():
         should_exit.set()
         server.send_signal(signal.SIGINT)
         agent.send_signal(signal.SIGINT)
-        await asyncio.gather(server_out, agent_out)
-        await asyncio.gather(server.communicate(), agent.communicate())
-        
+        try:
+            await asyncio.gather(server_out, agent_out)
+            await asyncio.gather(server.communicate(), agent.communicate())
+        except:
+            pass
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -106,7 +106,7 @@ jobs:
             expected_str: ": 1"
           - path: libbpf-tools/mountsnoop
             executable: ./mountsnoop
-            victim: mount -- -t tmpfs -o size=1G tmpfs /mnt/ramdisk/
+            victim: mount -- -t tmpfs -o size=1G tmpfs /mnt/ramdisk
             syscall_trace: true
             expected_str:  mount("tmpfs", "/mnt/ramdisk", "tmpfs", 0x0, "size=1G")
 
@@ -138,7 +138,7 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install -y zlib1g-dev libelf-dev llvm
-          mkdir /mnt/ramdisk
+          sudo mkdir /mnt/ramdisk
       - name: Build test assets
         run: |
           make -C example/${{matrix.examples.path}} -j

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -88,7 +88,7 @@ jobs:
             executable: ./sslsniff
             victim: /bin/wget https://www.google.com
             syscall_trace: false
-            expected_str: "----- DATA -----"
+            expected_str: "----- DATA -----111"
           - path: libbpf-tools/bashreadline
             executable: ./readline
             victim: /bin/bash

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -88,7 +88,7 @@ jobs:
             executable: ./sslsniff
             victim: /bin/wget https://www.google.com
             syscall_trace: false
-            expected_str: "----- DATA -----111"
+            expected_str: "----- DATA -----"
           - path: libbpf-tools/bashreadline
             executable: ./readline
             victim: /bin/bash

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -106,7 +106,7 @@ jobs:
             expected_str: ": 1"
           - path: libbpf-tools/mountsnoop
             executable: ./mountsnoop
-            victim: mount -- -t tmpfs -o size=1G tmpfs /mnt/ramdisk
+            victim: ./victim
             syscall_trace: true
             expected_str:  mount(
 

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -108,7 +108,7 @@ jobs:
             executable: ./mountsnoop
             victim: mount -- -t tmpfs -o size=1G tmpfs /mnt/ramdisk
             syscall_trace: true
-            expected_str:  mount("tmpfs", "/mnt/ramdisk", "tmpfs", 0x0, "size=1G")
+            expected_str:  mount(
 
           
     steps:
@@ -151,7 +151,7 @@ jobs:
         shell: "sudo /bin/bash -e {0}"
         run: |
           cd example/${{matrix.examples.path}}
-          sudo -E python3 /home/runner/work/bpftime/bpftime/.github/script/run_example.py "${{matrix.examples.executable}}" "${{matrix.examples.victim}}" '${{matrix.examples.expected_str}}' "/home/runner/.bpftime/bpftime -i /home/runner/.bpftime" 1
+          sudo -E python3 /home/runner/work/bpftime/bpftime/.github/script/run_example.py "${{matrix.examples.executable}}" "${{matrix.examples.victim}}" "${{matrix.examples.expected_str}}" "/home/runner/.bpftime/bpftime -i /home/runner/.bpftime" 1
       - name: Test CLI - attach by running (uprobe)
         if: '!matrix.examples.syscall_trace'
         shell: "sudo /bin/bash -e {0}"

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -104,6 +104,12 @@ jobs:
             victim: ./victim
             syscall_trace: false
             expected_str: ": 1"
+          - path: libbpf-tools/mountsnoop
+            executable: ./mountsnoop
+            victim: mount -- -t tmpfs -o size=1G tmpfs /mnt/ramdisk/
+            syscall_trace: true
+            expected_str:  mount("tmpfs", "/mnt/ramdisk", "tmpfs", 0x0, "size=1G")
+
           
     steps:
       - uses: actions/checkout@v2
@@ -132,6 +138,7 @@ jobs:
         run: |
           sudo apt-get update -y
           sudo apt-get install -y zlib1g-dev libelf-dev llvm
+          mkdir /mnt/ramdisk
       - name: Build test assets
         run: |
           make -C example/${{matrix.examples.path}} -j
@@ -144,10 +151,10 @@ jobs:
         shell: "sudo /bin/bash -e {0}"
         run: |
           cd example/${{matrix.examples.path}}
-          sudo -E python3 /home/runner/work/bpftime/bpftime/.github/script/run_example.py "${{matrix.examples.executable}}" "${{matrix.examples.victim}}" "${{matrix.examples.expected_str}}" "/home/runner/.bpftime/bpftime -i /home/runner/.bpftime" 1
+          sudo -E python3 /home/runner/work/bpftime/bpftime/.github/script/run_example.py "${{matrix.examples.executable}}" "${{matrix.examples.victim}}" '${{matrix.examples.expected_str}}' "/home/runner/.bpftime/bpftime -i /home/runner/.bpftime" 1
       - name: Test CLI - attach by running (uprobe)
         if: '!matrix.examples.syscall_trace'
         shell: "sudo /bin/bash -e {0}"
         run: |
           cd example/${{matrix.examples.path}}
-          sudo -E python3 /home/runner/work/bpftime/bpftime/.github/script/run_example.py "${{matrix.examples.executable}}" "${{matrix.examples.victim}}" "${{matrix.examples.expected_str}}" "/home/runner/.bpftime/bpftime -i /home/runner/.bpftime" 0
+          sudo -E python3 /home/runner/work/bpftime/bpftime/.github/script/run_example.py "${{matrix.examples.executable}}" "${{matrix.examples.victim}}" '${{matrix.examples.expected_str}}' "/home/runner/.bpftime/bpftime -i /home/runner/.bpftime" 0

--- a/example/libbpf-tools/mountsnoop/.gitignore
+++ b/example/libbpf-tools/mountsnoop/.gitignore
@@ -1,0 +1,11 @@
+.vscode
+package.json
+*.o
+*.skel.json
+*.skel.yaml
+package.yaml
+ecli
+bootstrap
+.output
+mountsnoop
+victim

--- a/example/libbpf-tools/mountsnoop/Makefile
+++ b/example/libbpf-tools/mountsnoop/Makefile
@@ -66,7 +66,7 @@ $(call allow-override,CC,$(CROSS_COMPILE)cc)
 $(call allow-override,LD,$(CROSS_COMPILE)ld)
 
 .PHONY: all
-all: $(APPS)
+all: $(APPS) victim
 
 .PHONY: clean
 clean:
@@ -136,3 +136,6 @@ $(APPS): %: $(OUTPUT)/%.o $(LIBBPF_OBJ) | $(OUTPUT)
 
 # keep intermediate (.skel.h, .bpf.o, etc) targets
 .SECONDARY:
+
+victim: victim.c
+	gcc victim.c -g -Wall -o victim

--- a/example/libbpf-tools/mountsnoop/Makefile
+++ b/example/libbpf-tools/mountsnoop/Makefile
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+OUTPUT := .output
+CLANG ?= clang
+LIBBPF_SRC := $(abspath ../../../third_party/libbpf/src)
+BPFTOOL_SRC := $(abspath ../../../third_party/bpftool/src)
+LIBBPF_OBJ := $(abspath $(OUTPUT)/libbpf.a)
+BPFTOOL_OUTPUT ?= $(abspath $(OUTPUT)/bpftool)
+BPFTOOL ?= $(BPFTOOL_OUTPUT)/bootstrap/bpftool
+ARCH ?= $(shell uname -m | sed 's/x86_64/x86/' \
+			 | sed 's/arm.*/arm/' \
+			 | sed 's/aarch64/arm64/' \
+			 | sed 's/ppc64le/powerpc/' \
+			 | sed 's/mips.*/mips/' \
+			 | sed 's/riscv64/riscv/' \
+			 | sed 's/loongarch64/loongarch/')
+VMLINUX := ../../../third_party/vmlinux/$(ARCH)/vmlinux.h
+# Use our own libbpf API headers and Linux UAPI headers distributed with
+# libbpf to avoid dependency on system-wide headers, which could be missing or
+# outdated
+INCLUDES := -I$(OUTPUT) -I../../../third_party/libbpf/include/uapi -I$(dir $(VMLINUX))
+CFLAGS := -g -Wall
+ALL_LDFLAGS := $(LDFLAGS) $(EXTRA_LDFLAGS)
+
+APPS = mountsnoop # minimal minimal_legacy uprobe kprobe fentry usdt sockfilter tc ksyscall
+
+CARGO ?= $(shell which cargo)
+ifeq ($(strip $(CARGO)),)
+BZS_APPS :=
+else
+BZS_APPS := # profile
+APPS += $(BZS_APPS)
+# Required by libblazesym
+ALL_LDFLAGS += -lrt -ldl -lpthread -lm
+endif
+
+# Get Clang's default includes on this system. We'll explicitly add these dirs
+# to the includes list when compiling with `-target bpf` because otherwise some
+# architecture-specific dirs will be "missing" on some architectures/distros -
+# headers such as asm/types.h, asm/byteorder.h, asm/socket.h, asm/sockios.h,
+# sys/cdefs.h etc. might be missing.
+#
+# Use '-idirafter': Don't interfere with include mechanics except where the
+# build would have failed anyways.
+CLANG_BPF_SYS_INCLUDES ?= $(shell $(CLANG) -v -E - </dev/null 2>&1 \
+	| sed -n '/<...> search starts here:/,/End of search list./{ s| \(/.*\)|-idirafter \1|p }')
+
+ifeq ($(V),1)
+	Q =
+	msg =
+else
+	Q = @
+	msg = @printf '  %-8s %s%s\n'					\
+		      "$(1)"						\
+		      "$(patsubst $(abspath $(OUTPUT))/%,%,$(2))"	\
+		      "$(if $(3), $(3))";
+	MAKEFLAGS += --no-print-directory
+endif
+
+define allow-override
+  $(if $(or $(findstring environment,$(origin $(1))),\
+            $(findstring command line,$(origin $(1)))),,\
+    $(eval $(1) = $(2)))
+endef
+
+$(call allow-override,CC,$(CROSS_COMPILE)cc)
+$(call allow-override,LD,$(CROSS_COMPILE)ld)
+
+.PHONY: all
+all: $(APPS)
+
+.PHONY: clean
+clean:
+	$(call msg,CLEAN)
+	$(Q)rm -rf $(OUTPUT) $(APPS)
+
+$(OUTPUT) $(OUTPUT)/libbpf $(BPFTOOL_OUTPUT):
+	$(call msg,MKDIR,$@)
+	$(Q)mkdir -p $@
+
+# Build libbpf
+$(LIBBPF_OBJ): $(wildcard $(LIBBPF_SRC)/*.[ch] $(LIBBPF_SRC)/Makefile) | $(OUTPUT)/libbpf
+	$(call msg,LIB,$@)
+	$(Q)$(MAKE) -C $(LIBBPF_SRC) CFLAGS="-O0 -g" BUILD_STATIC_ONLY=1		      \
+		    OBJDIR=$(dir $@)/libbpf DESTDIR=$(dir $@)		      \
+		    INCLUDEDIR= LIBDIR= UAPIDIR=			      \
+		    install
+
+# Build bpftool
+$(BPFTOOL): | $(BPFTOOL_OUTPUT)
+	$(call msg,BPFTOOL,$@)
+	$(Q)$(MAKE) ARCH= CROSS_COMPILE= OUTPUT=$(BPFTOOL_OUTPUT)/ -C $(BPFTOOL_SRC) bootstrap
+
+
+$(LIBBLAZESYM_SRC)/target/release/libblazesym.a::
+	$(Q)cd $(LIBBLAZESYM_SRC) && $(CARGO) build --features=cheader,dont-generate-test-files --release
+
+$(LIBBLAZESYM_OBJ): $(LIBBLAZESYM_SRC)/target/release/libblazesym.a | $(OUTPUT)
+	$(call msg,LIB, $@)
+	$(Q)cp $(LIBBLAZESYM_SRC)/target/release/libblazesym.a $@
+
+$(LIBBLAZESYM_HEADER): $(LIBBLAZESYM_SRC)/target/release/libblazesym.a | $(OUTPUT)
+	$(call msg,LIB,$@)
+	$(Q)cp $(LIBBLAZESYM_SRC)/target/release/blazesym.h $@
+
+# Build BPF code
+$(OUTPUT)/%.bpf.o: %.bpf.c $(LIBBPF_OBJ) $(wildcard %.h) $(VMLINUX) | $(OUTPUT) $(BPFTOOL)
+	$(call msg,BPF,$@)
+	$(Q)$(CLANG) -g -O2 -target bpf -D__TARGET_ARCH_$(ARCH)		      \
+		     $(INCLUDES) $(CLANG_BPF_SYS_INCLUDES)		      \
+		     -c $(filter %.c,$^) -o $(patsubst %.bpf.o,%.tmp.bpf.o,$@)
+	$(Q)$(BPFTOOL) gen object $@ $(patsubst %.bpf.o,%.tmp.bpf.o,$@)
+
+# Generate BPF skeletons
+$(OUTPUT)/%.skel.h: $(OUTPUT)/%.bpf.o | $(OUTPUT) $(BPFTOOL)
+	$(call msg,GEN-SKEL,$@)
+	$(Q)$(BPFTOOL) gen skeleton $< > $@
+
+# Build user-space code
+$(patsubst %,$(OUTPUT)/%.o,$(APPS)): %.o: %.skel.h
+
+$(OUTPUT)/%.o: %.c $(wildcard %.h) | $(OUTPUT)
+	$(call msg,CC,$@)
+	$(Q)$(CC) $(CFLAGS) $(INCLUDES) -c $(filter %.c,$^) -o $@
+
+$(patsubst %,$(OUTPUT)/%.o,$(BZS_APPS)): $(LIBBLAZESYM_HEADER)
+
+$(BZS_APPS): $(LIBBLAZESYM_OBJ)
+
+# Build application binary
+$(APPS): %: $(OUTPUT)/%.o $(LIBBPF_OBJ) | $(OUTPUT)
+	$(call msg,BINARY,$@)
+	$(Q)$(CC) $(CFLAGS) $^ $(ALL_LDFLAGS) -lelf -lz -o $@
+
+# delete failed targets
+.DELETE_ON_ERROR:
+
+# keep intermediate (.skel.h, .bpf.o, etc) targets
+.SECONDARY:

--- a/example/libbpf-tools/mountsnoop/mountsnoop.bpf.c
+++ b/example/libbpf-tools/mountsnoop/mountsnoop.bpf.c
@@ -26,7 +26,7 @@ struct {
 	__type(value, struct arg);
 } args SEC(".maps");
 
-static int probe_entry(const char *src, const char *dest, const char *fs,
+static __always_inline int probe_entry(const char *src, const char *dest, const char *fs,
 		       __u64 flags, const char *data, enum op op)
 {
 	__u64 pid_tgid = bpf_get_current_pid_tgid();
@@ -48,7 +48,7 @@ static int probe_entry(const char *src, const char *dest, const char *fs,
 	return 0;
 };
 
-static int probe_exit(void *ctx, int ret)
+static __always_inline int probe_exit(void *ctx, int ret)
 {
 	__u64 pid_tgid = bpf_get_current_pid_tgid();
 	__u32 pid = pid_tgid >> 32;

--- a/example/libbpf-tools/mountsnoop/mountsnoop.bpf.c
+++ b/example/libbpf-tools/mountsnoop/mountsnoop.bpf.c
@@ -1,0 +1,134 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/* Copyright (c) 2021 Hengqi Chen */
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_core_read.h>
+#include <bpf/bpf_tracing.h>
+
+#include "mountsnoop.h"
+
+#define MAX_ENTRIES 10240
+
+const volatile pid_t target_pid = 0;
+
+#define RINGBUF_SIZE		(1024 * 256)
+
+
+struct {
+	__uint(type, BPF_MAP_TYPE_RINGBUF);
+	__uint(max_entries, RINGBUF_SIZE);
+} events SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, __u32);
+	__type(value, struct arg);
+} args SEC(".maps");
+
+static int probe_entry(const char *src, const char *dest, const char *fs,
+		       __u64 flags, const char *data, enum op op)
+{
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	__u32 pid = pid_tgid >> 32;
+	__u32 tid = (__u32)pid_tgid;
+	struct arg arg = {};
+
+	if (target_pid && target_pid != pid)
+		return 0;
+
+	arg.ts = bpf_ktime_get_ns();
+	arg.flags = flags;
+	arg.src = src;
+	arg.dest = dest;
+	arg.fs = fs;
+	arg.data= data;
+	arg.op = op;
+	bpf_map_update_elem(&args, &tid, &arg, BPF_ANY);
+	return 0;
+};
+
+static int probe_exit(void *ctx, int ret)
+{
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	__u32 pid = pid_tgid >> 32;
+	__u32 tid = (__u32)pid_tgid;
+	// struct task_struct *task;
+	struct event *eventp;
+	struct arg *argp;
+
+	argp = bpf_map_lookup_elem(&args, &tid);
+	if (!argp)
+		return 0;
+
+	eventp = bpf_ringbuf_reserve(&events, sizeof(*eventp), 0);
+	if (!eventp)
+		goto cleanup;
+
+	// task = (struct task_struct *)bpf_get_current_task();
+	eventp->delta = bpf_ktime_get_ns() - argp->ts;
+	eventp->flags = argp->flags;
+	eventp->pid = pid;
+	eventp->tid = tid;
+	eventp->mnt_ns = 0;
+	eventp->ret = ret;
+	eventp->op = argp->op;
+	bpf_get_current_comm(&eventp->comm, sizeof(eventp->comm));
+	if (argp->src)
+		bpf_probe_read_user_str(eventp->src, sizeof(eventp->src), argp->src);
+	else
+		eventp->src[0] = '\0';
+	if (argp->dest)
+		bpf_probe_read_user_str(eventp->dest, sizeof(eventp->dest), argp->dest);
+	else
+		eventp->dest[0] = '\0';
+	if (argp->fs)
+		bpf_probe_read_user_str(eventp->fs, sizeof(eventp->fs), argp->fs);
+	else
+		eventp->fs[0] = '\0';
+	if (argp->data)
+		bpf_probe_read_user_str(eventp->data, sizeof(eventp->data), argp->data);
+	else
+		eventp->data[0] = '\0';
+
+	bpf_ringbuf_submit(eventp, 0);
+
+cleanup:
+	bpf_map_delete_elem(&args, &tid);
+	return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_mount")
+int mount_entry(struct trace_event_raw_sys_enter *ctx)
+{
+	const char *src = (const char *)ctx->args[0];
+	const char *dest = (const char *)ctx->args[1];
+	const char *fs = (const char *)ctx->args[2];
+	__u64 flags = (__u64)ctx->args[3];
+	const char *data = (const char *)ctx->args[4];
+
+	return probe_entry(src, dest, fs, flags, data, MOUNT);
+}
+
+SEC("tracepoint/syscalls/sys_exit_mount")
+int mount_exit(struct trace_event_raw_sys_exit *ctx)
+{
+	return probe_exit(ctx, (int)ctx->ret);
+}
+
+SEC("tracepoint/syscalls/sys_enter_umount")
+int umount_entry(struct trace_event_raw_sys_enter *ctx)
+{
+	const char *dest = (const char *)ctx->args[0];
+	__u64 flags = (__u64)ctx->args[1];
+
+	return probe_entry(NULL, dest, NULL, flags, NULL, UMOUNT);
+}
+
+SEC("tracepoint/syscalls/sys_exit_umount")
+int umount_exit(struct trace_event_raw_sys_exit *ctx)
+{
+	return probe_exit(ctx, (int)ctx->ret);
+}
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";

--- a/example/libbpf-tools/mountsnoop/mountsnoop.c
+++ b/example/libbpf-tools/mountsnoop/mountsnoop.c
@@ -116,8 +116,8 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 static int libbpf_print_fn(enum libbpf_print_level level, const char *format,
 			   va_list args)
 {
-	// if (level == LIBBPF_DEBUG && !verbose)
-	// 	return 0;
+	if (level == LIBBPF_DEBUG && !verbose)
+		return 0;
 	return vfprintf(stderr, format, args);
 }
 
@@ -284,7 +284,7 @@ int main(int argc, char **argv)
 		printf("%-16s %-7s %-7s %-11s %s\n", "COMM", "PID", "TID",
 		       "MNT_NS", "CALL");
 	}
-
+	fflush(stdout);
 	while (!exiting) {
 		err = ring_buffer__poll(buf, POLL_TIMEOUT_MS);
 		if (err < 0 && err != -EINTR) {
@@ -294,6 +294,7 @@ int main(int argc, char **argv)
 		}
 		/* reset err to return 0 if exiting */
 		err = 0;
+		fflush(stdout);
 	}
 
 cleanup:

--- a/example/libbpf-tools/mountsnoop/mountsnoop.c
+++ b/example/libbpf-tools/mountsnoop/mountsnoop.c
@@ -1,0 +1,304 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+
+/*
+ * mountsnoop  Trace mount and umount[2] syscalls
+ *
+ * Copyright (c) 2021 Hengqi Chen
+ * 30-May-2021   Hengqi Chen   Created this.
+ */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <argp.h>
+#include <errno.h>
+#include <signal.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <bpf/libbpf.h>
+#include <bpf/bpf.h>
+#include "mountsnoop.h"
+#include "mountsnoop.skel.h"
+#define POLL_TIMEOUT_MS 100
+#define warn(...) fprintf(stderr, __VA_ARGS__)
+
+/* https://www.gnu.org/software/gnulib/manual/html_node/strerrorname_005fnp.html
+ */
+#if !defined(__GLIBC__) || __GLIBC__ < 2 ||                                    \
+	(__GLIBC__ == 2 && __GLIBC_MINOR__ < 32)
+const char *strerrorname_np(int errnum)
+{
+	return NULL;
+}
+#endif
+
+static volatile sig_atomic_t exiting = 0;
+
+static pid_t target_pid = 0;
+static bool emit_timestamp = false;
+static bool output_vertically = false;
+static bool verbose = false;
+static const char *flag_names[] = {
+	[0] = "MS_RDONLY",	 [1] = "MS_NOSUID",
+	[2] = "MS_NODEV",	 [3] = "MS_NOEXEC",
+	[4] = "MS_SYNCHRONOUS",	 [5] = "MS_REMOUNT",
+	[6] = "MS_MANDLOCK",	 [7] = "MS_DIRSYNC",
+	[8] = "MS_NOSYMFOLLOW",	 [9] = "MS_NOATIME",
+	[10] = "MS_NODIRATIME",	 [11] = "MS_BIND",
+	[12] = "MS_MOVE",	 [13] = "MS_REC",
+	[14] = "MS_VERBOSE",	 [15] = "MS_SILENT",
+	[16] = "MS_POSIXACL",	 [17] = "MS_UNBINDABLE",
+	[18] = "MS_PRIVATE",	 [19] = "MS_SLAVE",
+	[20] = "MS_SHARED",	 [21] = "MS_RELATIME",
+	[22] = "MS_KERNMOUNT",	 [23] = "MS_I_VERSION",
+	[24] = "MS_STRICTATIME", [25] = "MS_LAZYTIME",
+	[26] = "MS_SUBMOUNT",	 [27] = "MS_NOREMOTELOCK",
+	[28] = "MS_NOSEC",	 [29] = "MS_BORN",
+	[30] = "MS_ACTIVE",	 [31] = "MS_NOUSER",
+};
+static const int flag_count = sizeof(flag_names) / sizeof(flag_names[0]);
+
+const char *argp_program_version = "mountsnoop 0.1";
+const char *argp_program_bug_address =
+	"https://github.com/iovisor/bcc/tree/master/libbpf-tools";
+const char argp_program_doc[] =
+	"Trace mount and umount syscalls.\n"
+	"\n"
+	"USAGE: mountsnoop [-h] [-t] [-p PID] [-v]\n"
+	"\n"
+	"EXAMPLES:\n"
+	"    mountsnoop         # trace mount and umount syscalls\n"
+	"    mountsnoop -d      # detailed output (one line per column value)\n"
+	"    mountsnoop -p 1216 # only trace PID 1216\n";
+
+static const struct argp_option opts[] = {
+	{ "pid", 'p', "PID", 0, "Process ID to trace" },
+	{ "timestamp", 't', NULL, 0, "Include timestamp on output" },
+	{ "detailed", 'd', NULL, 0, "Output result in detail mode" },
+	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
+	{},
+};
+
+static error_t parse_arg(int key, char *arg, struct argp_state *state)
+{
+	long pid;
+
+	switch (key) {
+	case 'p':
+		errno = 0;
+		pid = strtol(arg, NULL, 10);
+		if (errno || pid <= 0) {
+			warn("Invalid PID: %s\n", arg);
+			argp_usage(state);
+		}
+		target_pid = pid;
+		break;
+	case 't':
+		emit_timestamp = true;
+		break;
+	case 'd':
+		output_vertically = true;
+		break;
+	case 'v':
+		verbose = true;
+		break;
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
+	default:
+		return ARGP_ERR_UNKNOWN;
+	}
+	return 0;
+}
+
+static int libbpf_print_fn(enum libbpf_print_level level, const char *format,
+			   va_list args)
+{
+	// if (level == LIBBPF_DEBUG && !verbose)
+	// 	return 0;
+	return vfprintf(stderr, format, args);
+}
+
+static void sig_int(int signo)
+{
+	exiting = 1;
+}
+
+static const char *strflags(__u64 flags)
+{
+	static char str[512];
+	int i;
+
+	if (!flags)
+		return "0x0";
+
+	str[0] = '\0';
+	for (i = 0; i < flag_count; i++) {
+		if (!((1 << i) & flags))
+			continue;
+		if (str[0])
+			strcat(str, " | ");
+		strcat(str, flag_names[i]);
+	}
+	return str;
+}
+
+static const char *strerrno(int errnum)
+{
+	const char *errstr;
+	static char ret[32] = {};
+
+	if (!errnum)
+		return "0";
+
+	ret[0] = '\0';
+	errstr = strerrorname_np(-errnum);
+	if (!errstr) {
+		snprintf(ret, sizeof(ret), "%d", errnum);
+		return ret;
+	}
+
+	snprintf(ret, sizeof(ret), "-%s", errstr);
+	return ret;
+}
+
+static const char *gen_call(const struct event *e)
+{
+	static char call[10240];
+
+	memset(call, 0, sizeof(call));
+	if (e->op == UMOUNT) {
+		snprintf(call, sizeof(call), "umount(\"%s\", %s) = %s", e->dest,
+			 strflags(e->flags), strerrno(e->ret));
+	} else {
+		snprintf(call, sizeof(call),
+			 "mount(\"%s\", \"%s\", \"%s\", %s, \"%s\") = %s",
+			 e->src, e->dest, e->fs, strflags(e->flags), e->data,
+			 strerrno(e->ret));
+	}
+	return call;
+}
+
+static int handle_event(void *ctx, void *data, size_t len)
+{
+	const struct event *e = data;
+	struct tm *tm;
+	char ts[32];
+	time_t t;
+	const char *indent;
+	static const char *op_name[] = {
+		[MOUNT] = "MOUNT",
+		[UMOUNT] = "UMOUNT",
+	};
+
+	if (emit_timestamp) {
+		time(&t);
+		tm = localtime(&t);
+		strftime(ts, sizeof(ts), "%H:%M:%S ", tm);
+		printf("%s", ts);
+		indent = "    ";
+	} else {
+		indent = "";
+	}
+	if (!output_vertically) {
+		printf("%-16s %-7d %-7d %-11u %s\n", e->comm, e->pid, e->tid,
+		       e->mnt_ns, gen_call(e));
+		return 0;
+	}
+	if (emit_timestamp)
+		printf("\n");
+	printf("%sPID:    %d\n", indent, e->pid);
+	printf("%sTID:    %d\n", indent, e->tid);
+	printf("%sCOMM:   %s\n", indent, e->comm);
+	printf("%sOP:     %s\n", indent, op_name[e->op]);
+	printf("%sRET:    %s\n", indent, strerrno(e->ret));
+	printf("%sLAT:    %lldus\n", indent, e->delta / 1000);
+	printf("%sMNT_NS: %u\n", indent, e->mnt_ns);
+	printf("%sFS:     %s\n", indent, e->fs);
+	printf("%sSOURCE: %s\n", indent, e->src);
+	printf("%sTARGET: %s\n", indent, e->dest);
+	printf("%sDATA:   %s\n", indent, e->data);
+	printf("%sFLAGS:  %s\n", indent, strflags(e->flags));
+	printf("\n");
+
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	LIBBPF_OPTS(bpf_object_open_opts, open_opts);
+	static const struct argp argp = {
+		.options = opts,
+		.parser = parse_arg,
+		.doc = argp_program_doc,
+	};
+	struct ring_buffer *buf = NULL;
+	struct mountsnoop_bpf *obj;
+	int err;
+
+	err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
+	if (err)
+		return err;
+
+	libbpf_set_print(libbpf_print_fn);
+
+	obj = mountsnoop_bpf__open_opts(&open_opts);
+	if (!obj) {
+		warn("failed to open BPF object\n");
+		return 1;
+	}
+
+	obj->rodata->target_pid = target_pid;
+
+	err = mountsnoop_bpf__load(obj);
+	if (err) {
+		warn("failed to load BPF object: %d\n", err);
+		goto cleanup;
+	}
+
+	buf = ring_buffer__new(bpf_map__fd(obj->maps.events), handle_event,
+			       NULL, NULL);
+	if (!buf) {
+		err = -errno;
+		warn("failed to create ring/perf buffer: %d\n", err);
+		goto cleanup;
+	}
+
+	err = mountsnoop_bpf__attach(obj);
+	if (err) {
+		warn("failed to attach BPF programs: %d\n", err);
+		goto cleanup;
+	}
+
+	if (signal(SIGINT, sig_int) == SIG_ERR) {
+		warn("can't set signal handler: %s\n", strerror(errno));
+		err = 1;
+		goto cleanup;
+	}
+
+	if (!output_vertically) {
+		if (emit_timestamp)
+			printf("%-8s ", "TIME");
+		printf("%-16s %-7s %-7s %-11s %s\n", "COMM", "PID", "TID",
+		       "MNT_NS", "CALL");
+	}
+
+	while (!exiting) {
+		err = ring_buffer__poll(buf, POLL_TIMEOUT_MS);
+		if (err < 0 && err != -EINTR) {
+			fprintf(stderr, "error polling ring/perf buffer: %s\n",
+				strerror(-err));
+			goto cleanup;
+		}
+		/* reset err to return 0 if exiting */
+		err = 0;
+	}
+
+cleanup:
+	ring_buffer__free(buf);
+	mountsnoop_bpf__destroy(obj);
+
+	return err != 0;
+}

--- a/example/libbpf-tools/mountsnoop/mountsnoop.h
+++ b/example/libbpf-tools/mountsnoop/mountsnoop.h
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause) */
+#ifndef __MOUNTSNOOP_H
+#define __MOUNTSNOOP_H
+
+#define TASK_COMM_LEN	16
+#define FS_NAME_LEN	8
+#define DATA_LEN	512
+#define PATH_MAX	4096
+
+enum op {
+	MOUNT,
+	UMOUNT,
+};
+
+struct arg {
+	__u64 ts;
+	__u64 flags;
+	const char *src;
+	const char *dest;
+	const char *fs;
+	const char *data;
+	enum op op;
+};
+
+struct event {
+	__u64 delta;
+	__u64 flags;
+	__u32 pid;
+	__u32 tid;
+	unsigned int mnt_ns;
+	int ret;
+	char comm[TASK_COMM_LEN];
+	char fs[FS_NAME_LEN];
+	char src[PATH_MAX];
+	char dest[PATH_MAX];
+	char data[DATA_LEN];
+	enum op op;
+};
+
+#endif /* __MOUNTSNOOP_H */

--- a/example/libbpf-tools/mountsnoop/victim.c
+++ b/example/libbpf-tools/mountsnoop/victim.c
@@ -1,0 +1,10 @@
+#include <assert.h>
+#include <sys/mount.h>
+
+int main()
+{
+	int err = mount("tmpfs", "/mnt/ramdisk", "tmpfs", 0,
+			(const void *)"size=1G");
+	assert(err == 0);
+	return 0;
+}


### PR DESCRIPTION
This PR adds an example mountsnoop. It utilizes syscall  tracepoint to trace call to mount/umount2, and prints the details in userspace program