### PR TITLE
example: add sigsnoop from libbpf-tools

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -109,7 +109,7 @@ jobs:
             victim: ./victim
             syscall_trace: true
             expected_str:  mount(
-          - path: libbpf-tools/mountsnoop
+          - path: libbpf-tools/sigsnoop
             executable: ./sigsnoop
             victim: ./victim
             syscall_trace: true

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -109,7 +109,11 @@ jobs:
             victim: ./victim
             syscall_trace: true
             expected_str:  mount(
-
+          - path: libbpf-tools/mountsnoop
+            executable: ./sigsnoop
+            victim: ./victim
+            syscall_trace: true
+            expected_str: "victim           0         -1      0"
           
     steps:
       - uses: actions/checkout@v2

--- a/example/libbpf-tools/sigsnoop/.gitignore
+++ b/example/libbpf-tools/sigsnoop/.gitignore
@@ -1,0 +1,13 @@
+.vscode
+package.json
+*.o
+*.skel.json
+*.skel.yaml
+package.yaml
+ecli
+bootstrap
+.output
+sigsnoop
+victim
+test.txt
+syscall-trace.txt

--- a/example/libbpf-tools/sigsnoop/Makefile
+++ b/example/libbpf-tools/sigsnoop/Makefile
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+OUTPUT := .output
+CLANG ?= clang
+LIBBPF_SRC := $(abspath ../../../third_party/libbpf/src)
+BPFTOOL_SRC := $(abspath ../../../third_party/bpftool/src)
+LIBBPF_OBJ := $(abspath $(OUTPUT)/libbpf.a)
+BPFTOOL_OUTPUT ?= $(abspath $(OUTPUT)/bpftool)
+BPFTOOL ?= $(BPFTOOL_OUTPUT)/bootstrap/bpftool
+ARCH ?= $(shell uname -m | sed 's/x86_64/x86/' \
+			 | sed 's/arm.*/arm/' \
+			 | sed 's/aarch64/arm64/' \
+			 | sed 's/ppc64le/powerpc/' \
+			 | sed 's/mips.*/mips/' \
+			 | sed 's/riscv64/riscv/' \
+			 | sed 's/loongarch64/loongarch/')
+VMLINUX := ../../../third_party/vmlinux/$(ARCH)/vmlinux.h
+# Use our own libbpf API headers and Linux UAPI headers distributed with
+# libbpf to avoid dependency on system-wide headers, which could be missing or
+# outdated
+INCLUDES := -I$(OUTPUT) -I../../../third_party/libbpf/include/uapi -I$(dir $(VMLINUX))
+CFLAGS := -g -Wall
+ALL_LDFLAGS := $(LDFLAGS) $(EXTRA_LDFLAGS)
+
+APPS = sigsnoop # minimal minimal_legacy uprobe kprobe fentry usdt sockfilter tc ksyscall
+
+CARGO ?= $(shell which cargo)
+ifeq ($(strip $(CARGO)),)
+BZS_APPS :=
+else
+BZS_APPS := # profile
+APPS += $(BZS_APPS)
+# Required by libblazesym
+ALL_LDFLAGS += -lrt -ldl -lpthread -lm
+endif
+
+# Get Clang's default includes on this system. We'll explicitly add these dirs
+# to the includes list when compiling with `-target bpf` because otherwise some
+# architecture-specific dirs will be "missing" on some architectures/distros -
+# headers such as asm/types.h, asm/byteorder.h, asm/socket.h, asm/sockios.h,
+# sys/cdefs.h etc. might be missing.
+#
+# Use '-idirafter': Don't interfere with include mechanics except where the
+# build would have failed anyways.
+CLANG_BPF_SYS_INCLUDES ?= $(shell $(CLANG) -v -E - </dev/null 2>&1 \
+	| sed -n '/<...> search starts here:/,/End of search list./{ s| \(/.*\)|-idirafter \1|p }')
+
+ifeq ($(V),1)
+	Q =
+	msg =
+else
+	Q = @
+	msg = @printf '  %-8s %s%s\n'					\
+		      "$(1)"						\
+		      "$(patsubst $(abspath $(OUTPUT))/%,%,$(2))"	\
+		      "$(if $(3), $(3))";
+	MAKEFLAGS += --no-print-directory
+endif
+
+define allow-override
+  $(if $(or $(findstring environment,$(origin $(1))),\
+            $(findstring command line,$(origin $(1)))),,\
+    $(eval $(1) = $(2)))
+endef
+
+$(call allow-override,CC,$(CROSS_COMPILE)cc)
+$(call allow-override,LD,$(CROSS_COMPILE)ld)
+
+.PHONY: all
+all: $(APPS) victim
+
+.PHONY: clean
+clean:
+	$(call msg,CLEAN)
+	$(Q)rm -rf $(OUTPUT) $(APPS)
+
+$(OUTPUT) $(OUTPUT)/libbpf $(BPFTOOL_OUTPUT):
+	$(call msg,MKDIR,$@)
+	$(Q)mkdir -p $@
+
+# Build libbpf
+$(LIBBPF_OBJ): $(wildcard $(LIBBPF_SRC)/*.[ch] $(LIBBPF_SRC)/Makefile) | $(OUTPUT)/libbpf
+	$(call msg,LIB,$@)
+	$(Q)$(MAKE) -C $(LIBBPF_SRC) CFLAGS="-O0 -g" BUILD_STATIC_ONLY=1		      \
+		    OBJDIR=$(dir $@)/libbpf DESTDIR=$(dir $@)		      \
+		    INCLUDEDIR= LIBDIR= UAPIDIR=			      \
+		    install
+
+# Build bpftool
+$(BPFTOOL): | $(BPFTOOL_OUTPUT)
+	$(call msg,BPFTOOL,$@)
+	$(Q)$(MAKE) ARCH= CROSS_COMPILE= OUTPUT=$(BPFTOOL_OUTPUT)/ -C $(BPFTOOL_SRC) bootstrap
+
+
+$(LIBBLAZESYM_SRC)/target/release/libblazesym.a::
+	$(Q)cd $(LIBBLAZESYM_SRC) && $(CARGO) build --features=cheader,dont-generate-test-files --release
+
+$(LIBBLAZESYM_OBJ): $(LIBBLAZESYM_SRC)/target/release/libblazesym.a | $(OUTPUT)
+	$(call msg,LIB, $@)
+	$(Q)cp $(LIBBLAZESYM_SRC)/target/release/libblazesym.a $@
+
+$(LIBBLAZESYM_HEADER): $(LIBBLAZESYM_SRC)/target/release/libblazesym.a | $(OUTPUT)
+	$(call msg,LIB,$@)
+	$(Q)cp $(LIBBLAZESYM_SRC)/target/release/blazesym.h $@
+
+# Build BPF code
+$(OUTPUT)/%.bpf.o: %.bpf.c $(LIBBPF_OBJ) $(wildcard %.h) $(VMLINUX) | $(OUTPUT) $(BPFTOOL)
+	$(call msg,BPF,$@)
+	$(Q)$(CLANG) -g -O2 -target bpf -D__TARGET_ARCH_$(ARCH)		      \
+		     $(INCLUDES) $(CLANG_BPF_SYS_INCLUDES)		      \
+		     -c $(filter %.c,$^) -o $(patsubst %.bpf.o,%.tmp.bpf.o,$@)
+	$(Q)$(BPFTOOL) gen object $@ $(patsubst %.bpf.o,%.tmp.bpf.o,$@)
+
+# Generate BPF skeletons
+$(OUTPUT)/%.skel.h: $(OUTPUT)/%.bpf.o | $(OUTPUT) $(BPFTOOL)
+	$(call msg,GEN-SKEL,$@)
+	$(Q)$(BPFTOOL) gen skeleton $< > $@
+
+# Build user-space code
+$(patsubst %,$(OUTPUT)/%.o,$(APPS)): %.o: %.skel.h
+
+$(OUTPUT)/%.o: %.c $(wildcard %.h) | $(OUTPUT)
+	$(call msg,CC,$@)
+	$(Q)$(CC) $(CFLAGS) $(INCLUDES) -c $(filter %.c,$^) -o $@
+
+$(patsubst %,$(OUTPUT)/%.o,$(BZS_APPS)): $(LIBBLAZESYM_HEADER)
+
+$(BZS_APPS): $(LIBBLAZESYM_OBJ)
+
+# Build application binary
+$(APPS): %: $(OUTPUT)/%.o $(LIBBPF_OBJ) | $(OUTPUT)
+	$(call msg,BINARY,$@)
+	$(Q)$(CC) $(CFLAGS) $^ $(ALL_LDFLAGS) -lelf -lz -o $@
+
+# delete failed targets
+.DELETE_ON_ERROR:
+
+# keep intermediate (.skel.h, .bpf.o, etc) targets
+.SECONDARY:
+
+victim: victim.cpp
+	$(CXX) victim.cpp -Wall -g -o victim

--- a/example/libbpf-tools/sigsnoop/sigsnoop.bpf.c
+++ b/example/libbpf-tools/sigsnoop/sigsnoop.bpf.c
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+/* Copyright (c) 2021~2022 Hengqi Chen */
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include "sigsnoop.h"
+
+#define MAX_ENTRIES	10240
+
+const volatile pid_t filtered_pid = 0;
+const volatile int target_signal = 0;
+const volatile bool failed_only = false;
+
+struct {
+	__uint(type, BPF_MAP_TYPE_HASH);
+	__uint(max_entries, MAX_ENTRIES);
+	__type(key, __u32);
+	__type(value, struct event);
+} values SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+	__uint(key_size, sizeof(__u32));
+	__uint(value_size, sizeof(__u32));
+} events SEC(".maps");
+
+static __always_inline int probe_entry(pid_t tpid, int sig)
+{
+	struct event event = {};
+	__u64 pid_tgid;
+	__u32 pid, tid;
+
+	if (target_signal && sig != target_signal)
+		return 0;
+
+	pid_tgid = bpf_get_current_pid_tgid();
+	pid = pid_tgid >> 32;
+	tid = (__u32)pid_tgid;
+	if (filtered_pid && pid != filtered_pid)
+		return 0;
+
+	event.pid = pid;
+	event.tpid = tpid;
+	event.sig = sig;
+	bpf_get_current_comm(event.comm, sizeof(event.comm));
+	bpf_map_update_elem(&values, &tid, &event, BPF_ANY);
+	return 0;
+}
+
+static __always_inline int probe_exit(void *ctx, int ret)
+{
+	__u64 pid_tgid = bpf_get_current_pid_tgid();
+	__u32 tid = (__u32)pid_tgid;
+	struct event *eventp;
+
+	eventp = bpf_map_lookup_elem(&values, &tid);
+	if (!eventp)
+		return 0;
+
+	if (failed_only && ret >= 0)
+		goto cleanup;
+
+	eventp->ret = ret;
+	bpf_perf_event_output(ctx, &events, BPF_F_CURRENT_CPU, eventp, sizeof(*eventp));
+
+cleanup:
+	bpf_map_delete_elem(&values, &tid);
+	return 0;
+}
+
+SEC("tracepoint/syscalls/sys_enter_kill")
+int kill_entry(struct trace_event_raw_sys_enter *ctx)
+{
+	pid_t tpid = (pid_t)ctx->args[0];
+	int sig = (int)ctx->args[1];
+
+	return probe_entry(tpid, sig);
+}
+
+SEC("tracepoint/syscalls/sys_exit_kill")
+int kill_exit(struct trace_event_raw_sys_exit *ctx)
+{
+	return probe_exit(ctx, ctx->ret);
+}
+
+SEC("tracepoint/syscalls/sys_enter_tkill")
+int tkill_entry(struct trace_event_raw_sys_enter *ctx)
+{
+	pid_t tpid = (pid_t)ctx->args[0];
+	int sig = (int)ctx->args[1];
+
+	return probe_entry(tpid, sig);
+}
+
+SEC("tracepoint/syscalls/sys_exit_tkill")
+int tkill_exit(struct trace_event_raw_sys_exit *ctx)
+{
+	return probe_exit(ctx, ctx->ret);
+}
+
+SEC("tracepoint/syscalls/sys_enter_tgkill")
+int tgkill_entry(struct trace_event_raw_sys_enter *ctx)
+{
+	pid_t tpid = (pid_t)ctx->args[1];
+	int sig = (int)ctx->args[2];
+
+	return probe_entry(tpid, sig);
+}
+
+SEC("tracepoint/syscalls/sys_exit_tgkill")
+int tgkill_exit(struct trace_event_raw_sys_exit *ctx)
+{
+	return probe_exit(ctx, ctx->ret);
+}
+
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";

--- a/example/libbpf-tools/sigsnoop/sigsnoop.c
+++ b/example/libbpf-tools/sigsnoop/sigsnoop.c
@@ -8,6 +8,7 @@
  * 08-Aug-2021   Hengqi Chen   Created this.
  */
 #include <argp.h>
+#include <stdio.h>
 #include <libgen.h>
 #include <signal.h>
 #include <time.h>
@@ -159,6 +160,7 @@ static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
 	else
 		printf("%-8s %-7d %-16s %-9d %-7d %-6d\n",
 		       ts, e->pid, e->comm, e->sig, e->tpid, e->ret);
+	fflush(stdout);
 }
 
 static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)

--- a/example/libbpf-tools/sigsnoop/sigsnoop.c
+++ b/example/libbpf-tools/sigsnoop/sigsnoop.c
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+
+/*
+ * sigsnoop	Trace standard and real-time signals.
+ *
+ * Copyright (c) 2021~2022 Hengqi Chen
+ *
+ * 08-Aug-2021   Hengqi Chen   Created this.
+ */
+#include <argp.h>
+#include <libgen.h>
+#include <signal.h>
+#include <time.h>
+
+#include <bpf/bpf.h>
+#include "sigsnoop.h"
+#include "sigsnoop.skel.h"
+
+#define PERF_BUFFER_PAGES	16
+#define PERF_POLL_TIMEOUT_MS	100
+#define warn(...) fprintf(stderr, __VA_ARGS__)
+#define ARRAY_SIZE(arr) (sizeof(arr) / sizeof((arr)[0]))
+
+static volatile sig_atomic_t exiting = 0;
+
+static pid_t target_pid = 0;
+static int target_signal = 0;
+static bool failed_only = false;
+// static bool kill_only = false;
+static bool signal_name = false;
+static bool verbose = false;
+
+static const char *sig_name[] = {
+	[0] = "N/A",
+	[1] = "SIGHUP",
+	[2] = "SIGINT",
+	[3] = "SIGQUIT",
+	[4] = "SIGILL",
+	[5] = "SIGTRAP",
+	[6] = "SIGABRT",
+	[7] = "SIGBUS",
+	[8] = "SIGFPE",
+	[9] = "SIGKILL",
+	[10] = "SIGUSR1",
+	[11] = "SIGSEGV",
+	[12] = "SIGUSR2",
+	[13] = "SIGPIPE",
+	[14] = "SIGALRM",
+	[15] = "SIGTERM",
+	[16] = "SIGSTKFLT",
+	[17] = "SIGCHLD",
+	[18] = "SIGCONT",
+	[19] = "SIGSTOP",
+	[20] = "SIGTSTP",
+	[21] = "SIGTTIN",
+	[22] = "SIGTTOU",
+	[23] = "SIGURG",
+	[24] = "SIGXCPU",
+	[25] = "SIGXFSZ",
+	[26] = "SIGVTALRM",
+	[27] = "SIGPROF",
+	[28] = "SIGWINCH",
+	[29] = "SIGIO",
+	[30] = "SIGPWR",
+	[31] = "SIGSYS",
+};
+
+const char *argp_program_version = "sigsnoop 0.1";
+const char *argp_program_bug_address =
+	"https://github.com/iovisor/bcc/tree/master/libbpf-tools";
+const char argp_program_doc[] =
+"Trace standard and real-time signals.\n"
+"\n"
+"USAGE: sigsnoop [-h] [-x] [-k] [-n] [-p PID] [-s SIGNAL]\n"
+"\n"
+"EXAMPLES:\n"
+"    sigsnoop             # trace signals system-wide\n"
+"    sigsnoop -x          # trace failed signals only\n"
+"    sigsnoop -p 1216     # only trace PID 1216\n"
+"    sigsnoop -s 9        # only trace signal 9\n";
+
+static const struct argp_option opts[] = {
+	{ "failed", 'x', NULL, 0, "Trace failed signals only." },
+	{ "pid", 'p', "PID", 0, "Process ID to trace" },
+	{ "signal", 's', "SIGNAL", 0, "Signal to trace." },
+	{ "name", 'n', NULL, 0, "Output signal name instead of signal number." },
+	{ "verbose", 'v', NULL, 0, "Verbose debug output" },
+	{ NULL, 'h', NULL, OPTION_HIDDEN, "Show the full help" },
+	{},
+};
+
+static error_t parse_arg(int key, char *arg, struct argp_state *state)
+{
+	long pid, sig;
+
+	switch (key) {
+	case 'p':
+		errno = 0;
+		pid = strtol(arg, NULL, 10);
+		if (errno || pid <= 0) {
+			warn("Invalid PID: %s\n", arg);
+			argp_usage(state);
+		}
+		target_pid = pid;
+		break;
+	case 's':
+		errno = 0;
+		sig = strtol(arg, NULL, 10);
+		if (errno || sig <= 0) {
+			warn("Invalid SIGNAL: %s\n", arg);
+			argp_usage(state);
+		}
+		target_signal = sig;
+		break;
+	case 'n':
+		signal_name = true;
+		break;
+	case 'x':
+		failed_only = true;
+		break;
+	case 'v':
+		verbose = true;
+		break;
+	case 'h':
+		argp_state_help(state, stderr, ARGP_HELP_STD_HELP);
+		break;
+	default:
+		return ARGP_ERR_UNKNOWN;
+	}
+	return 0;
+}
+
+static int libbpf_print_fn(enum libbpf_print_level level, const char *format, va_list args)
+{
+	if (level == LIBBPF_DEBUG && !verbose)
+		return 0;
+	return vfprintf(stderr, format, args);
+}
+
+
+static void sig_int(int signo)
+{
+	exiting = 1;
+}
+
+static void handle_event(void *ctx, int cpu, void *data, __u32 data_sz)
+{
+	struct event *e = data;
+	struct tm *tm;
+	char ts[32];
+	time_t t;
+
+	time(&t);
+	tm = localtime(&t);
+	strftime(ts, sizeof(ts), "%H:%M:%S", tm);
+	if (signal_name && e->sig < ARRAY_SIZE(sig_name))
+		printf("%-8s %-7d %-16s %-9s %-7d %-6d\n",
+		       ts, e->pid, e->comm, sig_name[e->sig], e->tpid, e->ret);
+	else
+		printf("%-8s %-7d %-16s %-9d %-7d %-6d\n",
+		       ts, e->pid, e->comm, e->sig, e->tpid, e->ret);
+}
+
+static void handle_lost_events(void *ctx, int cpu, __u64 lost_cnt)
+{
+	warn("lost %llu events on CPU #%d\n", lost_cnt, cpu);
+}
+
+int main(int argc, char **argv)
+{
+	static const struct argp argp = {
+		.options = opts,
+		.parser = parse_arg,
+		.doc = argp_program_doc,
+	};
+	struct perf_buffer *pb = NULL;
+	struct sigsnoop_bpf *obj;
+	int err;
+
+	err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
+	if (err)
+		return err;
+
+	libbpf_set_print(libbpf_print_fn);
+
+	obj = sigsnoop_bpf__open();
+	if (!obj) {
+		warn("failed to open BPF object\n");
+		return 1;
+	}
+
+	obj->rodata->filtered_pid = target_pid;
+	obj->rodata->target_signal = target_signal;
+	obj->rodata->failed_only = failed_only;
+
+	// if (kill_only) {
+	// 	bpf_program__set_autoload(obj->progs.sig_trace, false);
+	// } else {
+	// 	bpf_program__set_autoload(obj->progs.kill_entry, false);
+	// 	bpf_program__set_autoload(obj->progs.kill_exit, false);
+	// 	bpf_program__set_autoload(obj->progs.tkill_entry, false);
+	// 	bpf_program__set_autoload(obj->progs.tkill_exit, false);
+	// 	bpf_program__set_autoload(obj->progs.tgkill_entry, false);
+	// 	bpf_program__set_autoload(obj->progs.tgkill_exit, false);
+	// }
+
+	err = sigsnoop_bpf__load(obj);
+	if (err) {
+		warn("failed to load BPF object: %d\n", err);
+		goto cleanup;
+	}
+
+	err = sigsnoop_bpf__attach(obj);
+	if (err) {
+		warn("failed to attach BPF programs: %d\n", err);
+		goto cleanup;
+	}
+
+	pb = perf_buffer__new(bpf_map__fd(obj->maps.events), PERF_BUFFER_PAGES,
+			      handle_event, handle_lost_events, NULL, NULL);
+	if (!pb) {
+		err = -errno;
+		warn("failed to open perf buffer: %d\n", err);
+		goto cleanup;
+	}
+
+	if (signal(SIGINT, sig_int) == SIG_ERR) {
+		warn("can't set signal handler: %s\n", strerror(errno));
+		goto cleanup;
+	}
+
+	printf("%-8s %-7s %-16s %-9s %-7s %-6s\n",
+	       "TIME", "PID", "COMM", "SIG", "TPID", "RESULT");
+
+	while (!exiting) {
+		err = perf_buffer__poll(pb, PERF_POLL_TIMEOUT_MS);
+		if (err < 0 && err != -EINTR) {
+			warn("error polling perf buffer: %s\n", strerror(-err));
+			goto cleanup;
+		}
+		/* reset err to return 0 if exiting */
+		err = 0;
+	}
+
+cleanup:
+	perf_buffer__free(pb);
+	sigsnoop_bpf__destroy(obj);
+
+	return err != 0;
+}

--- a/example/libbpf-tools/sigsnoop/sigsnoop.h
+++ b/example/libbpf-tools/sigsnoop/sigsnoop.h
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+/* Copyright (c) 2021~2022 Hengqi Chen */
+#ifndef __SIGSNOOP_H
+#define __SIGSNOOP_H
+
+#define TASK_COMM_LEN	16
+
+struct event {
+	__u32 pid;
+	__u32 tpid;
+	int sig;
+	int ret;
+	char comm[TASK_COMM_LEN];
+};
+
+#endif /* __SIGSNOOP_H */

--- a/example/libbpf-tools/sigsnoop/victim.cpp
+++ b/example/libbpf-tools/sigsnoop/victim.cpp
@@ -1,0 +1,12 @@
+#include <signal.h>
+#include <unistd.h>
+
+int main()
+{
+	int self_pid = getpid();
+	kill(self_pid, 0);
+	kill(self_pid, SIGCHLD);
+	killpg(self_pid, 0);
+	kill(-1, 0);
+	return 0;
+}


### PR DESCRIPTION
Adds sigsnoop, which is an example that traces call to kill/pkill/tgkill