### PR TITLE
runtime: enable syscall server to load and run cross boundary programs.

### DIFF
--- a/daemon/user/bpftime_driver.cpp
+++ b/daemon/user/bpftime_driver.cpp
@@ -242,6 +242,7 @@ int bpftime_driver::bpftime_maps_create_server(int kernel_id)
 	SPDLOG_INFO("create map in kernel id {}", kernel_id);
 	return kernel_id;
 }
+
 int bpftime_driver::bpftime_attach_perf_to_bpf_fd_server(int server_pid,
 							 int perf_fd,
 							 int bpf_prog_fd)
@@ -256,6 +257,7 @@ int bpftime_driver::bpftime_attach_perf_to_bpf_fd_server(int server_pid,
 	}
 	return bpftime_attach_perf_to_bpf_server(server_pid, perf_fd, prog_id);
 }
+
 int bpftime_driver::bpftime_attach_perf_to_bpf_server(int server_pid,
 						      int perf_fd,
 						      int kernel_bpf_id)

--- a/example/malloc/README.md
+++ b/example/malloc/README.md
@@ -66,5 +66,5 @@ LD_PRELOAD=build/runtime/syscall-server/libbpftime-syscall-server.so example/mal
 client
 
 ```sh
-LD_PRELOAD=build/runtime/agent/libbpftime-agent.so example/malloc/test
+LD_PRELOAD=build/runtime/agent/libbpftime-agent.so example/malloc/victim
 ```

--- a/runtime/include/bpftime_shm.hpp
+++ b/runtime/include/bpftime_shm.hpp
@@ -254,7 +254,7 @@ void *bpftime_get_ringbuf_producer_page(int ringbuf_fd);
 int bpftime_is_ringbuf_map(int fd);
 int bpftime_is_array_map(int fd);
 int bpftime_is_epoll_handler(int fd);
-
+int bpftime_is_perf_event_fd(int fd);
 int bpftime_is_prog_fd(int fd);
 int bpftime_is_map_fd(int fd);
 

--- a/runtime/src/bpftime_shm.cpp
+++ b/runtime/src/bpftime_shm.cpp
@@ -183,6 +183,10 @@ int bpftime_is_map_fd(int fd)
 	return shm_holder.global_shared_memory.is_map_fd(fd);
 }
 
+int bpftime_is_perf_event_fd(int fd) {
+	return shm_holder.global_shared_memory.is_perf_event_handler_fd(fd);
+}
+
 int bpftime_is_prog_fd(int fd)
 {
 	return shm_holder.global_shared_memory.is_prog_fd(fd);

--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -140,8 +140,8 @@ int bpftime_shm::add_uprobe(int fd, int pid, const char *name, uint64_t offset,
 		// if fd is negative, we need to create a new fd for allocating
 		fd = open_fake_fd();
 	}
-	SPDLOG_DEBUG("Set fd {} to uprobe, pid={}, name={}, offset={}", fd,
-		      pid, name, offset);
+	SPDLOG_DEBUG("Set fd {} to uprobe, pid={}, name={}, offset={}", fd, pid,
+		     name, offset);
 	return manager->set_handler(
 		fd,
 		bpftime::bpf_perf_event_handler{ retprobe, offset, pid, name,
@@ -157,7 +157,7 @@ int bpftime_shm::add_uprobe_override(int fd, int pid, const char *name,
 		fd = open_fake_fd();
 	}
 	SPDLOG_DEBUG("Set fd {} to ureplace, pid={}, name={}, offset={}", fd,
-		      pid, name, offset);
+		     pid, name, offset);
 	if (is_replace) {
 		return manager->set_handler(
 			fd,
@@ -168,9 +168,9 @@ int bpftime_shm::add_uprobe_override(int fd, int pid, const char *name,
 	} else {
 		return manager->set_handler(
 			fd,
-			bpf_perf_event_handler(bpf_event_type::BPF_TYPE_UPROBE_OVERRIDE,
-					       offset, pid, name, segment,
-					       true),
+			bpf_perf_event_handler(
+				bpf_event_type::BPF_TYPE_UPROBE_OVERRIDE,
+				offset, pid, name, segment, true),
 			segment);
 	}
 }
@@ -210,8 +210,7 @@ int bpftime_shm::attach_perf_to_bpf(int perf_fd, int bpf_fd)
 
 int bpftime_shm::add_bpf_prog_attach_target(int perf_fd, int bpf_fd)
 {
-	SPDLOG_DEBUG("Try attaching prog fd {} to perf fd {}", bpf_fd,
-		      perf_fd);
+	SPDLOG_DEBUG("Try attaching prog fd {} to perf fd {}", bpf_fd, perf_fd);
 	if (!is_prog_fd(bpf_fd)) {
 		SPDLOG_ERROR("Fd {} is not a prog fd", bpf_fd);
 		errno = ENOENT;
@@ -307,12 +306,12 @@ int bpftime_shm::add_ringbuf_to_epoll(int ringbuf_fd, int epoll_fd,
 		epoll_inst.files.emplace_back(val->create_impl_weak_ptr(),
 					      extra_data);
 		SPDLOG_DEBUG("Ringbuf {} added to epoll {}", ringbuf_fd,
-			      epoll_fd);
+			     epoll_fd);
 		return 0;
 	} else {
 		errno = EINVAL;
 		SPDLOG_ERROR("Map fd {} is expected to be an ringbuf map",
-			      ringbuf_fd);
+			     ringbuf_fd);
 		return -1;
 	}
 }
@@ -595,7 +594,7 @@ bpftime_shm::bpftime_shm(bpftime::shm_open_type type)
 	: bpftime_shm(bpftime::get_global_shm_name(), type)
 {
 	SPDLOG_INFO("Global shm constructed. shm_open_type {} for {}",
-		     (int)type, bpftime::get_global_shm_name());
+		    (int)type, bpftime::get_global_shm_name());
 }
 
 int bpftime_shm::add_bpf_map(int fd, const char *name,
@@ -631,6 +630,10 @@ const handler_manager *bpftime_shm::get_manager() const
 
 bool bpftime_shm::is_perf_event_handler_fd(int fd) const
 {
+	if (manager == nullptr || fd < 0 ||
+	    (std::size_t)fd >= manager->size()) {
+		return false;
+	}
 	auto &handler = get_handler(fd);
 	return std::holds_alternative<bpf_perf_event_handler>(handler);
 }

--- a/runtime/syscall-server/README.md
+++ b/runtime/syscall-server/README.md
@@ -6,6 +6,18 @@ Use as a LD_PRELOAD to intercept bpf syscalls and mock them in userspace, or tra
 
 The default behavior is to run with userspace eBPF. Using userspace eBPF means using userspace eBPF maps in shared memory, using userspace eBPF verifier and userspace eBPF runtime.
 
+server
+
+```sh
+LD_PRELOAD=build/runtime/syscall-server/libbpftime-syscall-server.so example/malloc/malloc
+```
+
+client
+
+```sh
+LD_PRELOAD=build/runtime/agent/libbpftime-agent.so example/malloc/victim
+```
+
 ## run with kernel
 
 Set the environment variable `BPFTIME_RUN_WITH_KERNEL` to `true` to make the kernel eBPF run with userspace eBPF. This means using kernel eBPF maps instead of userspace eBPF maps, and using kernel eBPF verifier instead of userspace eBPF verifier.
@@ -14,8 +26,14 @@ Set the environment variable `BPFTIME_RUN_WITH_KERNEL` to `true` to make the ker
 BPFTIME_RUN_WITH_KERNEL=true
 ```
 
-example:
+example start tracing:
 
 ```sh
 SPDLOG_LEVEL=Debug BPFTIME_RUN_WITH_KERNEL=true LD_PRELOAD=build/runtime/syscall-server/libbpftime-syscall-server.so example/malloc/malloc
+```
+
+example run target program:
+
+```sh
+SPDLOG_LEVEL=Debug LD_PRELOAD=build/runtime/agent/libbpftime-agent.so example/malloc/victim
 ```

--- a/runtime/syscall-server/README.md
+++ b/runtime/syscall-server/README.md
@@ -1,0 +1,21 @@
+# syscall_server.so
+
+Use as a LD_PRELOAD to intercept bpf syscalls and mock them in userspace, or trace them and make kernel eBPF run with userspace eBPF.
+
+## Run with userspace eBPF
+
+The default behavior is to run with userspace eBPF. Using userspace eBPF means using userspace eBPF maps in shared memory, using userspace eBPF verifier and userspace eBPF runtime.
+
+## run with kernel
+
+Set the environment variable `BPFTIME_RUN_WITH_KERNEL` to `true` to make the kernel eBPF run with userspace eBPF. This means using kernel eBPF maps instead of userspace eBPF maps, and using kernel eBPF verifier instead of userspace eBPF verifier.
+
+```sh
+BPFTIME_RUN_WITH_KERNEL=true
+```
+
+example:
+
+```sh
+SPDLOG_LEVEL=Debug BPFTIME_RUN_WITH_KERNEL=true LD_PRELOAD=build/runtime/syscall-server/libbpftime-syscall-server.so example/malloc/malloc
+```

--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -353,6 +353,11 @@ long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 			-1 /* let the shm alloc fd for us */, prog_fd,
 			target_fd);
 		SPDLOG_DEBUG("Created link {}", id);
+		if (bpftime_is_prog_fd(prog_fd) && bpftime_is_perf_event_fd(target_fd)) {
+			SPDLOG_DEBUG("Attaching map {} to prog {}", target_fd,
+				     prog_fd);
+			bpftime_attach_perf_to_bpf(target_fd, prog_fd);
+		}
 		return id;
 	}
 	case BPF_MAP_FREEZE: {

--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -14,7 +14,20 @@
 #include <sys/epoll.h>
 #include <sys/mman.h>
 #include <unistd.h>
+#include <bpf/bpf.h>
+
 using namespace bpftime;
+
+void syscall_context::load_config_from_env()
+{
+	const char *run_with_kernel_env = getenv("BPFTIME_RUN_WITH_KERNEL");
+	if (run_with_kernel_env != nullptr) {
+		run_with_kernel = true;
+		SPDLOG_INFO("Using kernel eBPF runtime and maps");
+	} else {
+		run_with_kernel = false;
+	}
+}
 
 void syscall_context::try_startup()
 {
@@ -25,11 +38,49 @@ void syscall_context::try_startup()
 
 int syscall_context::handle_close(int fd)
 {
-	if (!enable_mock)
+	if (!enable_mock || run_with_kernel)
 		return orig_close_fn(fd);
 	try_startup();
 	bpftime_close(fd);
 	return orig_close_fn(fd);
+}
+
+int syscall_context::create_kernel_bpf_map(int map_fd)
+{
+	bpf_map_info info = {};
+	uint32_t info_len = sizeof(info);
+	int res = bpf_obj_get_info_by_fd(map_fd, &info, &info_len);
+	if (res < 0) {
+		SPDLOG_ERROR("Failed to get map info for id {}", info.id);
+		return -1;
+	}
+	bpftime::bpf_map_attr attr;
+	// convert type to kernel-user type
+	attr.type = info.type + KERNEL_USER_MAP_OFFSET;
+	attr.key_size = info.key_size;
+	attr.value_size = info.value_size;
+	attr.max_ents = info.max_entries;
+	attr.flags = info.map_flags;
+	attr.kernel_bpf_map_id = info.id;
+	attr.btf_id = info.btf_id;
+	attr.btf_key_type_id = info.btf_key_type_id;
+	attr.btf_value_type_id = info.btf_value_type_id;
+	attr.btf_vmlinux_value_type_id = info.btf_vmlinux_value_type_id;
+	attr.ifindex = info.ifindex;
+
+	if (bpftime_is_map_fd(info.id)) {
+		// check whether the map is exist
+		SPDLOG_INFO("map {} already exists", info.id);
+		return 0;
+	}
+
+	res = bpftime_maps_create(info.id, info.name, attr);
+	if (res < 0) {
+		SPDLOG_ERROR("Failed to create map for id {}", info.id);
+		return -1;
+	}
+	SPDLOG_INFO("create map in kernel id {}", info.id);
+	return map_fd;
 }
 
 long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
@@ -42,6 +93,14 @@ long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 	char *errmsg;
 	switch (cmd) {
 	case BPF_MAP_CREATE: {
+		if (run_with_kernel) {
+			SPDLOG_DEBUG("Creating kernel map");
+			int fd = orig_syscall_fn(__NR_bpf, (long)cmd,
+						 (long)(uintptr_t)attr,
+						 (long)size);
+			SPDLOG_DEBUG("Created kernel map {}", fd);
+			return create_kernel_bpf_map(fd);
+		}
 		SPDLOG_DEBUG("Creating map");
 		int id = bpftime_maps_create(
 			-1 /* let the shm alloc fd for us */, attr->map_name,
@@ -66,6 +125,11 @@ long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 	}
 	case BPF_MAP_LOOKUP_ELEM: {
 		SPDLOG_DEBUG("Looking up map {}", attr->map_fd);
+		if (run_with_kernel) {
+			return orig_syscall_fn(__NR_bpf, (long)cmd,
+					       (long)(uintptr_t)attr,
+					       (long)size);
+		}
 		// Note that bpftime_map_lookup_elem is adapted as a bpf helper,
 		// meaning that it will *return* the address of the matched
 		// value. But here the syscall has a different interface. Here
@@ -84,6 +148,11 @@ long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 	}
 	case BPF_MAP_UPDATE_ELEM: {
 		SPDLOG_DEBUG("Updating map");
+		if (run_with_kernel) {
+			return orig_syscall_fn(__NR_bpf, (long)cmd,
+					       (long)(uintptr_t)attr,
+					       (long)size);
+		}
 		return bpftime_map_update_elem(
 			attr->map_fd, (const void *)(uintptr_t)attr->key,
 			(const void *)(uintptr_t)attr->value,
@@ -91,11 +160,21 @@ long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 	}
 	case BPF_MAP_DELETE_ELEM: {
 		SPDLOG_DEBUG("Deleting map");
+		if (run_with_kernel) {
+			return orig_syscall_fn(__NR_bpf, (long)cmd,
+					       (long)(uintptr_t)attr,
+					       (long)size);
+		}
 		return bpftime_map_delete_elem(
 			attr->map_fd, (const void *)(uintptr_t)attr->key);
 	}
 	case BPF_MAP_GET_NEXT_KEY: {
 		SPDLOG_DEBUG("Getting next key");
+		if (run_with_kernel) {
+			return orig_syscall_fn(__NR_bpf, (long)cmd,
+					       (long)(uintptr_t)attr,
+					       (long)size);
+		}
 		return (long)(uintptr_t)bpftime_map_get_next_key(
 			attr->map_fd, (const void *)(uintptr_t)attr->key,
 			(void *)(uintptr_t)attr->next_key);
@@ -109,7 +188,11 @@ long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 				(const char *)(uintptr_t)attr->license,
 				attr->prog_type, attr->attach_type,
 				attr->map_type);
-
+			if (run_with_kernel) {
+				return orig_syscall_fn(__NR_bpf, (long)cmd,
+						       (long)(uintptr_t)attr,
+						       (long)size);
+			}
 			// tracepoint -> BPF_PROG_TYPE_TRACEPOINT
 			// uprobe/uretprobe -> BPF_PROG_TYPE_SOCKET_FILTER
 			std::optional<std::string> simple_section_name;
@@ -123,7 +206,7 @@ long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 			// Only do verification for tracepoint/uprobe/uretprobe
 			if (simple_section_name.has_value()) {
 				SPDLOG_DEBUG("Verying program {}",
-					      attr->prog_name);
+					     attr->prog_name);
 				auto result = verifier::verify_ebpf_program(
 					(uint64_t *)(uintptr_t)attr->insns,
 					(size_t)attr->insn_cnt,
@@ -166,13 +249,18 @@ long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 				(size_t)attr->insn_cnt, attr->prog_name,
 				attr->prog_type);
 			SPDLOG_DEBUG("Loaded program `{}` id={}",
-				      attr->prog_name, id);
+				     attr->prog_name, id);
 			return id;
 		}
 	case BPF_LINK_CREATE: {
 		auto prog_fd = attr->link_create.prog_fd;
 		auto target_fd = attr->link_create.target_fd;
 		SPDLOG_DEBUG("Creating link {} -> {}", prog_fd, target_fd);
+		if (run_with_kernel && !bpftime_is_perf_event_fd(target_fd)) {
+			return orig_syscall_fn(__NR_bpf, (long)cmd,
+					       (long)(uintptr_t)attr,
+					       (long)size);
+		}
 		int id = bpftime_link_create(
 			-1 /* let the shm alloc fd for us */, prog_fd,
 			target_fd);
@@ -180,11 +268,21 @@ long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 		return id;
 	}
 	case BPF_MAP_FREEZE: {
+		if (run_with_kernel) {
+			return orig_syscall_fn(__NR_bpf, (long)cmd,
+					       (long)(uintptr_t)attr,
+					       (long)size);
+		}
 		SPDLOG_DEBUG(
 			"Calling bpf map freeze, but we didn't implement this");
 		return 0;
 	}
 	case BPF_OBJ_GET_INFO_BY_FD: {
+		if (run_with_kernel) {
+			return orig_syscall_fn(__NR_bpf, (long)cmd,
+					       (long)(uintptr_t)attr,
+					       (long)size);
+		}
 		SPDLOG_DEBUG("Getting info by fd");
 		bpftime::bpf_map_attr map_attr;
 		const char *map_name;
@@ -218,6 +316,11 @@ long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 		auto prog_fd = attr->attach_bpf_fd;
 		auto target_fd = attr->target_fd;
 		SPDLOG_DEBUG("BPF_PROG_ATTACH {} -> {}", prog_fd, target_fd);
+		if (run_with_kernel && !bpftime_is_perf_event_fd(target_fd)) {
+			return orig_syscall_fn(__NR_bpf, (long)cmd,
+					       (long)(uintptr_t)attr,
+					       (long)size);
+		}
 		int id = bpftime_attach_perf_to_bpf(target_fd, prog_fd);
 		SPDLOG_DEBUG("Created attach {}", id);
 		return id;
@@ -278,7 +381,8 @@ int syscall_context::handle_perfevent(perf_event_attr *attr, pid_t pid, int cpu,
 			true);
 		SPDLOG_DEBUG("Created ureplace with fd {}", fd);
 		return fd;
-	} else if ((int)attr->type == (int)bpf_event_type::BPF_TYPE_UPROBE_OVERRIDE) {
+	} else if ((int)attr->type ==
+		   (int)bpf_event_type::BPF_TYPE_UPROBE_OVERRIDE) {
 		SPDLOG_DEBUG("Detected ufiltered hook");
 		const char *name = (const char *)(uintptr_t)attr->config1;
 		uint64_t offset = attr->config2;
@@ -297,7 +401,7 @@ int syscall_context::handle_perfevent(perf_event_attr *attr, pid_t pid, int cpu,
 void *syscall_context::handle_mmap(void *addr, size_t length, int prot,
 				   int flags, int fd, off64_t offset)
 {
-	if (!enable_mock)
+	if (!enable_mock || run_with_kernel)
 		return orig_mmap_fn(addr, length, prot, flags, fd, offset);
 	try_startup();
 	SPDLOG_DEBUG("Called normal mmap");
@@ -307,13 +411,12 @@ void *syscall_context::handle_mmap(void *addr, size_t length, int prot,
 void *syscall_context::handle_mmap64(void *addr, size_t length, int prot,
 				     int flags, int fd, off64_t offset)
 {
-	if (!enable_mock)
+	if (!enable_mock || run_with_kernel)
 		return orig_mmap64_fn(addr, length, prot, flags, fd, offset);
 	try_startup();
 	SPDLOG_DEBUG("Calling mocked mmap64");
 	if (fd != -1 && bpftime_is_ringbuf_map(fd)) {
-		SPDLOG_DEBUG("Entering mmap64 handling for ringbuf fd: {}",
-			      fd);
+		SPDLOG_DEBUG("Entering mmap64 handling for ringbuf fd: {}", fd);
 		if (prot == (PROT_WRITE | PROT_READ)) {
 			if (auto ptr = bpftime_get_ringbuf_consumer_page(fd);
 			    ptr != nullptr) {
@@ -367,6 +470,9 @@ int syscall_context::handle_ioctl(int fd, unsigned long req, int data)
 	int res;
 	if (req == PERF_EVENT_IOC_ENABLE) {
 		SPDLOG_DEBUG("Enabling perf event {}", fd);
+		if (run_with_kernel && !bpftime_is_perf_event_fd(fd)) {
+			return orig_ioctl_fn(fd, req, data);
+		}
 		res = bpftime_perf_event_enable(fd);
 		if (res >= 0)
 			return res;
@@ -375,6 +481,9 @@ int syscall_context::handle_ioctl(int fd, unsigned long req, int data)
 			res);
 	} else if (req == PERF_EVENT_IOC_DISABLE) {
 		SPDLOG_DEBUG("Disabling perf event {}", fd);
+		if (run_with_kernel && !bpftime_is_perf_event_fd(fd)) {
+			return orig_ioctl_fn(fd, req, data);
+		}
 		res = bpftime_perf_event_disable(fd);
 		if (res >= 0)
 			return res;
@@ -383,7 +492,10 @@ int syscall_context::handle_ioctl(int fd, unsigned long req, int data)
 			res);
 	} else if (req == PERF_EVENT_IOC_SET_BPF) {
 		SPDLOG_DEBUG("Setting bpf for perf event {} and bpf {}", fd,
-			      data);
+			     data);
+		if (run_with_kernel && !bpftime_is_perf_event_fd(fd)) {
+			return orig_ioctl_fn(fd, req, data);
+		}
 		res = bpftime_attach_perf_to_bpf(fd, data);
 		if (res >= 0)
 			return res;
@@ -397,7 +509,7 @@ int syscall_context::handle_ioctl(int fd, unsigned long req, int data)
 
 int syscall_context::handle_epoll_create1(int flags)
 {
-	if (!enable_mock)
+	if (!enable_mock || run_with_kernel)
 		return orig_epoll_create1_fn(flags);
 	try_startup();
 	return bpftime_epoll_create();
@@ -406,7 +518,7 @@ int syscall_context::handle_epoll_create1(int flags)
 int syscall_context::handle_epoll_ctl(int epfd, int op, int fd,
 				      epoll_event *evt)
 {
-	if (!enable_mock)
+	if (!enable_mock || run_with_kernel)
 		return orig_epoll_ctl_fn(epfd, op, fd, evt);
 	try_startup();
 	if (op == EPOLL_CTL_ADD) {
@@ -435,7 +547,7 @@ int syscall_context::handle_epoll_ctl(int epfd, int op, int fd,
 int syscall_context::handle_epoll_wait(int epfd, epoll_event *evt,
 				       int maxevents, int timeout)
 {
-	if (!enable_mock)
+	if (!enable_mock || run_with_kernel)
 		orig_epoll_wait_fn(epfd, evt, maxevents, timeout);
 	try_startup();
 	if (bpftime_is_epoll_handler(epfd)) {
@@ -447,13 +559,13 @@ int syscall_context::handle_epoll_wait(int epfd, epoll_event *evt,
 
 int syscall_context::handle_munmap(void *addr, size_t size)
 {
-	if (!enable_mock)
+	if (!enable_mock || run_with_kernel)
 		orig_munmap_fn(addr, size);
 	try_startup();
 	if (auto itr = mocked_mmap_values.find((uintptr_t)addr);
 	    itr != mocked_mmap_values.end()) {
 		SPDLOG_DEBUG("Handling munmap of mocked addr: {:x}, size {}",
-			      (uintptr_t)addr, size);
+			     (uintptr_t)addr, size);
 		mocked_mmap_values.erase(itr);
 		return 0;
 	} else {

--- a/runtime/syscall-server/syscall_context.hpp
+++ b/runtime/syscall-server/syscall_context.hpp
@@ -12,6 +12,7 @@
 #include <sys/types.h>
 #include <spdlog/spdlog.h>
 #include <unordered_set>
+
 class syscall_context {
 	using syscall_fn = long (*)(long, ...);
 	using close_fn = int (*)(int);
@@ -30,7 +31,7 @@ class syscall_context {
 	epoll_wait_fn orig_epoll_wait_fn = nullptr;
 	munmap_fn orig_munmap_fn = nullptr;
 	mmap_fn orig_mmap_fn = nullptr;
-	
+
 	std::unordered_set<uintptr_t> mocked_mmap_values;
 	void init_original_functions()
 	{
@@ -57,13 +58,18 @@ class syscall_context {
 			(uintptr_t)orig_munmap_fn, (uintptr_t)orig_mmap_fn);
 	}
 
-	void try_startup();
+	int create_kernel_bpf_map(int fd);
 
+	void try_startup();
+	bool run_with_kernel = false;
+	void load_config_from_env();
     public:
+
 	bool enable_mock = true;
 	syscall_context()
 	{
 		init_original_functions();
+		load_config_from_env();
 		SPDLOG_INFO("manager constructed");
 	}
 	syscall_fn orig_syscall_fn = nullptr;

--- a/runtime/syscall-server/syscall_context.hpp
+++ b/runtime/syscall-server/syscall_context.hpp
@@ -59,9 +59,13 @@ class syscall_context {
 	}
 
 	int create_kernel_bpf_map(int fd);
+	int create_kernel_bpf_prog_in_userspace(int cmd,
+							 union bpf_attr *attr,
+							 size_t size);
 
 	void try_startup();
 	bool run_with_kernel = false;
+	std::string by_pass_kernel_verifier_pattern;
 	void load_config_from_env();
     public:
 

--- a/runtime/syscall-server/syscall_context.hpp
+++ b/runtime/syscall-server/syscall_context.hpp
@@ -62,13 +62,20 @@ class syscall_context {
 	int create_kernel_bpf_prog_in_userspace(int cmd,
 							 union bpf_attr *attr,
 							 size_t size);
-
+	// try loading the bpf syscall helpers.
+	// if the syscall original function is not prepared, if will cause a
+	// segfault.
 	void try_startup();
+	// enable userspace eBPF runing with kernel eBPF.
 	bool run_with_kernel = false;
+	// allow programs to by pass the verifier
+	// some extensions are not supported by the verifier, so we need to
+	// by pass the verifier to make it work.
 	std::string by_pass_kernel_verifier_pattern;
 	void load_config_from_env();
     public:
 
+	// enable mock the syscall behavior in userspace
 	bool enable_mock = true;
 	syscall_context()
 	{


### PR DESCRIPTION
<!--# Pull Request Template-->

## Description

Currently, if we want running uprobe with kprobe, we need to use the daemon. This PR make LD_PRELOAD server can run krpobe or use kernel verifier.

Also improve documents.

## Type of change

<!--Please delete options that are not relevant.-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
