### PR TITLE
runtime: remove attach type replace, rename filter to override

### DIFF
--- a/runtime/src/attach/attach_manager/base_attach_manager.hpp
+++ b/runtime/src/attach/attach_manager/base_attach_manager.hpp
@@ -40,10 +40,10 @@ class base_attach_manager {
 	using uprobe_callback = std::function<void(const pt_regs &regs)>;
 	using uretprobe_callback = std::function<void(const pt_regs &regs)>;
 	using replace_callback = std::function<uint64_t(const pt_regs &regs)>;
-	using filter_callback = std::function<bool(const pt_regs &regs)>;
+	using uprobe_override_callback = std::function<void(const pt_regs &regs)>;
 	using callback_variant =
 		std::variant<uprobe_callback, uretprobe_callback,
-			     replace_callback, filter_callback>;
+			     replace_callback, uprobe_override_callback>;
 	using attach_iterate_callback =
 		std::function<void(int id, const void *addr, attach_type ty)>;
 
@@ -59,7 +59,7 @@ class base_attach_manager {
 	virtual int attach_replace_at(void *func_addr,
 				      replace_callback &&cb) = 0;
 
-	virtual int attach_filter_at(void *func_addr, filter_callback &&cb) = 0;
+	virtual int attach_uprobe_override_at(void *func_addr, uprobe_override_callback &&cb) = 0;
 	virtual int destroy_attach(int id) = 0;
 	virtual int destroy_attach_by_func_addr(const void *func) = 0;
 	virtual void iterate_attaches(attach_iterate_callback cb) = 0;

--- a/runtime/src/attach/attach_manager/base_attach_manager.hpp
+++ b/runtime/src/attach/attach_manager/base_attach_manager.hpp
@@ -26,24 +26,27 @@ enum class attach_type {
 	// Invoked when the attached function was invoked, receiving the input
 	// args of that function
 	URETPROBE = 1,
-	// Use the provided callback to replace the function. Call the callback
-	// instead of the original function
-	REPLACE = 2,
+	// // Use the provided callback to replace the function. Call the
+	// callback
+	// // instead of the original function
+	// REPLACE = 2,
 	// Run before the original function was invoked. Use bpf_override_return
 	// to set the return value of the function. If the return value is set,
 	// the original function will not be invoked.
-	UPROBE_OVERRIDE = 3
+	UPROBE_OVERRIDE = 2
 };
 
 class base_attach_manager {
     public:
 	using uprobe_callback = std::function<void(const pt_regs &regs)>;
 	using uretprobe_callback = std::function<void(const pt_regs &regs)>;
-	using replace_callback = std::function<uint64_t(const pt_regs &regs)>;
-	using uprobe_override_callback = std::function<void(const pt_regs &regs)>;
+	// using replace_callback = std::function<uint64_t(const pt_regs
+	// &regs)>;
+	using uprobe_override_callback =
+		std::function<void(const pt_regs &regs)>;
 	using callback_variant =
 		std::variant<uprobe_callback, uretprobe_callback,
-			     replace_callback, uprobe_override_callback>;
+			     uprobe_override_callback>;
 	using attach_iterate_callback =
 		std::function<void(int id, const void *addr, attach_type ty)>;
 
@@ -56,10 +59,12 @@ class base_attach_manager {
 	virtual int attach_uprobe_at(void *func_addr, uprobe_callback &&cb) = 0;
 	virtual int attach_uretprobe_at(void *func_addr,
 					uretprobe_callback &&cb) = 0;
-	virtual int attach_replace_at(void *func_addr,
-				      replace_callback &&cb) = 0;
+	// virtual int attach_replace_at(void *func_addr,
+	// 			      replace_callback &&cb) = 0;
 
-	virtual int attach_uprobe_override_at(void *func_addr, uprobe_override_callback &&cb) = 0;
+	virtual int
+	attach_uprobe_override_at(void *func_addr,
+				  uprobe_override_callback &&cb) = 0;
 	virtual int destroy_attach(int id) = 0;
 	virtual int destroy_attach_by_func_addr(const void *func) = 0;
 	virtual void iterate_attaches(attach_iterate_callback cb) = 0;

--- a/runtime/src/attach/attach_manager/base_attach_manager.hpp
+++ b/runtime/src/attach/attach_manager/base_attach_manager.hpp
@@ -26,10 +26,6 @@ enum class attach_type {
 	// Invoked when the attached function was invoked, receiving the input
 	// args of that function
 	URETPROBE = 1,
-	// // Use the provided callback to replace the function. Call the
-	// callback
-	// // instead of the original function
-	// REPLACE = 2,
 	// Run before the original function was invoked. Use bpf_override_return
 	// to set the return value of the function. If the return value is set,
 	// the original function will not be invoked.
@@ -40,8 +36,6 @@ class base_attach_manager {
     public:
 	using uprobe_callback = std::function<void(const pt_regs &regs)>;
 	using uretprobe_callback = std::function<void(const pt_regs &regs)>;
-	// using replace_callback = std::function<uint64_t(const pt_regs
-	// &regs)>;
 	using uprobe_override_callback =
 		std::function<void(const pt_regs &regs)>;
 	using callback_variant =
@@ -59,8 +53,6 @@ class base_attach_manager {
 	virtual int attach_uprobe_at(void *func_addr, uprobe_callback &&cb) = 0;
 	virtual int attach_uretprobe_at(void *func_addr,
 					uretprobe_callback &&cb) = 0;
-	// virtual int attach_replace_at(void *func_addr,
-	// 			      replace_callback &&cb) = 0;
 
 	virtual int
 	attach_uprobe_override_at(void *func_addr,

--- a/runtime/src/attach/attach_manager/frida_attach_manager.cpp
+++ b/runtime/src/attach/attach_manager/frida_attach_manager.cpp
@@ -125,12 +125,6 @@ int frida_attach_manager::attach_uretprobe_at(void *func_addr,
 			cb));
 }
 
-// int frida_attach_manager::attach_replace_at(void *func_addr,
-// 					    replace_callback &&cb)
-// {
-// 	return attach_at(func_addr, cb);
-// }
-
 int frida_attach_manager::attach_uprobe_override_at(
 	void *func_addr, uprobe_override_callback &&cb)
 {
@@ -267,18 +261,6 @@ frida_internal_attach_entry::frida_internal_attach_entry(
 				user_ret_ctx = ctx;
 			});
 	}
-	// else if (basic_attach_type == attach_type::REPLACE) {
-	// 	if (int err = gum_interceptor_replace(
-	// 		    interceptor, function,
-	// 		    (void
-	// *)__bpftime_frida_attach_manager__replace_handler, 		    this, nullptr);
-	// 	    err < 0) {
-	// 		SPDLOG_ERROR(
-	// 			"Failed to execute frida replace for function
-	// {:x}, when attaching replace, err={}", 			(uintptr_t)function, err);
-	// 		throw std::runtime_error("Failed to attach replace");
-	// 	}
-	// }
 	this->interceptor = gum_object_ref(interceptor);
 }
 
@@ -300,8 +282,7 @@ frida_internal_attach_entry::~frida_internal_attach_entry()
 bool frida_internal_attach_entry::has_override() const
 {
 	for (auto v : user_attaches) {
-		if ( // v->get_type() == attach_type::REPLACE ||
-			v->get_type() == attach_type::UPROBE_OVERRIDE) {
+		if (v->get_type() == attach_type::UPROBE_OVERRIDE) {
 			return true;
 		}
 	}
@@ -318,21 +299,6 @@ bool frida_internal_attach_entry::has_uprobe_or_uretprobe() const
 	}
 	return false;
 }
-
-// base_attach_manager::replace_callback &
-// frida_internal_attach_entry::get_replace_callback() const
-// {
-// 	for (auto v : user_attaches) {
-// 		if (v->get_type() == attach_type::REPLACE) {
-// 			return std::get<base_attach_manager::replace_callback>(
-// 				v->cb);
-// 		}
-// 	}
-// 	SPDLOG_ERROR(
-// 		"Replace attach not found at function {:x}, but try to get replace callback",
-// 		(uintptr_t)function);
-// 	throw std::runtime_error("Unable to find replace callback");
-// }
 
 base_attach_manager::uprobe_override_callback &
 frida_internal_attach_entry::get_filter_callback() const
@@ -372,22 +338,6 @@ void frida_internal_attach_entry::iterate_uretprobe_callbacks(
 } // namespace bpftime
 
 using namespace bpftime;
-
-// extern "C" uint64_t __bpftime_frida_attach_manager__replace_handler()
-// {
-// 	GumInvocationContext *ctx;
-// 	pt_regs regs;
-
-// 	ctx = gum_interceptor_get_current_invocation();
-// 	convert_gum_cpu_context_to_pt_regs(*ctx->cpu_context, regs);
-// 	frida_internal_attach_entry *hook_entry =
-// 		(frida_internal_attach_entry *)
-// 			gum_invocation_context_get_replacement_data(ctx);
-// 	auto &cb = hook_entry->get_replace_callback();
-// 	uint64_t ret = cb(regs);
-// 	gum_invocation_context_replace_return_value(ctx, (gpointer)ret);
-// 	return ret;
-// }
 
 extern "C" void *__bpftime_frida_attach_manager__override_handler()
 {

--- a/runtime/src/attach/attach_manager/frida_attach_manager.cpp
+++ b/runtime/src/attach/attach_manager/frida_attach_manager.cpp
@@ -62,7 +62,7 @@ void *frida_attach_manager::resolve_function_addr_by_module_offset(
 	}
 	if (!module_base_addr) {
 		SPDLOG_ERROR("Failed to find module base address for {}",
-			      module_name);
+			     module_name);
 		return nullptr;
 	}
 
@@ -131,10 +131,14 @@ int frida_attach_manager::attach_replace_at(void *func_addr,
 	return attach_at(func_addr, cb);
 }
 
-int frida_attach_manager::attach_filter_at(void *func_addr,
-					   filter_callback &&cb)
+int frida_attach_manager::attach_uprobe_override_at(
+	void *func_addr, uprobe_override_callback &&cb)
 {
-	return attach_at(func_addr, cb);
+	return attach_at(
+		func_addr,
+		callback_variant(std::in_place_index_t<(
+					 int)attach_type::UPROBE_OVERRIDE>(),
+				 cb));
 }
 
 int frida_attach_manager::destroy_attach(int id)
@@ -329,12 +333,12 @@ frida_internal_attach_entry::get_replace_callback() const
 	throw std::runtime_error("Unable to find replace callback");
 }
 
-base_attach_manager::filter_callback &
+base_attach_manager::uprobe_override_callback &
 frida_internal_attach_entry::get_filter_callback() const
 {
 	for (auto v : user_attaches) {
 		if (v->get_type() == attach_type::UPROBE_OVERRIDE) {
-			return std::get<base_attach_manager::filter_callback>(
+			return std::get<(int)attach_type::UPROBE_OVERRIDE>(
 				v->cb);
 		}
 	}

--- a/runtime/src/attach/attach_manager/frida_attach_manager.hpp
+++ b/runtime/src/attach/attach_manager/frida_attach_manager.hpp
@@ -55,9 +55,9 @@ class frida_internal_attach_entry {
 	uint64_t user_ret_ctx = 0;
 	override_return_set_callback override_return_callback;
 
-	bool has_replace_or_override() const;
+	bool has_override() const;
 	bool has_uprobe_or_uretprobe() const;
-	base_attach_manager::replace_callback &get_replace_callback() const;
+	// base_attach_manager::replace_callback &get_replace_callback() const;
 	base_attach_manager::uprobe_override_callback &get_filter_callback() const;
 	void iterate_uprobe_callbacks(const pt_regs &regs) const;
 	void iterate_uretprobe_callbacks(const pt_regs &regs) const;
@@ -81,7 +81,7 @@ class frida_attach_manager final : public base_attach_manager {
 		const std::string_view &module_name, uintptr_t func_offset);
 	int attach_uprobe_at(void *func_addr, uprobe_callback &&cb);
 	int attach_uretprobe_at(void *func_addr, uretprobe_callback &&cb);
-	int attach_replace_at(void *func_addr, replace_callback &&cb);
+	// int attach_replace_at(void *func_addr, replace_callback &&cb);
 	int attach_uprobe_override_at(void *func_addr, uprobe_override_callback &&cb);
 	int destroy_attach(int id);
 	void iterate_attaches(attach_iterate_callback cb);

--- a/runtime/src/attach/attach_manager/frida_attach_manager.hpp
+++ b/runtime/src/attach/attach_manager/frida_attach_manager.hpp
@@ -58,7 +58,7 @@ class frida_internal_attach_entry {
 	bool has_replace_or_override() const;
 	bool has_uprobe_or_uretprobe() const;
 	base_attach_manager::replace_callback &get_replace_callback() const;
-	base_attach_manager::filter_callback &get_filter_callback() const;
+	base_attach_manager::uprobe_override_callback &get_filter_callback() const;
 	void iterate_uprobe_callbacks(const pt_regs &regs) const;
 	void iterate_uretprobe_callbacks(const pt_regs &regs) const;
 	frida_internal_attach_entry(const frida_internal_attach_entry &) =
@@ -82,7 +82,7 @@ class frida_attach_manager final : public base_attach_manager {
 	int attach_uprobe_at(void *func_addr, uprobe_callback &&cb);
 	int attach_uretprobe_at(void *func_addr, uretprobe_callback &&cb);
 	int attach_replace_at(void *func_addr, replace_callback &&cb);
-	int attach_filter_at(void *func_addr, filter_callback &&cb);
+	int attach_uprobe_override_at(void *func_addr, uprobe_override_callback &&cb);
 	int destroy_attach(int id);
 	void iterate_attaches(attach_iterate_callback cb);
 

--- a/runtime/src/attach/attach_manager/frida_attach_manager.hpp
+++ b/runtime/src/attach/attach_manager/frida_attach_manager.hpp
@@ -57,7 +57,6 @@ class frida_internal_attach_entry {
 
 	bool has_override() const;
 	bool has_uprobe_or_uretprobe() const;
-	// base_attach_manager::replace_callback &get_replace_callback() const;
 	base_attach_manager::uprobe_override_callback &get_filter_callback() const;
 	void iterate_uprobe_callbacks(const pt_regs &regs) const;
 	void iterate_uretprobe_callbacks(const pt_regs &regs) const;
@@ -81,7 +80,6 @@ class frida_attach_manager final : public base_attach_manager {
 		const std::string_view &module_name, uintptr_t func_offset);
 	int attach_uprobe_at(void *func_addr, uprobe_callback &&cb);
 	int attach_uretprobe_at(void *func_addr, uretprobe_callback &&cb);
-	// int attach_replace_at(void *func_addr, replace_callback &&cb);
 	int attach_uprobe_override_at(void *func_addr, uprobe_override_callback &&cb);
 	int destroy_attach(int id);
 	void iterate_attaches(attach_iterate_callback cb);

--- a/runtime/src/attach/bpf_attach_ctx.cpp
+++ b/runtime/src/attach/bpf_attach_ctx.cpp
@@ -176,16 +176,14 @@ int bpf_attach_ctx::init_attach_ctx_from_handlers(
 						i);
 					return -ENOENT;
 				}
-				err = attach_manager->attach_filter_at(
-					func_addr,
-					[=](const pt_regs &regs) -> bool {
+				err = attach_manager->attach_uprobe_override_at(
+					func_addr, [=](const pt_regs &regs) {
 						uint64_t ret;
 						progs[0].second
 							->bpftime_prog_exec(
 								(void *)&regs,
 								sizeof(regs),
 								&ret);
-						return !ret;
 					});
 				if (err < 0)
 					SPDLOG_ERROR(

--- a/runtime/src/attach/bpf_attach_ctx.cpp
+++ b/runtime/src/attach/bpf_attach_ctx.cpp
@@ -23,6 +23,7 @@
 #include <utility>
 #include <variant>
 #include <sys/resource.h>
+extern "C" uint64_t bpftime_set_retval(uint64_t value);
 namespace bpftime
 {
 
@@ -210,16 +211,17 @@ int bpf_attach_ctx::init_attach_ctx_from_handlers(
 						i);
 					return -ENOENT;
 				}
-				err = attach_manager->attach_replace_at(
-					func_addr,
-					[=](const pt_regs &regs) -> uint64_t {
+				err = attach_manager->attach_uprobe_override_at(
+					func_addr, [=](const pt_regs &regs) {
 						uint64_t ret;
 						progs[0].second
 							->bpftime_prog_exec(
 								(void *)&regs,
 								sizeof(regs),
 								&ret);
-						return ret;
+						// return ret;
+
+						bpftime_set_retval(ret);
 					});
 				if (err < 0)
 					SPDLOG_ERROR(

--- a/runtime/test/src/test_attach_replace.cpp
+++ b/runtime/test/src/test_attach_replace.cpp
@@ -16,6 +16,8 @@
 #include "bpftime_ffi.hpp"
 #include "attach/attach_manager/base_attach_manager.hpp"
 
+extern "C" uint64_t bpftime_set_retval(uint64_t value);
+
 using namespace bpftime;
 
 // This is the original function to hook.
@@ -71,12 +73,12 @@ int main()
 	res = prog->bpftime_prog_load(false);
 	assert(res == 0);
 	// attach
-	int fd = probe_ctx.get_attach_manager().attach_replace_at(
-		(void *)my_function, [=](const pt_regs &regs) -> uint64_t {
+	int fd = probe_ctx.get_attach_manager().attach_uprobe_override_at(
+		(void *)my_function, [=](const pt_regs &regs) {
 			uint64_t ret;
 			prog->bpftime_prog_exec((void *)&regs, sizeof(regs),
 						&ret);
-			return ret;
+			bpftime_set_retval(ret);
 		});
 	assert(fd >= 0);
 

--- a/runtime/unit-test/CMakeLists.txt
+++ b/runtime/unit-test/CMakeLists.txt
@@ -15,8 +15,8 @@ set(TEST_SOURCES
     test_bpftime_shm_json.cpp
     attach/test_uprobe_uretprobe.cpp
     attach/test_function_address_resolve.cpp
-    attach/test_filter_attach.cpp
-    attach/test_replace_attach.cpp
+    attach/test_filter_attach_with_override.cpp
+    attach/test_replace_attach_with_override.cpp
     attach_with_ebpf/test_attach_filter_with_ebpf.cpp
 
     # attach_with_ebpf/test_attach_replace_with_ebpf.cpp # Unfinished yet

--- a/runtime/unit-test/attach/test_filter_attach_with_override.cpp
+++ b/runtime/unit-test/attach/test_filter_attach_with_override.cpp
@@ -14,7 +14,6 @@ __bpftime_func_to_filter(uint64_t a, uint64_t b)
 	asm("");
 	return (a << 32) | b;
 }
-
 __attribute__((__noinline__, optnone, noinline)) static uint64_t
 call_filter_func(uint64_t a, uint64_t b)
 {
@@ -32,15 +31,13 @@ TEST_CASE("Test attaching filter programs and revert")
 	const uint64_t b = 0x1234;
 	const uint64_t expected_result = (a << 32) | b;
 	REQUIRE(__bpftime_func_to_filter(a, b) == expected_result);
-	int id = man.attach_filter_at(
-		func_addr, [&](const pt_regs &regs) -> bool {
+	int id = man.attach_uprobe_override_at(
+		func_addr, [&](const pt_regs &regs) {
 			uint64_t first_arg = regs.di;
 			uint64_t second_arg = regs.si;
 			if (first_arg == a) {
 				bpftime_set_retval(first_arg + second_arg);
-				return true;
 			}
-			return false;
 		});
 	REQUIRE(id >= 0);
 	REQUIRE(__bpftime_func_to_filter(1, 2) == (((uint64_t)1 << 32) | 2));

--- a/runtime/unit-test/attach_with_ebpf/test_attach_filter_with_ebpf.cpp
+++ b/runtime/unit-test/attach_with_ebpf/test_attach_filter_with_ebpf.cpp
@@ -53,14 +53,13 @@ TEST_CASE("Test attaching filter program with ebpf, and reverting")
 	};
 	REQUIRE(prog->bpftime_prog_register_raw_helper(info) >= 0);
 	REQUIRE(prog->bpftime_prog_load(false) >= 0);
-	int id = man.attach_filter_at(
+	int id = man.attach_uprobe_override_at(
 		(void *)__bpftime_attach_filter_with_ebpf__my_function,
-		[=](const pt_regs &regs) -> bool {
+		[=](const pt_regs &regs) {
 			uint64_t ret;
 			REQUIRE(prog->bpftime_prog_exec((void *)&regs,
 							sizeof(regs),
 							&ret) >= 0);
-			return !ret;
 		});
 	REQUIRE(id >= 0);
 	REQUIRE(__bpftime_attach_filter_with_ebpf__my_function("hello aaa", 'c',


### PR DESCRIPTION
This PR removes the implementation of attach type replace in the attach manager, and modifies tests that shipped with replace to override. 

Replace and filter were unified to override now. The override callback was performed before the hooked function's execution. It has access to the arguments, and could override the return value of the hooked function using `bpftime_set_retval`. If `bpftime_set_retval` was called, the original function will not be executed. Otherwise, the execution of the hooked function was not affected.

Closes #112