### PR TITLE
runtime: implement userspace USDT

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: | 
           sudo apt-get update
-          sudo apt-get install binutils-dev libboost1.74-all-dev libelf-dev zlib1g-dev libyaml-cpp-dev gcc-12 g++-12 llvm systemtap-sdt-dev
+          sudo apt-get install binutils-dev libboost1.74-all-dev libelf-dev zlib1g-dev libyaml-cpp-dev gcc-12 g++-12 llvm
       - name: Build and install runtime (with llvm-jit)
         if: ${{matrix.enable_jit}}
         run: |
@@ -146,7 +146,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y zlib1g-dev libelf-dev llvm
+          sudo apt-get install -y zlib1g-dev libelf-dev llvm systemtap-sdt-dev
           sudo mkdir /mnt/ramdisk
       - name: Build test assets
         run: |

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -114,6 +114,11 @@ jobs:
             victim: ./victim
             syscall_trace: false
             expected_str: "See /sys/kernel/debug/tracing/trace_pipe for output (15)"
+          - path: usdt_minimal
+            executable: ./usdt_minimal
+            victim: ./victim
+            syscall_trace: false
+            expected_str: "bpf:"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: | 
           sudo apt-get update
-          sudo apt-get install binutils-dev libboost1.74-all-dev libelf-dev zlib1g-dev libyaml-cpp-dev gcc-12 g++-12 llvm
+          sudo apt-get install binutils-dev libboost1.74-all-dev libelf-dev zlib1g-dev libyaml-cpp-dev gcc-12 g++-12 llvm systemtap-sdt-dev
       - name: Build and install runtime (with llvm-jit)
         if: ${{matrix.enable_jit}}
         run: |

--- a/example/usdt_minimal/.gitignore
+++ b/example/usdt_minimal/.gitignore
@@ -1,0 +1,11 @@
+.vscode
+package.json
+*.o
+*.skel.json
+*.skel.yaml
+package.yaml
+ecli
+.output
+test
+victim
+usdt_minimal

--- a/example/usdt_minimal/Makefile
+++ b/example/usdt_minimal/Makefile
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+OUTPUT := .output
+CLANG ?= clang
+LIBBPF_SRC := $(abspath ../../third_party/libbpf/src)
+BPFTOOL_SRC := $(abspath ../../third_party/bpftool/src)
+LIBBPF_OBJ := $(abspath $(OUTPUT)/libbpf.a)
+BPFTOOL_OUTPUT ?= $(abspath $(OUTPUT)/bpftool)
+BPFTOOL ?= $(BPFTOOL_OUTPUT)/bootstrap/bpftool
+ARCH ?= $(shell uname -m | sed 's/x86_64/x86/' \
+			 | sed 's/arm.*/arm/' \
+			 | sed 's/aarch64/arm64/' \
+			 | sed 's/ppc64le/powerpc/' \
+			 | sed 's/mips.*/mips/' \
+			 | sed 's/riscv64/riscv/' \
+			 | sed 's/loongarch64/loongarch/')
+VMLINUX := ../../third_party/vmlinux/$(ARCH)/vmlinux.h
+# Use our own libbpf API headers and Linux UAPI headers distributed with
+# libbpf to avoid dependency on system-wide headers, which could be missing or
+# outdated
+INCLUDES := -I$(OUTPUT) -I../../third_party/libbpf/include/uapi -I$(dir $(VMLINUX))
+CFLAGS := -g -Wall
+ALL_LDFLAGS := $(LDFLAGS) $(EXTRA_LDFLAGS)
+
+APPS = usdt_minimal
+
+CARGO ?= $(shell which cargo)
+ifeq ($(strip $(CARGO)),)
+BZS_APPS :=
+else
+BZS_APPS := # profile
+APPS += $(BZS_APPS)
+# Required by libblazesym
+ALL_LDFLAGS += -lrt -ldl -lpthread -lm
+endif
+
+# Get Clang's default includes on this system. We'll explicitly add these dirs
+# to the includes list when compiling with `-target bpf` because otherwise some
+# architecture-specific dirs will be "missing" on some architectures/distros -
+# headers such as asm/types.h, asm/byteorder.h, asm/socket.h, asm/sockios.h,
+# sys/cdefs.h etc. might be missing.
+#
+# Use '-idirafter': Don't interfere with include mechanics except where the
+# build would have failed anyways.
+CLANG_BPF_SYS_INCLUDES ?= $(shell $(CLANG) -v -E - </dev/null 2>&1 \
+	| sed -n '/<...> search starts here:/,/End of search list./{ s| \(/.*\)|-idirafter \1|p }')
+
+ifeq ($(V),1)
+	Q =
+	msg =
+else
+	Q = @
+	msg = @printf '  %-8s %s%s\n'					\
+		      "$(1)"						\
+		      "$(patsubst $(abspath $(OUTPUT))/%,%,$(2))"	\
+		      "$(if $(3), $(3))";
+	MAKEFLAGS += --no-print-directory
+endif
+
+define allow-override
+  $(if $(or $(findstring environment,$(origin $(1))),\
+            $(findstring command line,$(origin $(1)))),,\
+    $(eval $(1) = $(2)))
+endef
+
+$(call allow-override,CC,$(CROSS_COMPILE)cc)
+$(call allow-override,LD,$(CROSS_COMPILE)ld)
+
+.PHONY: all
+all: $(APPS) victim
+
+victim: victim.cpp
+	g++ victim.cpp -o victim -Wall -g
+
+.PHONY: clean
+clean:
+	$(call msg,CLEAN)
+	$(Q)rm -rf $(OUTPUT) $(APPS)
+
+$(OUTPUT) $(OUTPUT)/libbpf $(BPFTOOL_OUTPUT):
+	$(call msg,MKDIR,$@)
+	$(Q)mkdir -p $@
+
+# Build libbpf
+$(LIBBPF_OBJ): $(wildcard $(LIBBPF_SRC)/*.[ch] $(LIBBPF_SRC)/Makefile) | $(OUTPUT)/libbpf
+	$(call msg,LIB,$@)
+	$(Q)$(MAKE) -C $(LIBBPF_SRC) BUILD_STATIC_ONLY=1		      \
+		    OBJDIR=$(dir $@)/libbpf DESTDIR=$(dir $@)		      \
+		    INCLUDEDIR= LIBDIR= UAPIDIR=			      \
+		    install
+
+# Build bpftool
+$(BPFTOOL): | $(BPFTOOL_OUTPUT)
+	$(call msg,BPFTOOL,$@)
+	$(Q)$(MAKE) ARCH= CROSS_COMPILE= OUTPUT=$(BPFTOOL_OUTPUT)/ -C $(BPFTOOL_SRC) bootstrap
+
+
+$(LIBBLAZESYM_SRC)/target/release/libblazesym.a::
+	$(Q)cd $(LIBBLAZESYM_SRC) && $(CARGO) build --features=cheader,dont-generate-test-files --release
+
+$(LIBBLAZESYM_OBJ): $(LIBBLAZESYM_SRC)/target/release/libblazesym.a | $(OUTPUT)
+	$(call msg,LIB, $@)
+	$(Q)cp $(LIBBLAZESYM_SRC)/target/release/libblazesym.a $@
+
+$(LIBBLAZESYM_HEADER): $(LIBBLAZESYM_SRC)/target/release/libblazesym.a | $(OUTPUT)
+	$(call msg,LIB,$@)
+	$(Q)cp $(LIBBLAZESYM_SRC)/target/release/blazesym.h $@
+
+# Build BPF code
+$(OUTPUT)/%.bpf.o: %.bpf.c $(LIBBPF_OBJ) $(wildcard %.h) $(VMLINUX) | $(OUTPUT) $(BPFTOOL)
+	$(call msg,BPF,$@)
+	$(Q)$(CLANG) -g -O2 -target bpf -D__TARGET_ARCH_$(ARCH)		      \
+		     $(INCLUDES) $(CLANG_BPF_SYS_INCLUDES)		      \
+		     -c $(filter %.c,$^) -o $(patsubst %.bpf.o,%.tmp.bpf.o,$@)
+	$(Q)$(BPFTOOL) gen object $@ $(patsubst %.bpf.o,%.tmp.bpf.o,$@)
+
+# Generate BPF skeletons
+$(OUTPUT)/%.skel.h: $(OUTPUT)/%.bpf.o | $(OUTPUT) $(BPFTOOL)
+	$(call msg,GEN-SKEL,$@)
+	$(Q)$(BPFTOOL) gen skeleton $< > $@
+
+# Build user-space code
+$(patsubst %,$(OUTPUT)/%.o,$(APPS)): %.o: %.skel.h
+
+$(OUTPUT)/%.o: %.c $(wildcard %.h) | $(OUTPUT)
+	$(call msg,CC,$@)
+	$(Q)$(CC) $(CFLAGS) $(INCLUDES) -c $(filter %.c,$^) -o $@
+
+$(patsubst %,$(OUTPUT)/%.o,$(BZS_APPS)): $(LIBBLAZESYM_HEADER)
+
+$(BZS_APPS): $(LIBBLAZESYM_OBJ)
+
+# Build application binary
+$(APPS): %: $(OUTPUT)/%.o $(LIBBPF_OBJ) | $(OUTPUT)
+	$(call msg,BINARY,$@)
+	$(Q)$(CC) $(CFLAGS) $^ $(ALL_LDFLAGS) -lelf -lz -o $@
+
+# delete failed targets
+.DELETE_ON_ERROR:
+
+# keep intermediate (.skel.h, .bpf.o, etc) targets
+.SECONDARY:

--- a/example/usdt_minimal/README.md
+++ b/example/usdt_minimal/README.md
@@ -1,0 +1,1 @@
+# USDT example

--- a/example/usdt_minimal/README.md
+++ b/example/usdt_minimal/README.md
@@ -1,1 +1,3 @@
 # USDT example
+
+This is an example demonstrating USDT. The ebpf program will be hooked onto the tracepoint named `probe1`, and print arguments through `bpf_printk`

--- a/example/usdt_minimal/usdt_minimal.bpf.c
+++ b/example/usdt_minimal/usdt_minimal.bpf.c
@@ -1,0 +1,14 @@
+
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include <bpf/usdt.bpf.h>
+
+SEC("usdt")
+int BPF_USDT(simple_probe, int x, int y, int z)
+{
+	bpf_printk("bpf: %d + %d = %d", x, y, z);
+	return 0;
+}
+
+char LICENSE[] SEC("license") = "Dual BSD/GPL";

--- a/example/usdt_minimal/usdt_minimal.bpf.c
+++ b/example/usdt_minimal/usdt_minimal.bpf.c
@@ -7,7 +7,7 @@
 SEC("usdt")
 int BPF_USDT(simple_probe, int x, int y, int z)
 {
-	bpf_printk("bpf: %d + %d = %d", x, y, z);
+	bpf_printk("bpf: %d + %d = %d\n", x, y, z);
 	return 0;
 }
 

--- a/example/usdt_minimal/usdt_minimal.c
+++ b/example/usdt_minimal/usdt_minimal.c
@@ -4,7 +4,7 @@
 #include <unistd.h>
 #include <setjmp.h>
 #include <linux/limits.h>
-#include "usdt_minimal.skel.h"
+#include ".output/usdt_minimal.skel.h"
 
 static volatile sig_atomic_t exiting;
 

--- a/example/usdt_minimal/usdt_minimal.c
+++ b/example/usdt_minimal/usdt_minimal.c
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+/* Copyright (c) 2022 Hengqi Chen */
+#include <signal.h>
+#include <unistd.h>
+#include <setjmp.h>
+#include <linux/limits.h>
+#include "usdt_minimal.skel.h"
+
+static volatile sig_atomic_t exiting;
+
+static void sig_int(int signo)
+{
+	exiting = 1;
+}
+
+static int libbpf_print_fn(enum libbpf_print_level level, const char *format,
+			   va_list args)
+{
+	return vfprintf(stderr, format, args);
+}
+
+int main(int argc, char **argv)
+{
+	struct usdt_minimal_bpf *skel;
+	int err;
+
+	libbpf_set_print(libbpf_print_fn);
+
+	skel = usdt_minimal_bpf__open();
+	if (!skel) {
+		fprintf(stderr, "Failed to open BPF skeleton\n");
+		return 1;
+	}
+
+	err = usdt_minimal_bpf__load(skel);
+	if (!skel) {
+		fprintf(stderr, "Failed to load BPF skeleton\n");
+		return 1;
+	}
+
+	skel->links.simple_probe =
+		bpf_program__attach_usdt(skel->progs.simple_probe, -1,
+					 "./victim", "victim", "probe1", NULL);
+	if (!skel->links.simple_probe) {
+		err = errno;
+		fprintf(stderr,
+			"Failed to attach BPF program `usdt_manual_attach`: %d\n",
+			err);
+		goto cleanup;
+	}
+
+	if (signal(SIGINT, sig_int) == SIG_ERR) {
+		err = errno;
+		fprintf(stderr, "can't set signal handler: %s\n",
+			strerror(errno));
+		goto cleanup;
+	}
+
+	printf("Successfully started! Please run `sudo cat /sys/kernel/debug/tracing/trace_pipe` "
+	       "to see output of the BPF programs.\n");
+
+	while (!exiting) {
+		/* trigger our BPF programs */
+		fprintf(stderr, ".");
+		sleep(1);
+	}
+
+cleanup:
+	usdt_minimal_bpf__destroy(skel);
+	return -err;
+}

--- a/example/usdt_minimal/victim.cpp
+++ b/example/usdt_minimal/victim.cpp
@@ -1,0 +1,21 @@
+#include <iostream>
+#include <ostream>
+#include <sys/sdt.h>
+#include <random>
+#include <thread>
+using namespace std::chrono_literals;
+int main()
+{
+	std::mt19937 gen;
+	gen.seed(std::random_device()());
+	std::uniform_int_distribution<int> rand(1, 1e6);
+	while (true) {
+		int x = rand(gen);
+		int y = rand(gen);
+		int z = x + y;
+		DTRACE_PROBE3(victim, probe1, x, y, z);
+		std::cout << x << " + " << y << " = " << z << std::endl;
+		std::this_thread::sleep_for(1s);
+	}
+	return 0;
+}

--- a/example/usdt_minimal/victim.cpp
+++ b/example/usdt_minimal/victim.cpp
@@ -15,6 +15,9 @@ int main()
 		int z = x + y;
 		DTRACE_PROBE3(victim, probe1, x, y, z);
 		std::cout << x << " + " << y << " = " << z << std::endl;
+		int x1 = y;
+		int y1 = x;
+		DTRACE_PROBE3(victim, probe1, x1, y1, z);
 		std::this_thread::sleep_for(1s);
 	}
 	return 0;

--- a/runtime/include/bpftime_prog.hpp
+++ b/runtime/include/bpftime_prog.hpp
@@ -7,11 +7,13 @@
 #define _BPFTIME_PROG_HPP
 
 #include <ebpf-vm.h>
-#include <cinttypes>
+#include <optional>
 #include <vector>
 #include <string>
 namespace bpftime
 {
+
+extern thread_local std::optional<uint64_t> current_thread_bpf_cookie;
 
 // executable program for bpf function
 class bpftime_prog {
@@ -31,6 +33,7 @@ class bpftime_prog {
 	// exec in user space
 	int bpftime_prog_exec(void *memory, size_t memory_size,
 			      uint64_t *return_val) const;
+
 	int bpftime_prog_register_raw_helper(struct bpftime_helper_info info);
 	const std::vector<ebpf_inst> &get_insns() const
 	{
@@ -55,7 +58,6 @@ class bpftime_prog {
 	struct bpftime_ffi_ctx *ffi_ctx;
 
 	// kernel runtime
-
 };
 
 } // namespace bpftime

--- a/runtime/include/bpftime_shm.hpp
+++ b/runtime/include/bpftime_shm.hpp
@@ -9,6 +9,7 @@
 #include <boost/interprocess/managed_shared_memory.hpp>
 #include <boost/interprocess/smart_ptr/unique_ptr.hpp>
 #include <boost/interprocess/containers/string.hpp>
+#include <cstdint>
 #include <ebpf-vm.h>
 #include <sys/epoll.h>
 
@@ -242,6 +243,8 @@ int bpftime_perf_event_disable(int fd);
 int bpftime_find_minimal_unused_fd();
 
 int bpftime_attach_perf_to_bpf(int perf_fd, int bpf_fd);
+int bpftime_attach_perf_to_bpf_with_cookie(int perf_fd, int bpf_fd,
+					   uint64_t cookie);
 int bpftime_add_ringbuf_fd_to_epoll(int ringbuf_fd, int epoll_fd,
 				    epoll_data_t extra_data);
 int bpftime_add_software_perf_event_fd_to_epoll(int swpe_fd, int epoll_fd,
@@ -276,6 +279,8 @@ int bpftime_perf_event_output(int fd, const void *buf, size_t sz);
 int bpftime_shared_perf_event_output(int map_fd, const void *buf, size_t sz);
 int bpftime_add_ureplace_or_override(int fd, int pid, const char *name,
 				     uint64_t offset, bool is_replace);
+
+int bpftime_get_current_thread_cookie(uint64_t *out);
 }
 
 #endif // BPFTIME_SHM_CPP_H

--- a/runtime/src/attach/bpf_attach_syscall.cpp
+++ b/runtime/src/attach/bpf_attach_syscall.cpp
@@ -46,7 +46,7 @@ int bpf_attach_ctx::create_tracepoint(int tracepoint_id, int perf_fd,
 				auto &prog = std::get<bpf_prog_handler>(
 					manager->get_handler(i));
 				for (auto v : prog.attach_fds) {
-					if (v == perf_fd) {
+					if (v.first == perf_fd) {
 						progs.push_back(
 							this->progs[i].get());
 						assert(progs.back());

--- a/runtime/src/bpf_helper.cpp
+++ b/runtime/src/bpf_helper.cpp
@@ -327,7 +327,18 @@ uint64_t bpftime_tail_call(uint64_t ctx, uint64_t prog_array, uint64_t index)
 	close(to_call_fd);
 	return run_opts.retval;
 }
-
+uint64_t bpftime_get_attach_cookie(uint64_t ctx, uint64_t, uint64_t, uint64_t,
+				   uint64_t)
+{
+	uint64_t cookie;
+	if (bpftime_get_current_thread_cookie(&cookie)) {
+		SPDLOG_DEBUG("Get cookie: {}", cookie);
+		return cookie;
+	} else {
+		SPDLOG_DEBUG("Cookie doesn't exist");
+		return 0;
+	}
+}
 } // extern "C"
 
 namespace bpftime
@@ -769,7 +780,11 @@ const bpftime_helper_group kernel_helper_group = {
 	  { BPF_FUNC_tail_call,
 	    bpftime_helper_info{ .index = BPF_FUNC_tail_call,
 				 .name = "bpf_tail_call",
-				 .fn = (void *)bpftime_tail_call } } }
+				 .fn = (void *)bpftime_tail_call } },
+	  { BPF_FUNC_get_attach_cookie,
+	    bpftime_helper_info{ .index = BPF_FUNC_get_attach_cookie,
+				 .name = "bpf_get_attach_cookie",
+				 .fn = (void *)bpftime_get_attach_cookie } } }
 
 };
 

--- a/runtime/src/bpftime_prog.cpp
+++ b/runtime/src/bpftime_prog.cpp
@@ -11,11 +11,14 @@
 #include <cstdlib>
 #include <cstdint>
 #include <cstddef>
+#include <optional>
 #include <spdlog/spdlog.h>
 
 using namespace std;
 namespace bpftime
 {
+
+thread_local std::optional<uint64_t> current_thread_bpf_cookie;
 
 bpftime_prog::bpftime_prog(const struct ebpf_inst *insn, size_t insn_cnt,
 			   const char *name)
@@ -85,7 +88,7 @@ int bpftime_prog::bpftime_prog_exec(void *memory, size_t memory_size,
 		this->name);
 	if (jitted) {
 		SPDLOG_DEBUG("Directly call jitted function at {:x}",
-			      (uintptr_t)fn);
+			     (uintptr_t)fn);
 		val = fn(memory, memory_size);
 	} else {
 		SPDLOG_DEBUG("Running using ebpf_exec");

--- a/runtime/src/bpftime_shm.cpp
+++ b/runtime/src/bpftime_shm.cpp
@@ -3,6 +3,7 @@
  * Copyright (c) 2022, eunomia-bpf org
  * All rights reserved.
  */
+#include "bpftime_prog.hpp"
 #include "handler/epoll_handler.hpp"
 #include "handler/map_handler.hpp"
 #include "handler/perf_event_handler.hpp"
@@ -118,9 +119,24 @@ int bpftime_perf_event_disable(int fd)
 int bpftime_attach_perf_to_bpf(int perf_fd, int bpf_fd)
 {
 	return shm_holder.global_shared_memory.attach_perf_to_bpf(perf_fd,
-								  bpf_fd);
+								  bpf_fd, {});
 }
 
+int bpftime_attach_perf_to_bpf_with_cookie(int perf_fd, int bpf_fd,
+					   uint64_t cookie)
+{
+	return shm_holder.global_shared_memory.attach_perf_to_bpf(
+		perf_fd, bpf_fd, cookie);
+}
+
+int bpftime_get_current_thread_cookie(uint64_t *out)
+{
+	if (current_thread_bpf_cookie.has_value()) {
+		*out = *current_thread_bpf_cookie;
+		return 1;
+	}
+	return 0;
+}
 int bpftime_add_ringbuf_fd_to_epoll(int ringbuf_fd, int epoll_fd,
 				    epoll_data_t extra_data)
 {

--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -8,6 +8,7 @@
 #include "handler/perf_event_handler.hpp"
 #include "spdlog/spdlog.h"
 #include <bpftime_shm_internal.hpp>
+#include <cerrno>
 #include <cstdio>
 #include <sys/epoll.h>
 #include <unistd.h>
@@ -198,19 +199,26 @@ int bpftime_shm::add_software_perf_event(int cpu, int32_t sample_type,
 	return fd;
 }
 
-int bpftime_shm::attach_perf_to_bpf(int perf_fd, int bpf_fd)
+int bpftime_shm::attach_perf_to_bpf(int perf_fd, int bpf_fd,
+				    std::optional<uint64_t> cookie)
 {
 	if (!is_perf_fd(perf_fd)) {
 		SPDLOG_ERROR("Fd {} is not a perf fd", perf_fd);
 		errno = ENOENT;
 		return -1;
 	}
-	return add_bpf_prog_attach_target(perf_fd, bpf_fd);
+	return add_bpf_prog_attach_target(perf_fd, bpf_fd, cookie);
 }
 
-int bpftime_shm::add_bpf_prog_attach_target(int perf_fd, int bpf_fd)
+int bpftime_shm::add_bpf_prog_attach_target(int perf_fd, int bpf_fd,
+					    std::optional<uint64_t> cookie)
 {
-	SPDLOG_DEBUG("Try attaching prog fd {} to perf fd {}", bpf_fd, perf_fd);
+	SPDLOG_DEBUG("Try attaching prog fd {} to perf fd {}, with cookie = {}",
+		     bpf_fd, perf_fd, cookie.has_value());
+	if (cookie) {
+		SPDLOG_DEBUG("With cookie: {}", *cookie);
+	}
+
 	if (!is_prog_fd(bpf_fd)) {
 		SPDLOG_ERROR("Fd {} is not a prog fd", bpf_fd);
 		errno = ENOENT;
@@ -218,7 +226,7 @@ int bpftime_shm::add_bpf_prog_attach_target(int perf_fd, int bpf_fd)
 	}
 	auto &handler = std::get<bpftime::bpf_prog_handler>(
 		manager->get_handler(bpf_fd));
-	handler.add_attach_fd(perf_fd);
+	handler.add_attach_fd(perf_fd, cookie);
 	return 0;
 }
 
@@ -460,6 +468,7 @@ int bpftime_shm::add_bpf_link(int fd, int prog_fd, int target_fd)
 		fd = open_fake_fd();
 	}
 	if (!manager->is_allocated(target_fd) || !is_prog_fd(prog_fd)) {
+		errno = EBADF;
 		return -1;
 	}
 	return manager->set_handler(

--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -426,7 +426,12 @@ bool bpftime_shm::is_perf_fd(int fd) const
 
 int bpftime_shm::open_fake_fd()
 {
-	return open("/dev/null", O_RDONLY);
+	int fd = open("/dev/null", O_RDONLY);
+	int cnt = 5;
+	while (fd <= 2 && fd >= 0 && --cnt > 0) {
+		fd = dup(fd);
+	}
+	return fd;
 }
 
 // handle bpf commands to load a bpf program

--- a/runtime/src/bpftime_shm_internal.hpp
+++ b/runtime/src/bpftime_shm_internal.hpp
@@ -83,7 +83,7 @@ class bpftime_shm {
 	bool is_prog_fd(int fd) const;
 
 	bool is_perf_fd(int fd) const;
-	
+
 	bool is_prog_array_map_fd(int fd) const;
 
 	int open_fake_fd();
@@ -125,10 +125,12 @@ class bpftime_shm {
 				uint64_t offset, bool is_replace);
 
 	// check and attach a perf event to a bpf program
-	int attach_perf_to_bpf(int perf_fd, int bpf_fd);
+	int attach_perf_to_bpf(int perf_fd, int bpf_fd,
+			       std::optional<uint64_t> cookie);
 
 	// add a attach target to a bpf program without checking the perf event
-	int add_bpf_prog_attach_target(int perf_fd, int bpf_fd);
+	int add_bpf_prog_attach_target(int perf_fd, int bpf_fd,
+				       std::optional<uint64_t> cookie);
 
 	// enable a perf event
 	int perf_event_enable(int fd) const;

--- a/runtime/src/bpftime_shm_json.cpp
+++ b/runtime/src/bpftime_shm_json.cpp
@@ -98,7 +98,7 @@ static int import_shm_handler_from_json(bpftime_shm &shm, json value, int fd)
 		}
 		shm.add_bpf_prog(fd, insns.data(), cnt, name.c_str(), type);
 		for (int perf_fd : value["attr"]["attach_fds"]) {
-			shm.add_bpf_prog_attach_target(perf_fd, fd);
+			shm.add_bpf_prog_attach_target(perf_fd, fd, {});
 		}
 	} else if (handler_type == "bpf_map_handler") {
 		std::string name = value["name"];
@@ -223,7 +223,7 @@ int bpftime::bpftime_export_shm_to_json(const bpftime_shm &shm,
 			// append attach fds to the json
 			for (auto &fd : prog_handler.attach_fds) {
 				j[std::to_string(i)]["attr"]["attach_fds"]
-					.push_back(fd);
+					.push_back(fd.first);
 			}
 			SPDLOG_INFO("find prog fd={} name={}", i,
 				    prog_handler.name);

--- a/runtime/src/handler/handler_manager.cpp
+++ b/runtime/src/handler/handler_manager.cpp
@@ -78,9 +78,9 @@ void handler_manager::clear_fd_at(int fd, managed_shared_memory &memory)
 				auto &prog_handler =
 					std::get<bpf_prog_handler>(handler);
 				auto &attach_fds = prog_handler.attach_fds;
-				auto new_tail =
-					std::remove(attach_fds.begin(),
-						    attach_fds.end(), fd);
+				auto new_tail = std::remove_if(
+					attach_fds.begin(), attach_fds.end(),
+					[=](auto t) { return t.first == fd; });
 				if (new_tail != attach_fds.end()) {
 					SPDLOG_DEBUG(
 						"Destroy attach of perf event {} to prog {}",

--- a/runtime/src/handler/prog_handler.cpp
+++ b/runtime/src/handler/prog_handler.cpp
@@ -11,7 +11,7 @@ bpf_prog_handler::bpf_prog_handler(managed_shared_memory &mem,
 				   size_t insn_cnt, const char *prog_name,
 				   int prog_type)
 	: insns(shm_ebpf_inst_vector_allocator(mem.get_segment_manager())),
-	  attach_fds(shm_int_vector_allocator(mem.get_segment_manager())),
+	  attach_fds(shm_pair_vector_allocator(mem.get_segment_manager())),
 	  name(char_allocator(mem.get_segment_manager()))
 {
 	insns.assign(insn, insn + insn_cnt);

--- a/runtime/src/handler/prog_handler.hpp
+++ b/runtime/src/handler/prog_handler.hpp
@@ -6,6 +6,8 @@
 #include <boost/interprocess/containers/string.hpp>
 #include <ebpf-vm.h>
 #include "bpftime_shm.hpp"
+#include <utility>
+#include <optional>
 
 namespace bpftime
 {
@@ -16,6 +18,8 @@ using char_allocator = boost::interprocess::allocator<
 using boost_shm_string =
 	boost::interprocess::basic_string<char, std::char_traits<char>,
 					  char_allocator>;
+
+using cookie_fd_pair = std::pair<int, std::optional<uint64_t> >;
 
 // bpf progs handler
 // in share memory. This is only a simple data struct to store the
@@ -48,20 +52,20 @@ class bpf_prog_handler {
 					    shm_ebpf_inst_vector_allocator>;
 	inst_vector insns;
 
-	using shm_int_vector_allocator = boost::interprocess::allocator<
-		int, managed_shared_memory::segment_manager>;
+	using shm_pair_vector_allocator = boost::interprocess::allocator<
+		cookie_fd_pair, managed_shared_memory::segment_manager>;
 
 	using attach_fds_vector =
-		boost::interprocess::vector<int, shm_int_vector_allocator>;
+		boost::interprocess::vector<cookie_fd_pair,
+					    shm_pair_vector_allocator>;
 	mutable attach_fds_vector attach_fds;
 
-	void add_attach_fd(int fd) const
+	void add_attach_fd(int fd, std::optional<uint64_t> cookie) const
 	{
 		SPDLOG_DEBUG("Add attach fd {} for bpf_prog {}", fd,
-			      name.c_str());
-		attach_fds.push_back(fd);
+			     name.c_str());
+		attach_fds.emplace_back(fd, cookie);
 	}
-
 	boost_shm_string name;
 };
 

--- a/runtime/syscall-server/syscall_server_main.cpp
+++ b/runtime/syscall-server/syscall_server_main.cpp
@@ -60,7 +60,7 @@ extern "C" void *mmap(void *addr, size_t length, int prot, int flags, int fd,
 
 extern "C" int close(int fd)
 {
-	SPDLOG_DEBUG("Closing {}", fd);
+	SPDLOG_DEBUG("Closing fd {}", fd);
 	return context.handle_close(fd);
 }
 

--- a/runtime/test/src/test_shm_progs_attach.cpp
+++ b/runtime/test/src/test_shm_progs_attach.cpp
@@ -82,7 +82,7 @@ void attach_uprobe(bpftime::handler_manager &manager_ref,
 		segment);
 	auto &prog_handler = std::get<bpf_prog_handler>(manager_ref[0]);
 	// the attach fd is 3
-	prog_handler.add_attach_fd(4);
+	prog_handler.add_attach_fd(4, {});
 }
 
 void attach_replace(bpftime::handler_manager &manager_ref,
@@ -103,12 +103,12 @@ void attach_replace(bpftime::handler_manager &manager_ref,
 		segment);
 	auto &prog_handler = std::get<bpf_prog_handler>(manager_ref[0]);
 	// the attach fd is 3
-	prog_handler.add_attach_fd(3);
+	prog_handler.add_attach_fd(3, {});
 	// attach replace
 	manager_ref.set_handler(
 		3,
-		bpf_perf_event_handler(bpf_event_type::BPF_TYPE_UREPLACE, offset,
-				       -1, "", segment, true),
+		bpf_perf_event_handler(bpf_event_type::BPF_TYPE_UREPLACE,
+				       offset, -1, "", segment, true),
 		segment);
 }
 

--- a/runtime/unit-test/test_bpftime_shm_json.cpp
+++ b/runtime/unit-test/test_bpftime_shm_json.cpp
@@ -80,7 +80,7 @@ TEST_CASE("Test bpftime shm json import/export")
 					      .key_size = 4,
 					      .value_size = 4,
 					      .max_ents = 10 });
-		shm.attach_perf_to_bpf(5, 4);
+		shm.attach_perf_to_bpf(5, 4,{});
 		int res = bpftime_export_shm_to_json(shm,
 					   "/tmp/bpftime_test_shm_json.json");
         REQUIRE(res == 0);

--- a/vm/test-runner/CMakeLists.txt
+++ b/vm/test-runner/CMakeLists.txt
@@ -2,5 +2,5 @@ add_executable(bpftime-vm-test-runner main.cpp)
 set_property(TARGET bpftime-vm-test-runner PROPERTY CXX_STANDARD 20)
 add_dependencies(bpftime-vm-test-runner vm-bpf)
 
-target_include_directories(bpftime-vm-test-runner PRIVATE ../include)
-target_link_libraries(bpftime-vm-test-runner vm-bpf)
+target_include_directories(bpftime-vm-test-runner PRIVATE ../include ${SPDLOG_INCLUDE})
+target_link_libraries(bpftime-vm-test-runner vm-bpf spdlog::spdlog)

--- a/vm/test-runner/main.cpp
+++ b/vm/test-runner/main.cpp
@@ -1,3 +1,4 @@
+#include "spdlog/cfg/env.h"
 #include <ebpf-vm.h>
 #include <memory>
 #include <iostream>
@@ -29,6 +30,7 @@ int read_file(const char *path, std::vector<char> &buf)
 
 int main(int argc, const char **argv)
 {
+	spdlog::cfg::load_env_levels();
 	if (argc < 2 || argc > 3) {
 		std::cerr
 			<< "Usage: " << argv[0]


### PR DESCRIPTION


Closes #135 


> On x86_64, a usdt tracepoint was corresponded to a nop instruction in the code. So we may hook this instruction to implement userspace USDT I've tested with GumInvocationListener of frida gum, it works well when attached to the address of the nop instruction.
> 
> So things we need to add USDT support are:
> 
> * logic to parse ELF and extract USDT definitions
> 
> Other logics would be similar to uprobe, and can even be reused

