### PR TITLE
Capture remaining arguments for bpftime start

### DIFF
--- a/tools/cli-cpp/main.cpp
+++ b/tools/cli-cpp/main.cpp
@@ -172,6 +172,7 @@ int main(int argc, const char **argv)
 		.flag();
 	start_command.add_argument("COMMAND")
 		.nargs(argparse::nargs_pattern::at_least_one)
+		.remaining()
 		.help("Command to run");
 
 	argparse::ArgumentParser attach_command("attach");


### PR DESCRIPTION
<!--# Pull Request Template-->

## Description

Fixes #181

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
I built and ran some Java programs manually.

```
sudo /root/.bpftime/bpftime start /tmp/jdk-11.0.19/bin/java  -XX:+UseThirdPartyHeap -Xms100M -Xmx100M -jar /usr/share/benchmarks/dacapo/dacapo-23.11-chopin.jar fop
[2024-01-28 03:48:57.447] [info] [agent.cpp:66] Entering bpftime agent
[2024-01-28 03:48:57.447] [info] [bpftime_shm_internal.cpp:618] Global shm constructed. shm_open_type 1 for bpftime_maps_shm
[2024-01-28 03:48:57.448] [info] [agent.cpp:81] Initializing agent..
[2024-01-28 03:48:57][info][1577983] Executable path: /tmp/jdk-11.0.19/bin/java
[2024-01-28 03:48:57][info][1577983] Attached 1 uprobe programs to function 7f60607b4f11
[2024-01-28 03:48:57][info][1577983] Executable path: /tmp/jdk-11.0.19/bin/java
[2024-01-28 03:48:57][info][1577983] Attached 1 uprobe programs to function 7f60607b35f1
[2024-01-28 03:48:57][info][1577983] Attach successfully
Version: fop 2.8 batik 1.16 (use -p to print nominal benchmark stats)
===== DaCapo 23.11-chopin fop starting =====
alignment.fo allregions.fo background.fo barcode.fo basic2.fo bleed-and-crop-marks.fo blockcontainer.fo border.fo borders.fo bordershorthand.fo break.fo character.fo columnlevel1.fo columns.fo corresprop.fo embedding.fo extensive.fo fonts.fo franklin_2pageseqs.fo franklin_alt.fo franklin_rep.fo giro.fo headfoot.fo helloworld.fo hide.fo hyphen.fo images.fo inhprop.fo instream.fo keep.fo leader.fo link.fo list.fo missing-image.fo newlinktest.fo normal.fo normalex.fo omit.fo pagelevel1.fo pagelevel2.fo pagelevel3.fo pagelevel4.fo pdfoutline.fo plan.fo readme.fo rounded-corners.fo simple.fo simplecol.fo simplecol2.fo simplecol3.fo simplecol4.fo space.fo table.fo tableunits.fo textdeko.fo
===== DaCapo 23.11-chopin fop PASSED in 2068 msec =====
INFO [1577983]: Global shm destructed
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
