### PR TITLE
runtime: Fix runtime epoll_wait error when timeout is set to -1

### DIFF
--- a/runtime/src/bpftime_shm.cpp
+++ b/runtime/src/bpftime_shm.cpp
@@ -322,7 +322,7 @@ int bpftime_epoll_wait(int fd, struct epoll_event *out_evts, int max_evt,
 		auto now_time = high_resolution_clock::now();
 		auto elasped =
 			duration_cast<milliseconds>(now_time - start_time);
-		if (elasped.count() > timeout) {
+		if (timeout && elasped.count() > timeout) {
 			break;
 		}
 		for (const auto &p : epoll_inst.files) {


### PR DESCRIPTION
<!--# Pull Request Template-->

## Description

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

Fixes #186

## Type of change

<!--Please delete options that are not relevant.-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [ ] Test A
- [ ] Test B

**Test Configuration**:

- Firmware version:
- Hardware:
- Toolchain:
- SDK:

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
