### PR TITLE
attach: fix the performance issue of the new attach implementation

### DIFF
--- a/attach/CMakeLists.txt
+++ b/attach/CMakeLists.txt
@@ -1,3 +1,8 @@
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    add_definitions(-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_DEBUG)
+  else()
+    add_definitions(-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO)
+  endif()
 add_subdirectory(base_attach_impl)
 add_subdirectory(frida_uprobe_attach_impl)
 add_subdirectory(syscall_trace_attach_impl)

--- a/attach/frida_uprobe_attach_impl/CMakeLists.txt
+++ b/attach/frida_uprobe_attach_impl/CMakeLists.txt
@@ -6,7 +6,7 @@ add_library(
     src/frida_attach_entry.cpp
     src/frida_attach_utils.cpp
     src/frida_attach_private_data.cpp
-    src/frida_uprobe_attach_internal.cpp
+    src/frida_register_conversion.cpp
 )
 add_dependencies(bpftime_frida_uprobe_attach_impl bpftime_base_attach_impl FridaGum spdlog::spdlog)
 

--- a/attach/frida_uprobe_attach_impl/include/frida_attach_entry.hpp
+++ b/attach/frida_uprobe_attach_impl/include/frida_attach_entry.hpp
@@ -1,7 +1,10 @@
 #ifndef _BPFTIME_FRIDA_ATTACH_ENTRY_HPP
 #define _BPFTIME_FRIDA_ATTACH_ENTRY_HPP
 
+#include "base_attach_impl.hpp"
 #include "frida_uprobe_attach_impl.hpp"
+#include "spdlog/spdlog.h"
+#include <variant>
 namespace bpftime
 {
 namespace attach
@@ -10,12 +13,38 @@ namespace attach
 // id, and holds a callback provided by the user
 class frida_attach_entry {
 	int self_id;
-	callback_variant cb;
+	frida_attach_entry_callback callback;
+
 	void *function;
 
 	class frida_internal_attach_entry *internal_attach;
 	friend class frida_attach_impl;
 	friend class frida_internal_attach_entry;
+
+	template <int callback_index>
+	void run_callback(const pt_regs &regs) const
+	{
+		if (std::holds_alternative<callback_variant>(callback)) {
+			SPDLOG_DEBUG(
+				"Run filter callback with original callback");
+			std::get<callback_index>(
+				std::get<callback_variant>(callback))(regs);
+		} else {
+			auto &ebpf_call_args =
+				std::get<ebpf_callback_args>(callback);
+
+			SPDLOG_DEBUG(
+				"Run filter callback with ebpf callback function, type {}",
+				ebpf_call_args.attach_type);
+			uint64_t ret = 0;
+			int err = ebpf_call_args.ebpf_cb((void *)&regs,
+							 sizeof(regs), &ret);
+			if (err < 0) {
+				SPDLOG_ERROR("Unable to run ebpf callback: {}",
+					     err);
+			}
+		}
+	}
 
     public:
 	// Get the specific attach type of this attach entry
@@ -23,9 +52,10 @@ class frida_attach_entry {
 	int get_type() const;
 	frida_attach_entry(const frida_attach_entry &) = delete;
 	frida_attach_entry &operator=(const frida_attach_entry &) = delete;
-	// Create this attach entry with its id, callback function, and function address to hook
-	frida_attach_entry(int id, callback_variant &&cb, void *function)
-		: self_id(id), cb(cb), function(function)
+	// Create this attach entry with its id, callback function, and function
+	// address to hook
+	frida_attach_entry(int id, frida_attach_entry_callback &&cb, void *function)
+		: self_id(id), callback(cb), function(function)
 	{
 	}
 	frida_attach_entry(frida_attach_entry &&) = default;

--- a/attach/frida_uprobe_attach_impl/include/frida_internal_attach_entry.hpp
+++ b/attach/frida_uprobe_attach_impl/include/frida_internal_attach_entry.hpp
@@ -1,5 +1,6 @@
 #ifndef _BPFTIME_FRIDA_INTERNAL_ATTACH_ENTRY_HPP
 #define _BPFTIME_FRIDA_INTERNAL_ATTACH_ENTRY_HPP
+#include "frida_attach_entry.hpp"
 #include <frida-gum.h>
 #include <vector>
 #include "frida_uprobe_attach_impl.hpp"
@@ -30,7 +31,7 @@ class frida_internal_attach_entry {
 
 	bool has_override() const;
 	bool has_uprobe_or_uretprobe() const;
-	uprobe_override_callback &get_filter_callback() const;
+	void run_filter_callback(const pt_regs &regs) const;
 	void iterate_uprobe_callbacks(const pt_regs &regs) const;
 	void iterate_uretprobe_callbacks(const pt_regs &regs) const;
 	frida_internal_attach_entry(const frida_internal_attach_entry &) =

--- a/attach/frida_uprobe_attach_impl/include/frida_register_conversion.hpp
+++ b/attach/frida_uprobe_attach_impl/include/frida_register_conversion.hpp
@@ -1,0 +1,36 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (c) 2022, eunomia-bpf org
+ * All rights reserved.
+ */
+#ifndef _ATTACH_INTERNAL_HPP
+#define _ATTACH_INTERNAL_HPP
+#include <frida_register_def.hpp>
+namespace bpftime
+{
+
+#if defined(__x86_64__) || defined(_M_X64)
+
+void convert_gum_cpu_context_to_pt_regs(const struct _GumX64CpuContext &context,
+					pt_regs &regs);
+
+void convert_pt_regs_to_gum_cpu_context(const pt_regs &regs,
+					struct _GumX64CpuContext &context);
+
+#elif defined(__aarch64__) || defined(_M_ARM64)
+void convert_gum_cpu_context_to_pt_regs(
+	const struct _GumArm64CpuContext &context, pt_regs &regs);
+void convert_pt_regs_to_gum_cpu_context(const pt_regs &regs,
+					struct _GumArm64CpuContext &context);
+#elif defined(__arm__) || defined(_M_ARM)
+void convert_gum_cpu_context_to_pt_regs(const struct _GumArmCpuContext &context,
+					pt_regs &regs);
+
+void convert_pt_regs_to_gum_cpu_context(const pt_regs &regs,
+					struct _GumArmCpuContext &context);
+#else
+#error "Unsupported architecture"
+#endif
+// GType uprobe_listener_get_type();
+} // namespace bpftime
+#endif

--- a/attach/frida_uprobe_attach_impl/include/frida_register_def.hpp
+++ b/attach/frida_uprobe_attach_impl/include/frida_register_def.hpp
@@ -1,10 +1,5 @@
-/* SPDX-License-Identifier: MIT
- *
- * Copyright (c) 2022, eunomia-bpf org
- * All rights reserved.
- */
-#ifndef _ATTACH_INTERNAL_HPP
-#define _ATTACH_INTERNAL_HPP
+#ifndef _BPFTIME_FRIDA_PT_REGS
+#define _BPFTIME_FRIDA_PT_REGS
 #include <cstdint>
 namespace bpftime
 {
@@ -78,28 +73,6 @@ struct pt_regs {
 #error "Unsupported architecture"
 #endif
 
-#if defined(__x86_64__) || defined(_M_X64)
-
-void convert_gum_cpu_context_to_pt_regs(const struct _GumX64CpuContext &context,
-					pt_regs &regs);
-
-void convert_pt_regs_to_gum_cpu_context(const pt_regs &regs,
-					struct _GumX64CpuContext &context);
-
-#elif defined(__aarch64__) || defined(_M_ARM64)
-void convert_gum_cpu_context_to_pt_regs(
-	const struct _GumArm64CpuContext &context, pt_regs &regs);
-void convert_pt_regs_to_gum_cpu_context(const pt_regs &regs,
-					struct _GumArm64CpuContext &context);
-#elif defined(__arm__) || defined(_M_ARM)
-void convert_gum_cpu_context_to_pt_regs(const struct _GumArmCpuContext &context,
-					pt_regs &regs);
-
-void convert_pt_regs_to_gum_cpu_context(const pt_regs &regs,
-					struct _GumArmCpuContext &context);
-#else
-#error "Unsupported architecture"
-#endif
-// GType uprobe_listener_get_type();
 } // namespace bpftime
+
 #endif

--- a/attach/frida_uprobe_attach_impl/include/frida_uprobe.hpp
+++ b/attach/frida_uprobe_attach_impl/include/frida_uprobe.hpp
@@ -6,6 +6,5 @@
 #include <frida_attach_utils.hpp>
 #include <frida_internal_attach_entry.hpp>
 #include <frida_uprobe_attach_impl.hpp>
-#include <frida_uprobe_attach_internal.hpp>
-
+#include <frida_register_def.hpp>
 #endif

--- a/attach/frida_uprobe_attach_impl/src/frida_attach_entry.cpp
+++ b/attach/frida_uprobe_attach_impl/src/frida_attach_entry.cpp
@@ -1,8 +1,14 @@
 #include "frida_attach_entry.hpp"
 #include "frida_attach_utils.hpp"
 #include "frida_uprobe_attach_impl.hpp"
+#include <variant>
 using namespace bpftime::attach;
 int frida_attach_entry::get_type() const
 {
-	return from_cb_idx_to_attach_type(cb.index());
+	if (std::holds_alternative<callback_variant>(callback)) {
+		return from_cb_idx_to_attach_type(
+			std::get<callback_variant>(callback).index());
+	} else {
+		return std::get<ebpf_callback_args>(callback).attach_type;
+	}
 }

--- a/attach/frida_uprobe_attach_impl/src/frida_attach_utils.cpp
+++ b/attach/frida_uprobe_attach_impl/src/frida_attach_utils.cpp
@@ -74,6 +74,7 @@ int from_cb_idx_to_attach_type(int idx)
 	default:
 		assert(false && "Unreachable!");
 	}
+	return 0;
 }
 } // namespace attach
 } // namespace bpftime

--- a/attach/frida_uprobe_attach_impl/src/frida_register_conversion.cpp
+++ b/attach/frida_uprobe_attach_impl/src/frida_register_conversion.cpp
@@ -1,4 +1,4 @@
-#include <frida_uprobe_attach_internal.hpp>
+#include <frida_register_conversion.hpp>
 #include <frida-gum.h>
 namespace bpftime
 {

--- a/attach/frida_uprobe_attach_impl/test/test_attach_with_unified_interface.cpp
+++ b/attach/frida_uprobe_attach_impl/test/test_attach_with_unified_interface.cpp
@@ -2,7 +2,7 @@
 #include "catch2/catch_test_macros.hpp"
 #include "frida_attach_private_data.hpp"
 #include "frida_uprobe_attach_impl.hpp"
-#include "frida_uprobe_attach_internal.hpp"
+#include "frida_register_def.hpp"
 #include <cstdint>
 #include <frida_uprobe.hpp>
 #include <memory>

--- a/runtime/src/attach/bpf_attach_ctx.cpp
+++ b/runtime/src/attach/bpf_attach_ctx.cpp
@@ -28,7 +28,7 @@
 #include <utility>
 #include <variant>
 #include <sys/resource.h>
-#include <frida_uprobe_attach_internal.hpp>
+#include <frida_register_def.hpp>
 #include <frida_uprobe_attach_impl.hpp>
 #include <frida_attach_private_data.hpp>
 extern "C" uint64_t bpftime_set_retval(uint64_t value);


### PR DESCRIPTION
Closes #223 

This PR allows `frida_attach_entry` accepting ebpf-arguments-like callbacks, in this way we could avoid an extra callback layer that translates ebpf arguments from original arguments.

## Benchmark result of the current commit
![image](https://github.com/eunomia-bpf/bpftime/assets/9004058/cb58768b-f16e-4c1d-9051-8392f8225c91)
## Benchmark result of the commit prior to the new attach implementation
![image](https://github.com/eunomia-bpf/bpftime/assets/9004058/ac4ff281-c0d6-4dcf-81ba-95b83be3253f)

According to the benchmark, the new attach implementation has the same performance as the previous one