### PR TITLE
#237 | hp77 | Make registers arch independent

### DIFF
--- a/attach/frida_uprobe_attach_impl/test/test_attach_with_unified_interface.cpp
+++ b/attach/frida_uprobe_attach_impl/test/test_attach_with_unified_interface.cpp
@@ -33,8 +33,8 @@ TEST_CASE("Test with unified interface")
 		id = man->create_attach_with_ebpf_callback(
 			[&](const void *v, size_t, uint64_t *) {
 				bpftime::pt_regs *mem = (bpftime::pt_regs *)v;
-				REQUIRE(mem->di == 1);
-				REQUIRE(mem->si == 2);
+				REQUIRE(PT_REGS_PARM1(mem) == 1);
+				REQUIRE(PT_REGS_PARM2(mem) == 2);
 				invoked = true;
 				return 0;
 			},
@@ -45,7 +45,7 @@ TEST_CASE("Test with unified interface")
 		id = man->create_attach_with_ebpf_callback(
 			[&](const void *v, size_t, uint64_t *) {
 				bpftime::pt_regs *mem = (bpftime::pt_regs *)v;
-				REQUIRE(mem->ax == 3);
+				REQUIRE(PT_REGS_RC(mem) == 3);
 				invoked = true;
 				return 0;
 			},


### PR DESCRIPTION
<!--# Pull Request Template-->

## Description

Issue was during `docker build`, `frida` tests were failing because of registers being used were only for x86

<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

Fixes #237 

## Type of change
Changed explicit register access to macro definition

<!--Please delete options that are not relevant.-->

- [x ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->


Ran the whole suite by running `make release` during `docker build`
**Test Configuration**:

- Firmware version: MacOS Sonoma 14.2
- Hardware: Macbook Air M2
- Toolchain: 
- SDK:

## Checklist

- [x] My code follows the style guidelines of this project
- [x ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
