### PR TITLE
misc: fix autocrlf for binary file example/goroutine/go-server-http/main

### DIFF
--- a/example/goroutine/go-server-http/.gitattributes
+++ b/example/goroutine/go-server-http/.gitattributes
@@ -1,0 +1,1 @@
+main binary


### PR DESCRIPTION
So that git won't treat that executable file as a text file and modify line endings in it