### PR TITLE
runtime: use bpf_link_handler to record attach links; rewrite attach part of bpf_attach_ctx

### DIFF
--- a/runtime/include/bpf_attach_ctx.hpp
+++ b/runtime/include/bpf_attach_ctx.hpp
@@ -5,6 +5,7 @@
 #include <map>
 #include <memory>
 #include <frida_uprobe_attach_impl.hpp>
+#include <set>
 #include <syscall_trace_attach_impl.hpp>
 typedef struct _GumInterceptor GumInterceptor;
 typedef struct _GumInvocationListener GumInvocationListener;
@@ -48,9 +49,15 @@ class bpf_attach_ctx {
 
 	// save the progs for memory management
 	std::map<int, std::unique_ptr<bpftime_prog> > progs;
+	std::map<int, int> attach_ids;
+	// std::unique_ptr<attach::base_attach_impl> frida_uprobe_attach_impl;
+	// std::unique_ptr<attach::base_attach_impl> syscall_trace_attach_impl;
 
-	std::unique_ptr<attach::base_attach_impl> frida_uprobe_attach_impl;
-	std::unique_ptr<attach::base_attach_impl> syscall_trace_attach_impl;
+	std::set<int> instantiated_handlers;
+
+	int instantiate_handler_at(const handler_manager *manager, int id,
+				   std::set<int> &stk,
+				   const agent_config &config);
 };
 
 } // namespace bpftime

--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -478,7 +478,7 @@ int bpftime_shm::add_bpf_link(int fd, struct bpf_link_create_args *args)
 void bpftime_shm::close_fd(int fd)
 {
 	if (manager) {
-		manager->clear_fd_at(fd, segment);
+		manager->clear_id_at(fd, segment);
 	}
 }
 

--- a/runtime/src/handler/handler_manager.hpp
+++ b/runtime/src/handler/handler_manager.hpp
@@ -111,7 +111,7 @@ class handler_manager {
 
 	int find_minimal_unused_idx() const;
 
-	void clear_fd_at(int fd, managed_shared_memory &memory);
+	void clear_id_at(int fd, managed_shared_memory &memory);
 
 	void clear_all(managed_shared_memory &memory);
 

--- a/runtime/src/handler/link_handler.hpp
+++ b/runtime/src/handler/link_handler.hpp
@@ -8,12 +8,16 @@
 
 #include <cstdint>
 #include <bpftime_shm.hpp>
+#include <optional>
 
 namespace bpftime
 {
 // handle the bpf link fd
 struct bpf_link_handler {
 	struct bpf_link_create_args args;
+	int prog_id;
+	int attach_target_id;
+	std::optional<uint64_t> attach_cookie;
 };
 } // namespace bpftime
 

--- a/runtime/src/handler/prog_handler.cpp
+++ b/runtime/src/handler/prog_handler.cpp
@@ -11,7 +11,6 @@ bpf_prog_handler::bpf_prog_handler(managed_shared_memory &mem,
 				   size_t insn_cnt, const char *prog_name,
 				   int prog_type)
 	: insns(shm_ebpf_inst_vector_allocator(mem.get_segment_manager())),
-	  attach_fds(shm_pair_vector_allocator(mem.get_segment_manager())),
 	  name(char_allocator(mem.get_segment_manager()))
 {
 	insns.assign(insn, insn + insn_cnt);

--- a/runtime/src/handler/prog_handler.hpp
+++ b/runtime/src/handler/prog_handler.hpp
@@ -52,20 +52,6 @@ class bpf_prog_handler {
 					    shm_ebpf_inst_vector_allocator>;
 	inst_vector insns;
 
-	using shm_pair_vector_allocator = boost::interprocess::allocator<
-		cookie_fd_pair, managed_shared_memory::segment_manager>;
-
-	using attach_fds_vector =
-		boost::interprocess::vector<cookie_fd_pair,
-					    shm_pair_vector_allocator>;
-	mutable attach_fds_vector attach_fds;
-
-	void add_attach_fd(int fd, std::optional<uint64_t> cookie) const
-	{
-		SPDLOG_DEBUG("Add attach fd {} for bpf_prog {}", fd,
-			     name.c_str());
-		attach_fds.emplace_back(fd, cookie);
-	}
 	boost_shm_string name;
 };
 

--- a/runtime/unit-test/maps/test_shm_hash_maps.cpp
+++ b/runtime/unit-test/maps/test_shm_hash_maps.cpp
@@ -70,7 +70,7 @@ static void handle_sub_process()
 	managed_shared_memory segment(open_only, SHM_NAME);
 	auto manager = segment.find<handler_manager>(HANDLER_NAME).first;
 	auto &manager_ref = *manager;
-	manager_ref.clear_fd_at(2, segment);
+	manager_ref.clear_id_at(2, segment);
 	test_lookup_map(1, manager_ref, segment);
 	test_lookup_map(3, manager_ref, segment);
 	test_get_next_element(1, manager_ref, segment);


### PR DESCRIPTION
**WIP**

This PR includes:
- Rewrite `init_attach_ctx_from_handlers`, so we can use a more robust method to instantiate handlers
- Use bpf_link_handler to record all attaches. Public APIs are kept untouched
