### PR TITLE
在Dockerfile文件中增加安装 Boost 库

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM ubuntu:23.04
 WORKDIR /bpftime
 RUN apt-get update && apt-get install -y --no-install-recommends \
         libelf1 libelf-dev zlib1g-dev make cmake git libboost1.74-all-dev \
-        binutils-dev libyaml-cpp-dev gcc g++ ca-certificates clang llvm
+        binutils-dev libyaml-cpp-dev gcc g++ ca-certificates clang llvm \
+        libboost-all-dev
 COPY . .
 RUN git submodule update --init --recursive
 ENV CXX=g++


### PR DESCRIPTION
在从dockerfile文件中构建docker时，执行指令`docker build .`遇到报错：
CMake Error at /usr/share/cmake-3.27/Modules/FindPackageHandleStandardArgs.cmake:230 (message): Could NOT find Boost (missing: Boost_INCLUDE_DIR) Call Stack (most recent call first): /usr/share/cmake-3.27/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE) /usr/share/cmake-3.27/Modules/FindBoost.cmake:2378 (find_package_handle_standard_args) runtime/CMakeLists.txt:45 (find_package)
显示是在make release阶段报的错，这个错误表明在构建过程中，CMake 无法找到 Boost 库，缺少 Boost_INCLUDE_DIR。执行指令sudo apt-get install libboost-all-dev安装 Boost 库即可解决问题，最终成功build the docker！
已将Boost 库的安装放在了dockerfile文件apt-get那一步中。