### PR TITLE
runtime: Add cmake options to control build runtime interact with kernel map

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 CMakeCache.*
 CMakeFiles/*
 [Tt]esting/*
+cmake-build-debug
 ebpf_code.h
 vm-exten.btf
 check
@@ -18,6 +19,7 @@ index.html*
 ### VisualStudioCode ###
 .vscode/settings.json
 .vscode/runtime.json
+.idea
 
 example/libffi/test
 test/man

--- a/cmake/StandardSettings.cmake
+++ b/cmake/StandardSettings.cmake
@@ -79,3 +79,6 @@ option(ENABLE_EBPF_VERIFIER "Whether to enable ebpf verifier" OFF)
 
 # whether to build with bpftime daemon
 option(BUILD_BPFTIME_DAEMON "Whether to build the bpftime daemon" ON)
+
+# whether to build with shared bpf_map
+option(BPFTIME_BUILD_KERNEL_BPF "Whether to build with bpf share maps" OFF)

--- a/cmake/StandardSettings.cmake
+++ b/cmake/StandardSettings.cmake
@@ -81,4 +81,4 @@ option(ENABLE_EBPF_VERIFIER "Whether to enable ebpf verifier" OFF)
 option(BUILD_BPFTIME_DAEMON "Whether to build the bpftime daemon" ON)
 
 # whether to build with shared bpf_map
-option(BPFTIME_BUILD_KERNEL_BPF "Whether to build with bpf share maps" OFF)
+option(BPFTIME_BUILD_KERNEL_BPF "Whether to build with bpf share maps" ON)

--- a/cmake/frida.cmake
+++ b/cmake/frida.cmake
@@ -26,6 +26,11 @@ elseif(${FRIDA_OS_ARCH} MATCHES "linux-arm.*")
   set(FRIDA_GUM_DEVKIT_SHA256 "6b5963eb740062aec6c22c46ec2944a68006f72d290f714fb747ffe75b448a60")
   # Frida only has armhf builds..
   set(FRIDA_OS_ARCH "linux-armhf")
+elseif(${FRIDA_OS_ARCH} MATCHES "darwin-arm.*")
+  set(FRIDA_CORE_DEVKIT_SHA256 "50aea2d5dfff000ed1f1dc1fdb2db67a02e4c4f44e782fa311f8afa31df327b6")
+  set(FRIDA_GUM_DEVKIT_SHA256 "b40c08bebd6958d41d91b7819171a457448cccad5faf417c9b4901be54b6c633")
+  # for macos-arm m* chip series 
+  set(FRIDA_OS_ARCH "macos-arm64e")
 else()
   message(FATAL_ERROR "Unsupported frida arch ${FRIDA_OS_ARCH}")
 endif()

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -70,21 +70,25 @@ set(sources
   src/bpf_map/userspace/per_cpu_array_map.cpp
   src/bpf_map/userspace/per_cpu_hash_map.cpp
   src/bpf_map/userspace/prog_array.cpp
-
-  src/bpf_map/shared/array_map_kernel_user.cpp
-  src/bpf_map/shared/hash_map_kernel_user.cpp
-  src/bpf_map/shared/percpu_array_map_kernel_user.cpp
-  src/bpf_map/shared/perf_event_array_kernel_user.cpp
-
   extension/extension_helper.cpp
 )
+
+if(BPFTIME_BUILD_KERNEL_BPF)
+  list(APPEND sources
+    src/bpf_map/shared/array_map_kernel_user.cpp
+    src/bpf_map/shared/hash_map_kernel_user.cpp
+    src/bpf_map/shared/percpu_array_map_kernel_user.cpp
+    src/bpf_map/shared/perf_event_array_kernel_user.cpp
+  )
+endif()
+
 
 set(headers
   include/
 )
-message(INFO "Headers: ${headers}")
+message(INFO " Headers: ${headers}")
 
-message(INFO "Found the following sources: ${sources}")
+message(INFO " Found the following sources: ${sources}")
 
 if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   add_definitions(-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_DEBUG)


### PR DESCRIPTION
<!--# Pull Request Template-->

## Description
Adding option to disable shared_maps in CMake
<!--Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.-->

Fixes #251 

## Type of change

<!--Please delete options that are not relevant.-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->
Checked if CI is failing or not, previously default was OFF but turned it ON and for users to disable shared_map will require them to turn it off while during ON.


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas

