### PR TITLE
runtime/agent: Add top level exception handlers

### DIFF
--- a/attach/frida_uprobe_attach_impl/src/frida_attach_utils.cpp
+++ b/attach/frida_uprobe_attach_impl/src/frida_attach_utils.cpp
@@ -72,7 +72,8 @@ int from_cb_idx_to_attach_type(int idx)
 	case ATTACH_URETPROBE_INDEX:
 		return ATTACH_URETPROBE;
 	default:
-		assert(false && "Unreachable!");
+		SPDLOG_ERROR("Unreachable branch reached!");
+		return -1;
 	}
 	return 0;
 }

--- a/attach/syscall_trace_attach_impl/src/syscall_table.cpp
+++ b/attach/syscall_trace_attach_impl/src/syscall_table.cpp
@@ -7,9 +7,9 @@
 #include "spdlog/spdlog.h"
 #include <filesystem>
 #include <fstream>
-#include <cassert>
 #include <map>
 #include <optional>
+#include <stdexcept>
 #include <syscall_id_list.h>
 static const char *SYSCALL_TRACEPOINT_ROOT =
 	"/sys/kernel/tracing/events/syscalls";
@@ -70,7 +70,11 @@ syscall_tracepoint_table create_syscall_tracepoint_id_table()
 		const auto &id_file = tp_dir.append("id");
 		SPDLOG_TRACE("Reading tracepoint id from {}", id_file.string());
 		std::ifstream id_ifs(id_file);
-		assert(id_ifs.is_open());
+		if (!id_ifs.is_open()) {
+			SPDLOG_ERROR("Unable to open & read {}",
+				     id_file.c_str());
+			throw std::runtime_error("Unable to open id file");
+		}
 		int32_t id;
 		id_ifs >> id;
 		return id;

--- a/attach/syscall_trace_attach_impl/src/syscall_trace_attach_impl.cpp
+++ b/attach/syscall_trace_attach_impl/src/syscall_trace_attach_impl.cpp
@@ -1,6 +1,5 @@
 #include "spdlog/spdlog.h"
 #include "syscall_trace_attach_private_data.hpp"
-#include <cassert>
 #include <cerrno>
 #include <iterator>
 #include <optional>
@@ -108,7 +107,8 @@ int syscall_trace_attach_impl::detach_by_id(int id)
 		} else if (!ent->is_enter) {
 			sys_exit_callbacks[ent->sys_nr].erase(ent.get());
 		} else {
-			assert(false && "Unreachable!");
+			SPDLOG_ERROR("Unreachable branch reached!");
+			return -EINVAL;
 		}
 		attach_entries.erase(itr);
 		return 0;

--- a/runtime/extension/extension_helper.cpp
+++ b/runtime/extension/extension_helper.cpp
@@ -1,5 +1,4 @@
 #include "bpftime_helper_group.hpp"
-#include <cassert>
 #include <cerrno>
 #include <sched.h>
 #ifdef ENABLE_BPFTIME_VERIFIER

--- a/runtime/src/bpf_helper.cpp
+++ b/runtime/src/bpf_helper.cpp
@@ -6,7 +6,6 @@
 #include "bpf/bpf.h"
 #include "bpf/libbpf_common.h"
 #include "bpftime_helper_group.hpp"
-#include <cassert>
 #include <cerrno>
 #include <sched.h>
 #ifdef ENABLE_BPFTIME_VERIFIER
@@ -33,9 +32,6 @@
 using namespace std;
 
 extern "C" {
-
-
-
 
 uint64_t bpftime_override_return(uint64_t ctx, uint64_t value);
 uint64_t bpftime_set_retval(uint64_t retval);
@@ -239,7 +235,11 @@ uint64_t bpf_perf_event_output(uint64_t ctx, uint64_t map, uint64_t flags,
 			       uint64_t data, uint64_t size)
 {
 	int32_t current_cpu = sched_getcpu();
-	assert(current_cpu != -1);
+	if (current_cpu == -1) {
+		SPDLOG_ERROR(
+			"Unable to get current cpu when running perf event output");
+		return (uint64_t)-1;
+	}
 	cpu_set_t mask, orig;
 	CPU_ZERO(&mask);
 	CPU_SET(current_cpu, &mask);

--- a/runtime/src/bpf_map/userspace/perf_event_array_map.cpp
+++ b/runtime/src/bpf_map/userspace/perf_event_array_map.cpp
@@ -5,9 +5,9 @@
  */
 #include "spdlog/spdlog.h"
 #include <bpf_map/userspace/perf_event_array_map.hpp>
-#include <cassert>
 #include <cerrno>
 #include <spdlog/spdlog.h>
+#include <stdexcept>
 
 namespace bpftime
 {
@@ -20,7 +20,8 @@ perf_event_array_map_impl::perf_event_array_map_impl(
 	if (key_size != 4 || value_size != 4) {
 		SPDLOG_ERROR(
 			"Key size and value size of perf_event_array must be 4");
-		assert(false);
+		throw std::runtime_error(
+			"Key size and value size of perf_event_array must be 4");
 	}
 }
 
@@ -58,8 +59,7 @@ long perf_event_array_map_impl::elem_delete(const void *key)
 	return 0;
 }
 
-int perf_event_array_map_impl::map_get_next_key(const void *key,
-						    void *next_key)
+int perf_event_array_map_impl::map_get_next_key(const void *key, void *next_key)
 {
 	int32_t *out = (int32_t *)next_key;
 	if (key == nullptr) {

--- a/runtime/src/bpf_map/userspace/prog_array.cpp
+++ b/runtime/src/bpf_map/userspace/prog_array.cpp
@@ -7,12 +7,12 @@
 #include "linux/bpf.h"
 #include "spdlog/spdlog.h"
 #include <bpf_map/userspace/prog_array.hpp>
-#include <cassert>
 #include <cerrno>
 #include <spdlog/spdlog.h>
 #include <bpf/libbpf.h>
 #include <dlfcn.h>
 #include <gnu/lib-names.h>
+#include <stdexcept>
 
 #ifndef offsetofend
 #define offsetofend(TYPE, FIELD)                                               \
@@ -78,8 +78,8 @@ prog_array_map_impl::prog_array_map_impl(
 	: data(max_entries, -1, memory.get_segment_manager())
 {
 	if (key_size != 4 || value_size != 4) {
-		SPDLOG_ERROR("Key size and value size of prog_array must be 4");
-		assert(false);
+		throw std::runtime_error(
+			"Key size and value size of prog_array must be 4");
 	}
 }
 

--- a/runtime/src/bpf_map/userspace/ringbuf_map.cpp
+++ b/runtime/src/bpf_map/userspace/ringbuf_map.cpp
@@ -9,6 +9,7 @@
 #include <boost/interprocess/sync/sharable_lock.hpp>
 #include <bpf_map/userspace/ringbuf_map.hpp>
 #include <spdlog/spdlog.h>
+#include <stdexcept>
 
 enum {
 	BPF_RINGBUF_BUSY_BIT = 2147483648,
@@ -163,8 +164,11 @@ ringbuf::ringbuf(uint32_t max_ent,
 		  memory))
 {
 	const auto page_size = getpagesize();
-	assert((size_t)page_size >= sizeof(unsigned long) &&
-	       "Page size is expected to be greater than sizeof(unsigned long)");
+
+	if ((size_t)page_size < sizeof(unsigned long)) {
+		throw std::runtime_error(
+			"Page size is expected to be greater than sizeof(unsigned long)");
+	}
 	consumer_pos = (unsigned long *)(uintptr_t)(&((*raw_buffer)[0]));
 	producer_pos =
 		(unsigned long *)(uintptr_t)(&((*raw_buffer)[page_size]));

--- a/runtime/src/bpftime_shm.cpp
+++ b/runtime/src/bpftime_shm.cpp
@@ -10,6 +10,7 @@
 #include "spdlog/spdlog.h"
 #include <csignal>
 #include <cstddef>
+#include <exception>
 #include <signal.h>
 #include <cerrno>
 #include <errno.h>
@@ -50,32 +51,68 @@ uint32_t bpftime_map_value_size_from_syscall(int fd)
 
 int bpftime_helper_map_get_next_key(int fd, const void *key, void *next_key)
 {
-	return shm_holder.global_shared_memory.bpf_map_get_next_key(
-		fd, key, next_key, false);
+	try {
+		return shm_holder.global_shared_memory.bpf_map_get_next_key(
+			fd, key, next_key, false);
+	} catch (std::exception &ex) {
+		SPDLOG_ERROR(
+			"Exception happened when performing map get next key (from helper): {}",
+			ex.what());
+		return -1;
+	}
 }
 
 const void *bpftime_map_lookup_elem(int fd, const void *key)
 {
-	return shm_holder.global_shared_memory.bpf_map_lookup_elem(fd, key,
-								   true);
+	try {
+		return shm_holder.global_shared_memory.bpf_map_lookup_elem(
+			fd, key, true);
+	} catch (std::exception &ex) {
+		SPDLOG_ERROR(
+			"Exception happened when performing map lookup elem: {}",
+			ex.what());
+		return nullptr;
+	}
 }
 
 long bpftime_map_update_elem(int fd, const void *key, const void *value,
 			     uint64_t flags)
 {
-	return shm_holder.global_shared_memory.bpf_map_update_elem(
-		fd, key, value, flags, true);
+	try {
+		return shm_holder.global_shared_memory.bpf_map_update_elem(
+			fd, key, value, flags, true);
+	} catch (std::exception &ex) {
+		SPDLOG_ERROR(
+			"Exception happened when performing map update: {}",
+			ex.what());
+		return -1;
+	}
 }
 
 long bpftime_map_delete_elem(int fd, const void *key)
 {
-	return shm_holder.global_shared_memory.bpf_delete_elem(fd, key, true);
+	try {
+		return shm_holder.global_shared_memory.bpf_delete_elem(fd, key,
+								       true);
+	} catch (std::exception &ex) {
+		SPDLOG_ERROR(
+			"Exception happened when performing map delete elem: {}",
+			ex.what());
+		return -1;
+	}
 }
 
 int bpftime_map_get_next_key(int fd, const void *key, void *next_key)
 {
-	return shm_holder.global_shared_memory.bpf_map_get_next_key(
-		fd, key, next_key, true);
+	try {
+		return shm_holder.global_shared_memory.bpf_map_get_next_key(
+			fd, key, next_key, true);
+	} catch (std::exception &ex) {
+		SPDLOG_ERROR(
+			"Exception happened when performing map get next key: {}",
+			ex.what());
+		return -1;
+	}
 }
 
 int bpftime_uprobe_create(int fd, int pid, const char *name, uint64_t offset,

--- a/runtime/src/handler/handler_manager.cpp
+++ b/runtime/src/handler/handler_manager.cpp
@@ -23,7 +23,9 @@ handler_manager::handler_manager(managed_shared_memory &mem,
 handler_manager::~handler_manager()
 {
 	for (std::size_t i = 0; i < handlers.size(); i++) {
-		assert(!is_allocated(i));
+		SPDLOG_ERROR(
+			"Handler at {} is not destroyed, but handler_manager is being destroyed",
+			i);
 	}
 }
 

--- a/runtime/src/handler/map_handler.hpp
+++ b/runtime/src/handler/map_handler.hpp
@@ -69,8 +69,9 @@ class bpf_map_handler {
 	{
 		this->attr = attr;
 	}
-	bpf_map_handler(int id, int type, uint32_t key_size, uint32_t value_size,
-			uint32_t max_ents, uint64_t flags, const char *name,
+	bpf_map_handler(int id, int type, uint32_t key_size,
+			uint32_t value_size, uint32_t max_ents, uint64_t flags,
+			const char *name,
 			boost::interprocess::managed_shared_memory &mem)
 		: type((bpf_map_type)type),
 		  name(char_allocator(mem.get_segment_manager())),
@@ -91,7 +92,11 @@ class bpf_map_handler {
 		// since we cannot free here because memory allocator pointer
 		// cannot be held between process, we will free the internal map
 		// in the handler_manager.
-		assert(map_impl_ptr.get() == nullptr);
+		if (map_impl_ptr.get() != nullptr) {
+			SPDLOG_CRITICAL(
+				"Map impl of id {} is not freed when the map was being destroyed. This should not happen",
+				id);
+		}
 	}
 	//  * BPF_MAP_LOOKUP_ELEM
 	// *	Description

--- a/runtime/src/handler/perf_event_handler.cpp
+++ b/runtime/src/handler/perf_event_handler.cpp
@@ -7,7 +7,6 @@
 #include "spdlog/spdlog.h"
 #include <boost/interprocess/detail/segment_manager_helper.hpp>
 #include <boost/interprocess/smart_ptr/shared_ptr.hpp>
-#include <cassert>
 #include <cstring>
 #include <handler/perf_event_handler.hpp>
 #include <boost/interprocess/managed_shared_memory.hpp>
@@ -223,8 +222,11 @@ void *software_perf_event_data::ensure_mmap_buffer(size_t buffer_size)
 		mmap_buffer.resize(buffer_size);
 		// Update data size in the mmap header
 		get_header_ref().data_size = buffer_size - pagesize;
-		assert(popcnt(buffer_size - pagesize) == 1 &&
-		       "Data size of a perf event buffer must be power of 2");
+		if (popcnt(buffer_size - pagesize) != 1) {
+			SPDLOG_ERROR(
+				"Data size of a perf event buffer must be power of 2");
+			return nullptr;
+		}
 	}
 	return mmap_buffer.data();
 }


### PR DESCRIPTION
Added top level exception handlers (try-catch) at:
- Instantiating handlers (boost::interprocess might throw exception like bad_alloc, some constructors might throw exceptions)
- Initializing shared memory (same as above)
- map operations (same as above)

This PR also replaces almost all asserts in runtime with throw std::runtime_error (Most of asserts are in constructors of handlers or maps, so if they were replaced with throws, we could catch whem when instantiating handlers or creating maps)