### PR TITLE
runtime/agent: implement detaching

### DIFF
--- a/attach/frida_uprobe_attach_impl/src/frida_internal_attach_entry.cpp
+++ b/attach/frida_uprobe_attach_impl/src/frida_internal_attach_entry.cpp
@@ -79,6 +79,7 @@ frida_internal_attach_entry::~frida_internal_attach_entry()
 		SPDLOG_DEBUG("Reverted function replace");
 	}
 	gum_object_unref(interceptor);
+	SPDLOG_DEBUG("Destructor of frida_internal_attach_entry exiting..");
 }
 
 bool frida_internal_attach_entry::has_override() const

--- a/runtime/agent/agent.cpp
+++ b/runtime/agent/agent.cpp
@@ -5,6 +5,7 @@
 #include "spdlog/common.h"
 #include "syscall_trace_attach_impl.hpp"
 #include "syscall_trace_attach_private_data.hpp"
+#include <csignal>
 #include <exception>
 #include <fcntl.h>
 #include <memory>
@@ -70,8 +71,16 @@ extern "C" int __libc_start_main(int (*main)(int, char **, char **), int argc,
 		    stack_end);
 }
 
+static void sig_handler_usr1(int sig)
+{
+	SPDLOG_DEBUG("Detaching..");
+	// ctx_holder.ctx.destroy_instantiated_attach_link;
+}
+
 extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 {
+	// We use SIGUSR1 to indicate the detaching
+	signal(SIGUSR1, sig_handler_usr1);
 	spdlog::cfg::load_env_levels();
 	try {
 		// If we are unable to initialize shared memory..

--- a/runtime/include/bpf_attach_ctx.hpp
+++ b/runtime/include/bpf_attach_ctx.hpp
@@ -52,6 +52,8 @@ class bpf_attach_ctx {
 			private_data_creator);
 	// Destroy a specific attach link
 	int destroy_instantiated_attach_link(int link_id);
+	// Destroy all instantiated attach links
+	int destroy_all_attach_links();
 
     private:
 	constexpr static int CURRENT_ID_OFFSET = 65536;
@@ -64,7 +66,7 @@ class bpf_attach_ctx {
 	std::map<int, std::unique_ptr<bpftime_prog> > instantiated_progs;
 	// handler_id -> (instantiated attaches id, attach_impl*)
 	std::map<int, std::pair<int, attach::base_attach_impl *> >
-		instantiated_attach_ids;
+		instantiated_attach_links;
 	// handler_id -> instantiated attach private data & attach type
 	std::map<int,
 		 std::pair<std::unique_ptr<attach::attach_private_data>, int> >

--- a/runtime/src/attach/bpf_attach_ctx.cpp
+++ b/runtime/src/attach/bpf_attach_ctx.cpp
@@ -236,7 +236,7 @@ int bpf_attach_ctx::instantiate_bpf_link_handler_at(
 			     id, attach_id);
 		return attach_id;
 	}
-	instantiated_attach_ids[id] = std::make_pair(attach_id, attach_impl);
+	instantiated_attach_links[id] = std::make_pair(attach_id, attach_impl);
 	return 0;
 }
 int bpf_attach_ctx::instantiate_perf_event_handler_at(
@@ -315,8 +315,8 @@ int bpf_attach_ctx::instantiate_perf_event_handler_at(
 int bpf_attach_ctx::destroy_instantiated_attach_link(int link_id)
 {
 	SPDLOG_DEBUG("Destroy attach link {}", link_id);
-	if (auto itr = instantiated_attach_ids.find(link_id);
-	    itr != instantiated_attach_ids.end()) {
+	if (auto itr = instantiated_attach_links.find(link_id);
+	    itr != instantiated_attach_links.end()) {
 		auto [attach_id, impl] = itr->second;
 		if (int err = impl->detach_by_id(attach_id); err < 0) {
 			SPDLOG_ERROR(
@@ -324,12 +324,24 @@ int bpf_attach_ctx::destroy_instantiated_attach_link(int link_id)
 				link_id, attach_id, err);
 			return err;
 		}
-		instantiated_attach_ids.erase(itr);
+		instantiated_attach_links.erase(itr);
 		return 0;
 	} else {
 		SPDLOG_ERROR("Unable to find instantiated attach link id {}",
 			     link_id);
 		return -ENOENT;
 	}
+}
+int bpf_attach_ctx::destroy_all_attach_links()
+{
+	for (const auto &[k, _] : instantiated_attach_links) {
+		SPDLOG_DEBUG("Destrying attach link {}", k);
+		if (int err = destroy_instantiated_attach_link(k); err < 0) {
+			SPDLOG_ERROR("Unable to destroy attach link {}: {}", k,
+				     err);
+			return err;
+		}
+	}
+	return 0;
 }
 } // namespace bpftime

--- a/runtime/src/attach/bpf_attach_ctx.cpp
+++ b/runtime/src/attach/bpf_attach_ctx.cpp
@@ -334,7 +334,11 @@ int bpf_attach_ctx::destroy_instantiated_attach_link(int link_id)
 }
 int bpf_attach_ctx::destroy_all_attach_links()
 {
-	for (const auto &[k, _] : instantiated_attach_links) {
+	// Avoid modifying along with iterating..
+	std::vector<int> to_detach;
+	for (const auto &[k, _] : instantiated_attach_links)
+		to_detach.push_back(k);
+	for (auto k : to_detach) {
 		SPDLOG_DEBUG("Destrying attach link {}", k);
 		if (int err = destroy_instantiated_attach_link(k); err < 0) {
 			SPDLOG_ERROR("Unable to destroy attach link {}: {}", k,

--- a/runtime/src/handler/handler_manager.hpp
+++ b/runtime/src/handler/handler_manager.hpp
@@ -53,6 +53,7 @@ constexpr const char *DEFAULT_GLOBAL_SHM_NAME = "bpftime_maps_shm";
 constexpr const char *DEFAULT_GLOBAL_HANDLER_NAME = "bpftime_handler";
 constexpr const char *DEFAULT_SYSCALL_PID_SET_NAME = "bpftime_syscall_pid_set";
 constexpr const char *DEFAULT_AGENT_CONFIG_NAME = "bpftime_agent_config";
+constexpr const char* DEFAULT_ALIVE_AGENT_PIDS_NAME = "bpftime_alive_agent_pids";
 inline const char *get_global_shm_name()
 {
 	const char *name = getenv("BPFTIME_GLOBAL_SHM_NAME");

--- a/tools/cli/CMakeLists.txt
+++ b/tools/cli/CMakeLists.txt
@@ -5,12 +5,12 @@ add_executable(
 
 set_target_properties(bpftime-cli-cpp PROPERTIES OUTPUT_NAME "bpftime")
 
-target_include_directories(bpftime-cli-cpp PRIVATE ${FRIDA_CORE_INSTALL_DIR} ${SPDLOG_INCLUDE} ${argparse_INCLUDE})
-target_link_libraries(bpftime-cli-cpp PRIVATE spdlog::spdlog ${FRIDA_CORE_INSTALL_DIR}/libfrida-core.a argparse)
+target_include_directories(bpftime-cli-cpp PRIVATE ${FRIDA_CORE_INSTALL_DIR} ${SPDLOG_INCLUDE} ${argparse_INCLUDE} ../../runtime/include)
+target_link_libraries(bpftime-cli-cpp PRIVATE spdlog::spdlog ${FRIDA_CORE_INSTALL_DIR}/libfrida-core.a argparse runtime)
 set_property(TARGET bpftime-cli-cpp PROPERTY CXX_STANDARD 20)
 
 target_compile_definitions(bpftime-cli-cpp PRIVATE _GNU_SOURCE)
 
-add_dependencies(bpftime-cli-cpp spdlog::spdlog FridaCore argparse)
+add_dependencies(bpftime-cli-cpp spdlog::spdlog FridaCore argparse runtime)
 
 install(TARGETS bpftime-cli-cpp CONFIGURATIONS Release Debug RelWithDebInfo DESTINATION ~/.bpftime)

--- a/tools/cli/main.cpp
+++ b/tools/cli/main.cpp
@@ -276,17 +276,21 @@ int main(int argc, const char **argv)
 				"Shared memory not created, seems syscall server is not running");
 			return 0;
 		}
+		bool sended = false;
 		bpftime::shm_holder.global_shared_memory
 			.iterate_all_pids_in_alive_agent_set([&](int pid) {
-				SPDLOG_INFO("Sending SIGUSR1 to {}", pid);
+				SPDLOG_INFO("Delivering SIGUSR1 to {}", pid);
 				int err = kill(pid, SIGUSR1);
 				if (err < 0) {
 					SPDLOG_WARN(
 						"Unable to signal process {}: {}",
 						pid, strerror(errno));
 				}
+				sended = true;
 			});
-		SPDLOG_INFO("Done");
+		if (!sended) {
+			SPDLOG_INFO("No process was signaled.");
+		}
 	}
 	return 0;
 }

--- a/tools/cli/main.cpp
+++ b/tools/cli/main.cpp
@@ -1,8 +1,12 @@
+#include "bpftime_shm.hpp"
+#include "bpftime_shm_internal.hpp"
 #include "spdlog/spdlog.h"
 #include "spdlog/cfg/env.h"
+#include <cerrno>
 #include <csignal>
 #include <cstdlib>
 #include <cstring>
+#include <exception>
 #include <frida-core.h>
 #include <argparse/argparse.hpp>
 #include <filesystem>
@@ -185,9 +189,13 @@ int main(int argc, const char **argv)
 		.flag();
 	attach_command.add_argument("PID").scan<'i', int>();
 
+	argparse::ArgumentParser detach_command("detach");
+	detach_command.add_description("Detach all attached agents");
+
 	program.add_subparser(load_command);
 	program.add_subparser(start_command);
 	program.add_subparser(attach_command);
+	program.add_subparser(detach_command);
 	try {
 		program.parse_args(argc, argv);
 	} catch (const std::exception &err) {
@@ -258,6 +266,27 @@ int main(int argc, const char **argv)
 		} else {
 			return inject_by_frida(pid, agent_path.c_str(), "");
 		}
+	} else if (program.is_subcommand_used("detach")) {
+		SPDLOG_DEBUG("Detaching..");
+		try {
+			bpftime_initialize_global_shm(
+				bpftime::shm_open_type::SHM_OPEN_ONLY);
+		} catch (std::exception &ex) {
+			SPDLOG_WARN(
+				"Shared memory not created, seems syscall server is not running");
+			return 0;
+		}
+		bpftime::shm_holder.global_shared_memory
+			.iterate_all_pids_in_alive_agent_set([&](int pid) {
+				SPDLOG_INFO("Sending SIGUSR1 to {}", pid);
+				int err = kill(pid, SIGUSR1);
+				if (err < 0) {
+					SPDLOG_WARN(
+						"Unable to signal process {}: {}",
+						pid, strerror(errno));
+				}
+			});
+		SPDLOG_INFO("Done");
 	}
 	return 0;
 }

--- a/vm/llvm-jit/include/llvm_bpf_jit.h
+++ b/vm/llvm-jit/include/llvm_bpf_jit.h
@@ -23,7 +23,7 @@ extern "C" {
 typedef uint64_t (*ext_func)(uint64_t arg0, uint64_t arg1, uint64_t arg2,
 			     uint64_t arg3, uint64_t arg4);
 
-struct llvm_bpf_jit_context;
+class llvm_bpf_jit_context;
 
 struct ebpf_vm {
 	/* ubpf_defs*/


### PR DESCRIPTION
Closes #261 

## Why?
We need a way to revert remote injected attaches

## What to do:
- Agent should revert any attached entries when received SIGUSR1
- After that, agent should unload itself from the injected process, i.e unload the shared object from the memory space of the injected process
- Add subcommand `detach` for bpftime cli

## How to implement?
- Every agent instance stores its pid into shared memory, if it was injected through frida
- Agent would register signal handler for `SIGUSR1`, and will call bpf_attach_ctx::destroy_all_attach_links to perform detach
- When we run `bpftime detach`, it reads all pids that was stored in the shared memory, and sends SIGUSR1 to them

## Known bugs:
- We can't unload the injected agent library. A shared object can't unload itself in its code