### PR TITLE
Allow defining shared memory size at runtime

### DIFF
--- a/daemon/user/bpftime_driver.cpp
+++ b/daemon/user/bpftime_driver.cpp
@@ -380,7 +380,8 @@ bpftime_driver::bpftime_driver(daemon_config cfg, struct bpf_tracer_bpf *obj)
 	config = cfg;
 	object = obj;
 	bpftime_initialize_global_shm(shm_open_type::SHM_REMOVE_AND_CREATE);
-	set_agent_config_from_env();
+	auto config = get_agent_config_from_env();
+	bpftime_set_agent_config(config);
 }
 
 bpftime_driver::~bpftime_driver()

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -62,6 +62,7 @@ set(sources
   src/bpftime_shm_internal.cpp
   src/bpftime_shm_json.cpp
   src/bpftime_prog.cpp
+  src/bpftime_config.cpp
   src/ufunc.cpp
   src/bpf_helper.cpp
   src/platform_utils.cpp

--- a/runtime/include/bpftime_config.hpp
+++ b/runtime/include/bpftime_config.hpp
@@ -18,7 +18,50 @@ struct agent_config {
 	// self-defined or non-buildin supported map type, if will not be
 	// rejected
 	bool allow_non_buildin_map_types = false;
+
+	// memory size will determine the maximum size of the shared memory
+	// available for the eBPF programs and maps
+	// The value is in MB
+	int shm_memory_size = 50; // 50MB
 };
+
+inline const agent_config get_agent_config_from_env()
+{
+	bpftime::agent_config agent_config;
+	if (const char *custom_helpers = getenv("BPFTIME_HELPER_GROUPS");
+	    custom_helpers != nullptr) {
+		agent_config.enable_kernel_helper_group =
+			agent_config.enable_ufunc_helper_group =
+				agent_config.enable_shm_maps_helper_group =
+					false;
+		auto helpers_sv = std::string_view(custom_helpers);
+		process_helper_sv(helpers_sv, ',', agent_config);
+	} else {
+		SPDLOG_INFO(
+			"Enabling helper groups ufunc, kernel, shm_map by default");
+		agent_config.enable_kernel_helper_group =
+			agent_config.enable_shm_maps_helper_group =
+				agent_config.enable_ufunc_helper_group = true;
+	}
+	if (getenv("BPFTIME_DISABLE_JIT") != nullptr) {
+		agent_config.jit_enabled = false;
+	}
+	if (getenv("BPFTIME_ALLOW_EXTERNAL_MAPS") != nullptr) {
+		agent_config.allow_non_buildin_map_types = true;
+	}
+	const char* shm_memory_size_str = getenv("BPFTIME_SHM_MEMORY_MB");
+	if (shm_memory_size_str != nullptr) {
+		try {
+			agent_config.shm_memory_size = std::stoi(shm_memory_size_str);
+		} catch (...) {
+			SPDLOG_ERROR(
+				"Invalid value for BPFTIME_SHM_MEMORY_SIZE: {}",
+				shm_memory_size_str);
+		}
+	}
+	return agent_config;
+}
+
 } // namespace bpftime
 
 #endif

--- a/runtime/include/bpftime_config.hpp
+++ b/runtime/include/bpftime_config.hpp
@@ -4,9 +4,10 @@
 #include <cstdlib>
 #include <string>
 
-
 namespace bpftime
 {
+// Configuration for the bpftime runtime
+// Initialize the configuration from the environment variables
 struct agent_config {
 	bool debug = false;
 	// Enable JIT?
@@ -26,7 +27,7 @@ struct agent_config {
 	// memory size will determine the maximum size of the shared memory
 	// available for the eBPF programs and maps
 	// The value is in MB
-	int shm_memory_size = 50; // 50MB
+	int shm_memory_size = 20; // 20MB
 };
 
 // Get the bpftime configuration from the environment variables

--- a/runtime/include/bpftime_config.hpp
+++ b/runtime/include/bpftime_config.hpp
@@ -1,6 +1,10 @@
 #ifndef _CONFIG_MANAGER_HPP
 #define _CONFIG_MANAGER_HPP
 
+#include <cstdlib>
+#include <string>
+
+
 namespace bpftime
 {
 struct agent_config {
@@ -25,42 +29,8 @@ struct agent_config {
 	int shm_memory_size = 50; // 50MB
 };
 
-inline const agent_config get_agent_config_from_env()
-{
-	bpftime::agent_config agent_config;
-	if (const char *custom_helpers = getenv("BPFTIME_HELPER_GROUPS");
-	    custom_helpers != nullptr) {
-		agent_config.enable_kernel_helper_group =
-			agent_config.enable_ufunc_helper_group =
-				agent_config.enable_shm_maps_helper_group =
-					false;
-		auto helpers_sv = std::string_view(custom_helpers);
-		process_helper_sv(helpers_sv, ',', agent_config);
-	} else {
-		SPDLOG_INFO(
-			"Enabling helper groups ufunc, kernel, shm_map by default");
-		agent_config.enable_kernel_helper_group =
-			agent_config.enable_shm_maps_helper_group =
-				agent_config.enable_ufunc_helper_group = true;
-	}
-	if (getenv("BPFTIME_DISABLE_JIT") != nullptr) {
-		agent_config.jit_enabled = false;
-	}
-	if (getenv("BPFTIME_ALLOW_EXTERNAL_MAPS") != nullptr) {
-		agent_config.allow_non_buildin_map_types = true;
-	}
-	const char* shm_memory_size_str = getenv("BPFTIME_SHM_MEMORY_MB");
-	if (shm_memory_size_str != nullptr) {
-		try {
-			agent_config.shm_memory_size = std::stoi(shm_memory_size_str);
-		} catch (...) {
-			SPDLOG_ERROR(
-				"Invalid value for BPFTIME_SHM_MEMORY_SIZE: {}",
-				shm_memory_size_str);
-		}
-	}
-	return agent_config;
-}
+// Get the bpftime configuration from the environment variables
+const agent_config get_agent_config_from_env();
 
 } // namespace bpftime
 

--- a/runtime/include/bpftime_shm.hpp
+++ b/runtime/include/bpftime_shm.hpp
@@ -153,9 +153,8 @@ enum class bpf_prog_type {
 };
 
 extern const shm_open_type global_shm_open_type;
-const bpftime::agent_config &set_agent_config_from_env();
 const bpftime::agent_config &bpftime_get_agent_config();
-void bpftime_set_agent_config(bpftime::agent_config &cfg);
+void bpftime_set_agent_config(const bpftime::agent_config &cfg);
 
 // Map ops for register external map types and operations
 //

--- a/runtime/src/bpftime_config.cpp
+++ b/runtime/src/bpftime_config.cpp
@@ -1,0 +1,77 @@
+#include "bpftime_config.hpp"
+#include "spdlog/spdlog.h"
+#include <string_view>
+
+using namespace bpftime;
+
+static void process_token(const std::string_view &token, agent_config &config)
+{
+	if (token == "ufunc") {
+		SPDLOG_INFO("Enabling ufunc helper group");
+		config.enable_ufunc_helper_group = true;
+	} else if (token == "kernel") {
+		SPDLOG_INFO("Enabling kernel helper group");
+		config.enable_kernel_helper_group = true;
+	} else if (token == "shm_map") {
+		SPDLOG_INFO("Enabling shm_map helper group");
+		config.enable_shm_maps_helper_group = true;
+	} else {
+		spdlog::warn("Unknown helper group: {}", token);
+	}
+}
+
+static void process_helper_sv(const std::string_view &str, const char delimiter,
+			      agent_config &config)
+{
+	std::string::size_type start = 0;
+	std::string::size_type end = str.find(delimiter);
+
+	while (end != std::string::npos) {
+		process_token(str.substr(start, end - start), config);
+		start = end + 1;
+		end = str.find(delimiter, start);
+	}
+
+	// Handle the last token, if any
+	if (start < str.size()) {
+		process_token(str.substr(start), config);
+	}
+}
+
+const agent_config get_agent_config_from_env()
+{
+	bpftime::agent_config agent_config;
+	if (const char *custom_helpers = getenv("BPFTIME_HELPER_GROUPS");
+	    custom_helpers != nullptr) {
+		agent_config.enable_kernel_helper_group =
+			agent_config.enable_ufunc_helper_group =
+				agent_config.enable_shm_maps_helper_group =
+					false;
+		auto helpers_sv = std::string_view(custom_helpers);
+		process_helper_sv(helpers_sv, ',', agent_config);
+	} else {
+		SPDLOG_INFO(
+			"Enabling helper groups ufunc, kernel, shm_map by default");
+		agent_config.enable_kernel_helper_group =
+			agent_config.enable_shm_maps_helper_group =
+				agent_config.enable_ufunc_helper_group = true;
+	}
+	if (getenv("BPFTIME_DISABLE_JIT") != nullptr) {
+		agent_config.jit_enabled = false;
+	}
+	if (getenv("BPFTIME_ALLOW_EXTERNAL_MAPS") != nullptr) {
+		agent_config.allow_non_buildin_map_types = true;
+	}
+	const char *shm_memory_size_str = getenv("BPFTIME_SHM_MEMORY_MB");
+	if (shm_memory_size_str != nullptr) {
+		try {
+			agent_config.shm_memory_size =
+				std::stoi(shm_memory_size_str);
+		} catch (...) {
+			SPDLOG_ERROR(
+				"Invalid value for BPFTIME_SHM_MEMORY_SIZE: {}",
+				shm_memory_size_str);
+		}
+	}
+	return agent_config;
+}

--- a/runtime/src/bpftime_config.cpp
+++ b/runtime/src/bpftime_config.cpp
@@ -38,7 +38,7 @@ static void process_helper_sv(const std::string_view &str, const char delimiter,
 	}
 }
 
-const agent_config get_agent_config_from_env()
+const agent_config bpftime::get_agent_config_from_env()
 {
 	bpftime::agent_config agent_config;
 	if (const char *custom_helpers = getenv("BPFTIME_HELPER_GROUPS");

--- a/runtime/src/bpftime_shm.cpp
+++ b/runtime/src/bpftime_shm.cpp
@@ -626,32 +626,6 @@ static void process_helper_sv(const std::string_view &str, const char delimiter,
 	}
 }
 
-const bpftime::agent_config &bpftime::set_agent_config_from_env()
-{
-	bpftime::agent_config agent_config;
-	if (const char *custom_helpers = getenv("BPFTIME_HELPER_GROUPS");
-	    custom_helpers != nullptr) {
-		agent_config.enable_kernel_helper_group =
-			agent_config.enable_ufunc_helper_group =
-				agent_config.enable_shm_maps_helper_group =
-					false;
-		auto helpers_sv = std::string_view(custom_helpers);
-		process_helper_sv(helpers_sv, ',', agent_config);
-	} else {
-		SPDLOG_INFO(
-			"Enabling helper groups ufunc, kernel, shm_map by default");
-		agent_config.enable_kernel_helper_group =
-			agent_config.enable_shm_maps_helper_group =
-				agent_config.enable_ufunc_helper_group = true;
-	}
-	const char *use_jit = getenv("BPFTIME_USE_JIT");
-	agent_config.jit_enabled = use_jit != nullptr;
-	agent_config.allow_non_buildin_map_types =
-		getenv("BPFTIME_ALLOW_EXTERNAL_MAPS") != nullptr;
-	bpftime_set_agent_config(agent_config);
-	return bpftime_get_agent_config();
-}
-
 int bpftime_add_custom_perf_event(int type, const char *attach_argument)
 {
 	return shm_holder.global_shared_memory.add_custom_perf_event(

--- a/runtime/src/bpftime_shm.cpp
+++ b/runtime/src/bpftime_shm.cpp
@@ -592,40 +592,6 @@ extern "C" uint64_t map_val(uint64_t map_ptr)
 	return (uint64_t)handler.map_lookup_elem(key.data());
 }
 
-static void process_token(const std::string_view &token, agent_config &config)
-{
-	if (token == "ufunc") {
-		SPDLOG_INFO("Enabling ufunc helper group");
-		config.enable_ufunc_helper_group = true;
-	} else if (token == "kernel") {
-		SPDLOG_INFO("Enabling kernel helper group");
-		config.enable_kernel_helper_group = true;
-	} else if (token == "shm_map") {
-		SPDLOG_INFO("Enabling shm_map helper group");
-		config.enable_shm_maps_helper_group = true;
-	} else {
-		spdlog::warn("Unknown helper group: {}", token);
-	}
-}
-
-static void process_helper_sv(const std::string_view &str, const char delimiter,
-			      agent_config &config)
-{
-	std::string::size_type start = 0;
-	std::string::size_type end = str.find(delimiter);
-
-	while (end != std::string::npos) {
-		process_token(str.substr(start, end - start), config);
-		start = end + 1;
-		end = str.find(delimiter, start);
-	}
-
-	// Handle the last token, if any
-	if (start < str.size()) {
-		process_token(str.substr(start), config);
-	}
-}
-
 int bpftime_add_custom_perf_event(int type, const char *attach_argument)
 {
 	return shm_holder.global_shared_memory.add_custom_perf_event(

--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -575,7 +575,7 @@ bpftime_shm::bpftime_shm(const char *shm_name, shm_open_type type)
 			memory_size);
 		segment = boost::interprocess::managed_shared_memory(
 			boost::interprocess::open_or_create,
-			// Allocate 50M bytes of memory by default
+			// Allocate 20M bytes of memory by default
 			shm_name, memory_size << 20);
 
 		manager = segment.find_or_construct<bpftime::handler_manager>(

--- a/runtime/syscall-server/syscall_server_utils.cpp
+++ b/runtime/syscall-server/syscall_server_utils.cpp
@@ -25,7 +25,8 @@ void start_up()
 	spdlog::cfg::load_env_levels();
 	spdlog::set_pattern("[%Y-%m-%d %H:%M:%S][%^%l%$][%t] %v");
 	bpftime_initialize_global_shm(shm_open_type::SHM_REMOVE_AND_CREATE);
-	const auto &agent_config = set_agent_config_from_env();
+	const auto agent_config = get_agent_config_from_env();
+	bpftime_set_agent_config(agent_config);
 #ifdef ENABLE_BPFTIME_VERIFIER
 	std::vector<int32_t> helper_ids;
 	std::map<int32_t, bpftime::verifier::BpftimeHelperProrotype>

--- a/tools/bpftimetool/main.cpp
+++ b/tools/bpftimetool/main.cpp
@@ -163,7 +163,8 @@ int main(int argc, char *argv[])
 		}
 		bpftime_initialize_global_shm(
 			shm_open_type::SHM_CREATE_OR_OPEN);
-		set_agent_config_from_env();
+		auto agent_config = get_agent_config_from_env();
+		bpftime_set_agent_config(agent_config);
 		auto filename = std::string(argv[2]);
 		return bpftime_import_global_shm_from_json(filename.c_str());
 	} else if (cmd == "remove") {


### PR DESCRIPTION
<!--# Pull Request Template-->

## Description

I have declared `extern size_t BPFTIME_SHARED_MEMORY_SIZE;` inside `bpftime_shm_internal.hpp` and inside `bpftime_shm_internal.cpp` defined the `size_t BPFTIME_SHARED_MEMORY_SIZE = 20; // Default size`

Then inside the cli/main.cpp I have added support for --shared-memory-size.


Fixes #282 

## Type of change

<!--Please delete options that are not relevant.-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [✅] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [ ] Test A
- [ ] Test B

**Test Configuration**:


## Checklist

- [✅] My code follows the style guidelines of this project
- [✅] I have performed a self-review of my own code
- [✅] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [✅] I have checked my code and corrected any misspellings
