### PR TITLE
Make llvm-jit work with bpftrace

### DIFF
--- a/vm/llvm-jit/CMakeLists.txt
+++ b/vm/llvm-jit/CMakeLists.txt
@@ -43,6 +43,8 @@ if (${LLVM_PACKAGE_VERSION} VERSION_LESS 15)
     message(FATAL_ERROR "LLVM version must be >=15")
 endif()
 
+option(ENABLE_LLVM_SHARED "Link shared library of LLVM" YES)
+
 if(ENABLE_LLVM_SHARED)
     set(LLVM_LIBS LLVM)
 else()


### PR DESCRIPTION
The root cause of #270 is symbol conflict. Closes #270 

- When bpftime links llvm statically and uses LD_PRELOAD to inject into other program which links LLVM dynamically, the symbol in bpftime will override the symbol linked in the injected program. So bpftime initialized LLVM, and the injected program also initialized LLVM, and their initializing results were put into the same global variable, thus leading to option conflict

There are also two solutions:
- Link LLVM dynamically in bpftime. This is relatively easy. We add a CMake option `ENABLE_LLVM_SHARED` and set it default to be true
- Use version script to limit symbols of LLVM into an individual namespace, so these symbols will not override symbols in the injected program. I've also tried this way but more problems were encountered. 

## Problems if we use version script

I use a version script like
```
BPFTIME_SYSCALL_SERVER_LLVM {
    local: _ZN4llvm*;  
};
```

But if we run bpftrace, we will have:
```console
root@mnfe-pve:~/bpftime# bpftime load bpftrace ./example/bpftrace/syscount.bt 
[2024-04-25 20:08:03.119] [info] [syscall_context.hpp:86] manager constructed
[2024-04-25 20:08:03.995] [info] [syscall_server_utils.cpp:24] Initialize syscall server
[2024-04-25 20:08:04][error][3770196] pkey_alloc failed
[2024-04-25 20:08:04][info][3770196] Global shm constructed. shm_open_type 0 for bpftime_maps_shm
[2024-04-25 20:08:04][info][3770196] Global shm initialized
[2024-04-25 20:08:04][info][3770196] Enabling helper groups ufunc, kernel, shm_map by default
[2024-04-25 20:08:04][info][3770196] bpftime-syscall-server started
/lib/modules/6.6.0/build/include/linux/kconfig.h:5:10: fatal error: sorry, this include generates a translation unit too large for Clang to process.
INFO [3770196]: Global shm destructed
[2024-04-25 20:08:04.083] [error] Program exited abnormally, code=1
```
An include file fails to parse. 

## Final
Linking LLVM dynamically works well, so we accept this method now. Further investigation of version-script method might be in the future

Reference:
- https://discourse.llvm.org/t/can-something-be-done-with-the-inconsistency-in-registered-commandline-options-error/1720/7