### PR TITLE
fix: fix segmentation fault about bashreadline

### DIFF
--- a/attach/frida_uprobe_attach_impl/include/frida_attach_private_data.hpp
+++ b/attach/frida_uprobe_attach_impl/include/frida_attach_private_data.hpp
@@ -2,6 +2,7 @@
 #define _BPFTIME_FRIDA_ATTACH_PRIVATE_DATA_HPP
 #include "attach_private_data.hpp"
 #include <cstdint>
+#include <string>
 namespace bpftime
 {
 namespace attach
@@ -10,6 +11,8 @@ namespace attach
 struct frida_attach_private_data final : public attach_private_data {
     // The address to hook
 	uint64_t addr;
+    // Saved module name
+    std::string module_name;
     // The input string should be: Either an decimal integer in string format, indicating the function address to hook. Or in format of NAME:OFFSET, where NAME is the module name (empty is ok), OFFSET is the module offset
 	int initialize_from_string(const std::string_view &sv) override;
 };

--- a/attach/frida_uprobe_attach_impl/src/frida_attach_private_data.cpp
+++ b/attach/frida_uprobe_attach_impl/src/frida_attach_private_data.cpp
@@ -28,6 +28,7 @@ int frida_attach_private_data::initialize_from_string(const std::string_view &sv
 		addr = (uintptr_t)resolve_function_addr_by_module_offset(
 			module_part, std::stoul(offset_part));
 		SPDLOG_DEBUG("Resolved address: {:x} from string {}", addr, sv);
+		this->module_name = module_part;
 	}
 
 	return 0;

--- a/attach/frida_uprobe_attach_impl/src/frida_uprobe_attach_impl.cpp
+++ b/attach/frida_uprobe_attach_impl/src/frida_uprobe_attach_impl.cpp
@@ -43,6 +43,10 @@ int frida_attach_impl::attach_at_with_ebpf_callback(void *func_addr,
 int frida_attach_impl::attach_at(void *func_addr,
 				 frida_attach_entry_callback &&cb)
 {
+	if (func_addr == nullptr) {
+		SPDLOG_ERROR("Unable to attach uprobes to address 0");
+		return -EINVAL;
+	}
 	auto itr = internal_attaches.find(func_addr);
 	int current_attach_type;
 	if (std::holds_alternative<callback_variant>(cb)) {

--- a/attach/frida_uprobe_attach_impl/src/frida_uprobe_attach_impl.cpp
+++ b/attach/frida_uprobe_attach_impl/src/frida_uprobe_attach_impl.cpp
@@ -10,7 +10,11 @@
 #include "spdlog/spdlog.h"
 #include <algorithm>
 #include <cerrno>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
 #include <memory>
+#include <string>
 #include <typeinfo>
 #include <utility>
 #include <unistd.h>
@@ -165,7 +169,42 @@ int frida_attach_impl::create_attach_with_ebpf_callback(
 	try {
 		auto &sub = dynamic_cast<const frida_attach_private_data &>(
 			private_data);
+		SPDLOG_DEBUG(
+			"Attaching with ebpf callback, private data offset={:x}, module name={}",
+			sub.addr, sub.module_name);
+		// Check if module path exists in the current process's map
+		{
+			bool ok = false;
+			std::ifstream ifs("/proc/self/maps");
+			std::string line;
+			while (ifs) {
+				std::getline(ifs, line);
+				SPDLOG_DEBUG("Checking map line {}", line);
+				char *module_path;
+				if (sscanf(line.c_str(), "%*s%*s%*s%*s%*s%ms",
+					   &module_path) == 1) {
+					std::string curr_module(module_path);
+					free(module_path);
 
+					bool matched =
+						std::filesystem::equivalent(
+							sub.module_name,
+							curr_module);
+					SPDLOG_DEBUG("Checking {}, matched={}",
+						     curr_module, matched);
+					if (matched) {
+						ok = true;
+						break;
+					}
+				}
+			}
+			if (!ok) {
+				SPDLOG_ERROR(
+					"Unable to attach: module name {} doesn't exist in current process's memory maps",
+					sub.module_name);
+				return -EINVAL;
+			}
+		}
 		ebpf_callback_args args{ .ebpf_cb = cb,
 					 .attach_type = attach_type };
 		if (attach_type == ATTACH_UPROBE ||

--- a/tools/bpftimetool/main.cpp
+++ b/tools/bpftimetool/main.cpp
@@ -72,7 +72,7 @@ int bpftime_run_ebpf_program(int id,
 	const handler_manager *manager =
 		shm_holder.global_shared_memory.get_manager();
 	size_t handler_size = manager->size();
-	if (id >= handler_size || id < 0) {
+	if ((size_t) id >= handler_size || id < 0) {
 		cerr << "Invalid id " << id << " not exist" << endl;
 		return 1;
 	}


### PR DESCRIPTION
There are two bugs that caused bpftime unable to run bashreadline (example/libbpf-tools/bashreadline)

- [ ] bashrc seems to be incompatible with bpftime+bash. These can be temporarily solved by running bash using `--norc`. This is not fixed yet.
- [x] All subprocesses spawned by bash will ended up with segmentation fault. This is caused by bpftime will not check if the injected process contains the module that uprobe requires, e.g we may attach a uprobe designed for `/bin/bash @ 0x123456` to `/bin/ls` (a process that bash spawns). Under this way, `resolve_function_addr_by_module_offset` is unable to resolve the real address that should be attached, it returns nullptr, so a segmentation fault will be raised if we invoke frida to add a invocation listener. This issue was solved by checking `/proc/self/maps` and try to match each line for the desired module. If nothing was matched, we will reject this attach

Closes #277 