### PR TITLE
fix: using the openssl resolved path in sslsniff

### DIFF
--- a/example/sslsniff/sslsniff.c
+++ b/example/sslsniff/sslsniff.c
@@ -447,7 +447,7 @@ int main(int argc, char **argv) {
 	if (env.openssl) {
 		char *openssl_path = find_library_path("libssl.so");
 		printf("OpenSSL path: %s\n", openssl_path);
-		attach_openssl(obj, "/lib/x86_64-linux-gnu/libssl.so.3");
+		attach_openssl(obj, openssl_path);
 	}
 	if (env.gnutls) {
 		char *gnutls_path = find_library_path("libgnutls.so");


### PR DESCRIPTION
## Description

`sslsniff` was using an hardcoded OpenSSL path by default and ignoring the previously resolved path.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Compile
- [x] Run the `sslsniff` without the `-o` option (Which disable OpenSSL hooking)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
