### PR TITLE
fix: log runtime output to env var "BPFTIME_LOG_OUTPUT"

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -31,11 +31,19 @@ jobs:
       - name: Build and install runtime (with llvm-jit)
         if: ${{matrix.enable_jit}}
         run: |
-          make release-with-llvm-jit -j
+          cmake -Bbuild  -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
+            -DBPFTIME_LLVM_JIT=1 \
+            -DBUILD_BPFTIME_DAEMON=1 \
+            -DCMAKE_CXX_FLAGS="-DDEFAULT_LOGGER_OUTPUT_PATH='\"console\"'"
+          cmake --build build --config RelWithDebInfo --target install -j
       - name: Build and install runtime (without llvm-jit)
         if: ${{!matrix.enable_jit}}
         run: |
-          make release -j
+          cmake -Bbuild  -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
+            -DBPFTIME_LLVM_JIT=0 \
+            -DBUILD_BPFTIME_DAEMON=1 \
+            -DCMAKE_CXX_FLAGS="-DDEFAULT_LOGGER_OUTPUT_PATH='\"console\"'"
+          cmake --build build --config RelWithDebInfo --target install -j
       - name: Upload build results (without jit)
         uses: actions/upload-artifact@v3
         if: ${{!matrix.enable_jit}}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,7 @@ message(STATUS "Started CMake for ${PROJECT_NAME} v${PROJECT_VERSION}...\n")
 
 # if option to build without libbpf is set
 if(${BPFTIME_BUILD_WITH_LIBBPF})
-  add_definitions(-DUSE_LIBBPF)
+  add_definitions(-DBPFTIME_BUILD_WITH_LIBBPF=1)
 endif()
 
 if(UNIX)
@@ -135,7 +135,7 @@ endif()
 add_subdirectory(third_party/spdlog)
 if(NOT DEFINED SPDLOG_ACTIVE_LEVEL)
   if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    add_compile_definitions(SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_DEBUG)
+    add_compile_definitions(SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE)
   else()
     add_compile_definitions(SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO)
   endif()

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ release: ## build the release version
 
 release-with-llvm-jit: ## build the package, with llvm-jit
 	cmake -Bbuild  -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
-				   -DBPFTIME_LLVM_JIT=1
+				   -DBPFTIME_LLVM_JIT=1 \
 				   -DBUILD_BPFTIME_DAEMON=1
 	cmake --build build --config RelWithDebInfo --target install -j$(JOBS)
 

--- a/README.md
+++ b/README.md
@@ -17,18 +17,18 @@
 
 ## Key Features
 
-- **Uprobe and Syscall hooks based on binary rewriting**: Run eBPF programs in userspace, attaching them to Uprobes and Syscall tracepoints: **No manual instrumentation or restart required!**. It can `trace` or `change` the execution of a function, `hook` or `filter` all syscalls of a process safely, and efficiently with an eBPF userspace runtime.
-- **Performance**: Experience up to a `10x` speedup in Uprobe overhead compared to kernel uprobe and uretprobe.
+- **Uprobe and Syscall hooks based on binary rewriting**: Run eBPF programs in userspace, attaching them to Uprobes and Syscall tracepoints: **No manual instrumentation or restart required!**. It can `trace` or `change` the execution of a function, `hook` or `filter` all syscalls of a process safely, and efficiently with an eBPF userspace runtime. Can inject eBPF runtime into any running process without the need for a restart or manual recompilation.
+- **Performance**: Experience up to a `10x` speedup in Uprobe overhead compared to kernel uprobe and uretprobe. Read/Write userspace memory is also faster than kernel eBPF.
 - **Interprocess eBPF Maps**: Implement userspace `eBPF maps` in shared userspace memory for summary aggregation or control plane communication.
-- **Compatibility**: use `existing eBPF toolchains` like clang and libbpf to develop userspace eBPF without any modifications. Supporting CO-RE via BTF, and offering userspace host function access.
-- **JIT Support**: Benefit from a cross-platform eBPF interpreter and a high-speed `JIT/AOT` compiler powered by LLVM. It also includes a handcrafted x86 JIT in C for limited resources. The vm can be built as `a standalone library` like ubpf.
-- **No instrumentation**: Can inject eBPF runtime into any running process without the need for a restart or manual recompilation.
+- **Compatibility**: use `existing eBPF toolchains` like clang, libbpf and bpftrace to develop userspace eBPF application without any modifications. Supporting CO-RE via BTF, and offering userspace `ufunc` access.
+- **Multi JIT Support**: Support [llvmbpf](https://github.com/eunomia-bpf/llvmbpf), a high-speed `JIT/AOT` compiler powered by LLVM, or using `ubpf JIT` and INTERPRETER. The vm can be built as `a standalone library` like ubpf.
 - **Run with kernel eBPF**: Can load userspace eBPF from kernel, and using kernel eBPF maps to cooperate with kernel eBPF programs like kprobes and network filters.
 
 ## Components
 
-- [`vm`](https://github.com/eunomia-bpf/bpftime/tree/master/vm): The eBPF VM and JIT for eBPF, you can choose from bpftime LLVM JIT and a simple JIT/interpreter based on ubpf. It can be built as a standalone library and integrated into other projects. The API is similar to ubpf.
-- [`runtime`](https://github.com/eunomia-bpf/bpftime/tree/master/runtime): The userspace runtime for eBPF, including the syscall server and agent, attaching eBPF programs to Uprobes and Syscall tracepoints, and eBPF maps in shared memory.
+- [`vm`](https://github.com/eunomia-bpf/bpftime/tree/master/vm): The eBPF VM and JIT compiler for bpftime, you can choose from [bpftime LLVM JIT/AOT compiler](https://github.com/eunomia-bpf/llvmbpf) and [ubpf](https://github.com/iovisor/ubpf). The [llvm-based vm](https://github.com/eunomia-bpf/llvmbpf) in bpftime can also be built as a standalone library and integrated into other projects, similar to ubpf.
+- [`runtime`](https://github.com/eunomia-bpf/bpftime/tree/master/runtime): The userspace runtime for eBPF, including the bpf-syscall loader(`syscall-server`) and agent, support attaching eBPF programs to Uprobes, Syscall tracepoints and other events, as well as eBPF maps in shared memory.
+- [verifier](https://github.com/eunomia-bpf/bpftime/tree/master/bpftime-verifier): Support using [PREVAIL](https://github.com/vbpf/ebpf-verifier) as userspace verifier, or using Linux kernel verifier as an option.
 - [`daemon`](https://github.com/eunomia-bpf/bpftime/tree/master/daemon): A daemon to make userspace eBPF working with kernel and compatible with kernel uprobe. Monitor and modify kernel eBPF events and syscalls, load eBPF in userspace from kernel.
 
 ## Quick Start

--- a/attach/text_segment_transformer/agent-transformer.cpp
+++ b/attach/text_segment_transformer/agent-transformer.cpp
@@ -69,7 +69,7 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 			"Please set AGENT_SO to the bpftime-agent when use this tranformer");
 		return;
 	}
-	SPDLOG_INFO("Using agent {}", agent_so);
+	SPDLOG_DEBUG("Using agent {}", agent_so);
 	cs_arch_register_x86();
 	bpftime::setup_syscall_tracer();
 	SPDLOG_DEBUG("Loading dynamic library..");
@@ -98,5 +98,5 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 		bpftime::get_call_hook();
 	entry_func(&orig_syscall_hooker_func);
 	bpftime::set_call_hook(orig_syscall_hooker_func);
-	SPDLOG_INFO("Transformer exiting, trace will be usable now");
+	SPDLOG_DEBUG("Transformer exiting, syscall trace is usable now");
 }

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -78,7 +78,7 @@ set(sources
   extension/extension_helper.cpp
 )
 
-if(UNIX AND NOT APPLE)
+if(UNIX AND NOT APPLE AND BPFTIME_BUILD_WITH_LIBBPF)
   list(APPEND sources
     src/bpf_map/shared/array_map_kernel_user.cpp
     src/bpf_map/shared/hash_map_kernel_user.cpp
@@ -93,13 +93,6 @@ set(headers
 )
 message(INFO " Headers: ${headers}")
 message(INFO " Found the following sources: ${sources}")
-
-
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-  add_definitions(-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_DEBUG)
-else()
-  add_definitions(-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO)
-endif()
 
 add_library(
   ${PROJECT_NAME}
@@ -238,16 +231,17 @@ message(DEBUG "Successfully added all dependencies and linked against them.")
 
 set(BPFTIME_RUNTIME_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
-
+if (BPFTIME_BUILD_WITH_LIBBPF)
 add_subdirectory(object)
+endif()
 add_subdirectory(agent)
 add_subdirectory(syscall-server)
 #
 # Unit testing setup
 #
-if(BPFTIME_ENABLE_UNIT_TESTING)
+if(BPFTIME_ENABLE_UNIT_TESTING AND BPFTIME_BUILD_WITH_LIBBPF)
   enable_testing()
-  message(STATUS "Build unit tests for the project. Tests should always be found in the test folder\n")
+  message(STATUS "Build unit tests for the runtime. Tests should always be found in the test folder\n")
   add_subdirectory(test)
   add_subdirectory(unit-test)
 endif()

--- a/runtime/include/bpftime_config.hpp
+++ b/runtime/include/bpftime_config.hpp
@@ -4,6 +4,11 @@
 #include <cstdlib>
 #include <string>
 
+#ifndef DEFAULT_LOGGER_OUTPUT_PATH
+#define DEFAULT_LOGGER_OUTPUT_PATH "~/.bpftime/runtime.log"
+#endif
+#define stringize(x) #x
+
 namespace bpftime
 {
 // Configuration for the bpftime runtime
@@ -28,10 +33,16 @@ struct agent_config {
 	// available for the eBPF programs and maps
 	// The value is in MB
 	int shm_memory_size = 20; // 20MB
+
+	// specify the where the logger output should be written to
+	// It can be a file path or "console".
+	// If it is "console", the logger will output to stderr
+	std::string logger_output_path = DEFAULT_LOGGER_OUTPUT_PATH;
 };
 
 // Get the bpftime configuration from the environment variables
-const agent_config get_agent_config_from_env();
+// If the shared memory is not int, this should be called first
+const agent_config get_agent_config_from_env() noexcept;
 
 } // namespace bpftime
 

--- a/runtime/include/bpftime_logger.hpp
+++ b/runtime/include/bpftime_logger.hpp
@@ -1,0 +1,73 @@
+#include <string>
+#include "spdlog/spdlog.h"
+#include "spdlog/cfg/env.h"
+#include "spdlog/sinks/rotating_file_sink.h"
+#include "spdlog/sinks/stdout_color_sinks.h"
+#include <cstdlib>
+#include <iostream>
+#include <filesystem>
+#include <fstream>
+
+namespace bpftime
+{
+
+inline std::string expand_user_path(const std::string &input_path)
+{
+	if (input_path.empty()) {
+		return "console";
+	}
+
+	if (input_path[0] == '~') {
+		const char *homeDir = getenv("HOME");
+		if (!homeDir) {
+			return "console";
+		}
+
+		if (input_path.size() == 1 || input_path[1] == '/') {
+			// Replace "~" with the home directory
+			std::string expandedPath = homeDir +
+				 input_path.substr(1);
+			return expandedPath;
+		} else {
+			return "console"; // Unsupported path format
+		}
+	}
+
+	// Return the original path if no tilde expansion is needed
+	return input_path;
+}
+
+inline void bpftime_set_logger(const std::string &target) noexcept
+{
+	std::string logger_target = expand_user_path(target);
+
+	if (logger_target == "console") {
+		// Set logger to stderr
+		auto logger = spdlog::stderr_color_mt("stderr");
+		logger->set_pattern("[%Y-%m-%d %H:%M:%S][%^%l%$][%t] %v");
+		logger->flush_on(spdlog::level::info);
+		spdlog::set_default_logger(logger);
+	} else {
+		// Set logger to file, with rotation 5MB and 3 files
+		auto max_size = 1048576 * 5;
+		auto max_files = 3;
+		auto logger = spdlog::rotating_logger_mt(
+			"bpftime_logger", logger_target, max_size, max_files);
+		logger->set_pattern("[%Y-%m-%d %H:%M:%S][%^%l%$][%t] %v");
+		logger->flush_on(spdlog::level::info);
+		spdlog::set_default_logger(logger);
+	}
+
+	// Load log level from environment
+	spdlog::cfg::load_env_levels();
+}
+
+/*
+    Flush the logger.
+*/
+inline void bpftime_logger_flush()
+{
+	spdlog::default_logger()->flush();
+}
+
+} // namespace bpftime

--- a/runtime/object/bpf_object.cpp
+++ b/runtime/object/bpf_object.cpp
@@ -15,7 +15,7 @@ using namespace bpftime;
 using namespace bpftime_epoll;
 #endif
 
-#ifdef USE_LIBBPF
+#ifdef BPFTIME_BUILD_WITH_LIBBPF
 extern "C" {
 #include <bpf/libbpf.h>
 #include <bpf/btf.h>

--- a/runtime/src/bpftime_shm.cpp
+++ b/runtime/src/bpftime_shm.cpp
@@ -516,7 +516,7 @@ int bpftime_perf_event_output(int fd, const void *buf, size_t sz)
 	}
 }
 
-#if __linux__
+#if __linux__ && BPFTIME_BUILD_WITH_LIBBPF
 int bpftime_shared_perf_event_output(int map_fd, const void *buf, size_t sz)
 {
 	SPDLOG_DEBUG("Output data into shared perf event array fd {}", map_fd);

--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -4,6 +4,7 @@
  * All rights reserved.
  */
 #include "bpftime_shm.hpp"
+#include <ebpf-vm.h>
 #include "handler/epoll_handler.hpp"
 #include "handler/handler_manager.hpp"
 #include "handler/link_handler.hpp"
@@ -41,8 +42,10 @@ extern "C" void bpftime_destroy_global_shm()
 		shm_holder.global_shared_memory.~bpftime_shm();
 		// Why not spdlog? because global variables that spdlog used
 		// were already destroyed..
+#ifdef DEBUG
 		fprintf(stderr, "INFO [%d]: Global shm destructed\n",
 			(int)getpid());
+#endif
 	}
 }
 
@@ -736,7 +739,7 @@ void bpftime_shm::set_agent_config(const struct agent_config &config)
 const struct agent_config &bpftime_shm::get_agent_config()
 {
 	if (agent_config == nullptr) {
-		SPDLOG_INFO("use current process config");
+		SPDLOG_DEBUG("use current process config");
 		return local_agent_config;
 	}
 	return *agent_config;

--- a/runtime/src/bpftime_shm_json.cpp
+++ b/runtime/src/bpftime_shm_json.cpp
@@ -4,6 +4,7 @@
  * All rights reserved.
  */
 #include "bpftime_shm.hpp"
+#include <ebpf-vm.h>
 #include "handler/epoll_handler.hpp"
 #include "handler/perf_event_handler.hpp"
 #include "spdlog/spdlog.h"

--- a/runtime/src/handler/map_handler.cpp
+++ b/runtime/src/handler/map_handler.cpp
@@ -12,7 +12,7 @@
 #include <bpf_map/userspace/fix_hash_map.hpp>
 #include <bpf_map/userspace/var_hash_map.hpp>
 #include <bpf_map/userspace/ringbuf_map.hpp>
-#ifdef USE_LIBBPF
+#ifdef BPFTIME_BUILD_WITH_LIBBPF
 #include <bpf_map/shared/array_map_kernel_user.hpp>
 #include <bpf_map/shared/hash_map_kernel_user.hpp>
 #include <bpf_map/shared/percpu_array_map_kernel_user.hpp>
@@ -119,7 +119,7 @@ const void *bpf_map_handler::map_lookup_elem(const void *key,
 		return from_syscall ? do_lookup_userspace(impl) :
 				      do_lookup(impl);
 	}
-	#ifdef USE_LIBBPF
+	#ifdef BPFTIME_BUILD_WITH_LIBBPF
 	case bpf_map_type::BPF_MAP_TYPE_KERNEL_USER_ARRAY: {
 		auto impl = static_cast<array_map_kernel_user_impl *>(
 			map_impl_ptr.get());
@@ -213,7 +213,7 @@ long bpf_map_handler::map_update_elem(const void *key, const void *value,
 		return from_syscall ? do_update_userspace(impl) :
 				      do_update(impl);
 	}
-	#ifdef USE_LIBBPF
+	#ifdef BPFTIME_BUILD_WITH_LIBBPF
 	case bpf_map_type::BPF_MAP_TYPE_KERNEL_USER_ARRAY: {
 		auto impl = static_cast<array_map_kernel_user_impl *>(
 			map_impl_ptr.get());
@@ -300,7 +300,7 @@ int bpf_map_handler::bpf_map_get_next_key(const void *key, void *next_key,
 			map_impl_ptr.get());
 		return do_get_next_key(impl);
 	}
-	#if __linux__
+	#if __linux__ && defined(BPFTIME_BUILD_WITH_LIBBPF)
 	case bpf_map_type::BPF_MAP_TYPE_KERNEL_USER_ARRAY: {
 		auto impl = static_cast<array_map_kernel_user_impl *>(
 			map_impl_ptr.get());
@@ -394,7 +394,7 @@ long bpf_map_handler::map_delete_elem(const void *key, bool from_syscall) const
 		return from_syscall ? do_delete_userspace(impl) :
 				      do_delete(impl);
 	}
-	#ifdef USE_LIBBPF
+	#ifdef BPFTIME_BUILD_WITH_LIBBPF
 	case bpf_map_type::BPF_MAP_TYPE_KERNEL_USER_ARRAY: {
 		auto impl = static_cast<array_map_kernel_user_impl *>(
 			map_impl_ptr.get());
@@ -491,7 +491,7 @@ int bpf_map_handler::map_init(managed_shared_memory &memory)
 			container_name.c_str())(memory, key_size, value_size);
 		return 0;
 	}
-	#ifdef USE_LIBBPF
+	#ifdef BPFTIME_BUILD_WITH_LIBBPF
 	case bpf_map_type::BPF_MAP_TYPE_KERNEL_USER_ARRAY: {
 		map_impl_ptr = memory.construct<array_map_kernel_user_impl>(
 			container_name.c_str())(memory, attr.kernel_bpf_map_id);
@@ -570,7 +570,7 @@ void bpf_map_handler::map_free(managed_shared_memory &memory)
 	case bpf_map_type::BPF_MAP_TYPE_PERCPU_HASH:
 		memory.destroy<per_cpu_hash_map_impl>(container_name.c_str());
 		break;
-	#ifdef USE_LIBBPF
+	#ifdef BPFTIME_BUILD_WITH_LIBBPF
 	case bpf_map_type::BPF_MAP_TYPE_KERNEL_USER_ARRAY:
 		memory.destroy<array_map_kernel_user_impl>(
 			container_name.c_str());

--- a/runtime/syscall-server/CMakeLists.txt
+++ b/runtime/syscall-server/CMakeLists.txt
@@ -20,9 +20,11 @@ target_link_libraries(bpftime-syscall-server PUBLIC
 add_dependencies(bpftime-syscall-server spdlog::spdlog)
 
 if(${BPFTIME_BUILD_WITH_LIBBPF})
+
 target_include_directories(bpftime-syscall-server
     PUBLIC
-    "../../core"
+    "../include"
+    "../../vm"
     "../../third_party/libbpf/include"
     "../../third_party/libbpf/include/uapi"
     ${SPDLOG_INCLUDE}
@@ -30,12 +32,13 @@ target_include_directories(bpftime-syscall-server
 else()
 target_include_directories(bpftime-syscall-server
     PUBLIC
-    "../../core"
+    "../../vm"
     ${SPDLOG_INCLUDE}
 )
 endif()
 
 set_target_properties(bpftime-syscall-server PROPERTIES CXX_STANDARD 20 LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/syscall-server.version)
+
 if(UNIX AND NOT APPLE)
 target_link_options(bpftime-syscall-server PRIVATE -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/syscall-server.version)
 endif()

--- a/runtime/syscall-server/syscall_context.hpp
+++ b/runtime/syscall-server/syscall_context.hpp
@@ -75,23 +75,20 @@ class syscall_context {
 	// if the syscall original function is not prepared, it will cause a
 	// segfault.
 	void try_startup();
+
 	// enable userspace eBPF runing with kernel eBPF.
 	bool run_with_kernel = false;
 	// allow programs to by pass the verifier
 	// some extensions are not supported by the verifier, so we need to
 	// by pass the verifier to make it work.
 	std::string by_pass_kernel_verifier_pattern;
+
 	void load_config_from_env();
     public:
 
 	// enable mock the syscall behavior in userspace
 	bool enable_mock = true;
-	syscall_context()
-	{
-		init_original_functions();
-		load_config_from_env();
-		SPDLOG_INFO("manager constructed");
-	}
+	syscall_context();
 	syscall_fn orig_syscall_fn = nullptr;
 
 	// handle syscall

--- a/runtime/syscall-server/syscall_server_main.cpp
+++ b/runtime/syscall-server/syscall_server_main.cpp
@@ -31,7 +31,7 @@ auto handle_exceptions(F &&f, Args &&...args) noexcept
 		SPDLOG_ERROR("Boost interprocess bad_alloc: {}", e.what());
 		SPDLOG_ERROR("Consider increasing the shared memory size by "
 			     "setting the BPFTIME_SHM_MEMORY_MB env var.");
-		std::abort();
+		std::exit(1);
 		// Terminate the program after logging the exception
 	}
 	// More exceptions can be added here

--- a/runtime/syscall-server/syscall_server_utils.cpp
+++ b/runtime/syscall-server/syscall_server_utils.cpp
@@ -6,6 +6,7 @@
 #include "bpftime_shm_internal.hpp"
 #include <spdlog/cfg/env.h>
 #include <spdlog/spdlog.h>
+#include "bpftime_logger.hpp"
 #include <bpftime_shm.hpp>
 #ifdef ENABLE_BPFTIME_VERIFIER
 #include <bpftime-verifier.hpp>
@@ -21,11 +22,11 @@ void start_up()
 	if (already_setup)
 		return;
 	already_setup = true;
-	SPDLOG_INFO("Initialize syscall server");
-	spdlog::cfg::load_env_levels();
-	spdlog::set_pattern("[%Y-%m-%d %H:%M:%S][%^%l%$][%t] %v");
-	bpftime_initialize_global_shm(shm_open_type::SHM_REMOVE_AND_CREATE);
 	const auto agent_config = get_agent_config_from_env();
+	bpftime_set_logger(agent_config.logger_output_path);
+	SPDLOG_INFO("Initialize syscall server");
+
+	bpftime_initialize_global_shm(shm_open_type::SHM_REMOVE_AND_CREATE);
 	bpftime_set_agent_config(agent_config);
 #ifdef ENABLE_BPFTIME_VERIFIER
 	std::vector<int32_t> helper_ids;


### PR DESCRIPTION
<!--# Pull Request Template-->

## Description

A draft version of logging. It implements:
- Log spdlogs to target from env var BPFTIME_LOG_OUTPUT. Default to be stderr. All logs from runtime (syscall_server, agent, agent-transformer) go to given target.
- Logs from client (cli/main.cpp) and ebpf program output untouched. I suppose ppl always want client feedback from stdout/err.

Used file but not named pipe. bpftime server should be similar to docker daemon, managing "services" of injected ebpf programs. The log should be persistent, reusable. 

Now usage:
```
kailian@ubt23:~/bpftime$ sudo BPFTIME_LOG_OUTPUT=skeleton_logging.out /home/kailian/.bpftime/bpftime -i /home/kailian/.bpftime load ./example/opensnoop/opensnoop\
PID    COMM              FD ERR PATH
^CINFO [40749]: Global shm destructed

kailian@ubt23:~/bpftime$ cat skeleton_logging.out
[2024-06-02 10:12:32][info][40749] manager constructed
[2024-06-02 10:12:32][info][40749] Initialize syscall server
[2024-06-02 10:12:32][info][40749] Global shm constructed. shm_open_type 0 for bpftime_maps_shm
[2024-06-02 10:12:32][info][40749] Global shm initialized
[2024-06-02 10:12:32][info][40749] Enabling helper groups ufunc, kernel, shm_map by default
[2024-06-02 10:12:32][info][40749] bpftime-syscall-server started
```

I may add these feature in this PR, hoping suggestions or confirmation from you:

- Provide a subcommand similar to trace to output logs we want.
- Logs be optionally reserved under /var/log/ or syslog under linux. Log rotation are management automatically.
- Merge logs from different processes as one. Add tags of source (which injected process causing) to the log. 
- Add documentations about logging. 

resolves # 279

## Type of change

<!--Please delete options that are not relevant.-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

<!--Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration-->

- [x] Manually test: load & start.

```
sudo BPFTIME_LOG_OUTPUT=skeleton_logging.out /home/kailian/.bpftime/bpftime -i /home/kailian/.bpftime load ./example/opensnoop/opensnoop
sudo BPFTIME_LOG_OUTPUT=skeleton_logging.out /home/kailian/.bpftime/bpftime -i /home/kailian/.bpftime start  ./example/opensnoop/victim
sudo BPFTIME_LOG_OUTPUT=skeleton_logging.out /home/kailian/.bpftime/bpftime -i /home/kailian/.bpftime start  -s ./example/opensnoop/victim
```

- [x] Manually test: load & attach.

```
sudo BPFTIME_LOG_OUTPUT=victim_out.log ./example/opensnoop/victim
sudo BPFTIME_LOG_OUTPUT=skeleton_logging.out /home/kailian/.bpftime/bpftime -i /home/kailian/.bpftime attach `pidof victim`
```

**Test Configuration**:

- Hardware: x86
- Toolchain:g++
- OS: ubuntu 23.10

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
