### PR TITLE
fix: do not override symbols in userland eBPF programs with symbols provided by bpftime's bundled libbpf

### DIFF
--- a/runtime/agent/CMakeLists.txt
+++ b/runtime/agent/CMakeLists.txt
@@ -2,7 +2,7 @@ add_library(bpftime-agent SHARED
   agent.cpp
 )
 add_dependencies(bpftime-agent FridaGum spdlog::spdlog bpftime_frida_uprobe_attach_impl bpftime_syscall_trace_attach_impl)
-set_target_properties(bpftime-agent PROPERTIES CXX_STANDARD 20)
+set_target_properties(bpftime-agent PROPERTIES CXX_STANDARD 20 LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/agent.version)
 target_link_options(bpftime-agent PRIVATE -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/agent.version)
 target_include_directories(bpftime-agent
   PRIVATE

--- a/runtime/agent/CMakeLists.txt
+++ b/runtime/agent/CMakeLists.txt
@@ -2,7 +2,8 @@ add_library(bpftime-agent SHARED
   agent.cpp
 )
 add_dependencies(bpftime-agent FridaGum spdlog::spdlog bpftime_frida_uprobe_attach_impl bpftime_syscall_trace_attach_impl)
-set_property(TARGET bpftime-agent PROPERTY CXX_STANDARD 20)
+set_target_properties(bpftime-agent PROPERTIES CXX_STANDARD 20)
+target_link_options(bpftime-agent PRIVATE -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/agent.version)
 target_include_directories(bpftime-agent
   PRIVATE
   ${FRIDA_GUM_INSTALL_DIR}

--- a/runtime/agent/agent.version
+++ b/runtime/agent/agent.version
@@ -1,0 +1,4 @@
+{
+    global: injected_with_frida; bpftime_hooked_main; __libc_start_main; bpftime_agent_main; syscall_callback; _bpftime__setup_syscall_trace_callback;
+    local: *;
+};

--- a/runtime/syscall-server/CMakeLists.txt
+++ b/runtime/syscall-server/CMakeLists.txt
@@ -23,8 +23,8 @@ target_include_directories(bpftime-syscall-server
     "../../third_party/libbpf/include/uapi"
     ${SPDLOG_INCLUDE}
 )
-set_property(TARGET bpftime-syscall-server PROPERTY CXX_STANDARD 20)
-
+set_target_properties(bpftime-syscall-server PROPERTIES CXX_STANDARD 20 LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/syscall-server.version)
+target_link_options(bpftime-syscall-server PRIVATE -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/syscall-server.version)
 if(${ENABLE_EBPF_VERIFIER})
     add_dependencies(bpftime-syscall-server bpftime-verifier)
     target_link_libraries(bpftime-syscall-server PRIVATE bpftime-verifier)

--- a/runtime/syscall-server/syscall-server.version
+++ b/runtime/syscall-server/syscall-server.version
@@ -1,0 +1,4 @@
+{
+    global: epoll_wait; epoll_ctl; epoll_create1; ioctl; mmap64; mmap; close; syscall; munmap;
+    local: *;
+};


### PR DESCRIPTION
Closes #184 
Use version script to limit dynamic exported symbols. Now only symbols needed for attaching was exported.
```console
root@mnfe-pve:~/bpftime/example/opensnoop# nm ~/.bpftime/libbpftime-agent.so  -D | grep " T " 
0000000000214c20 T bpftime_agent_main
0000000000214bc0 T bpftime_hooked_main
0000000000216030 T _bpftime__setup_syscall_trace_callback
00000000002155b0 T __libc_start_main
0000000000215f90 T syscall_callback
root@mnfe-pve:~/bpftime# nm -D ~/.bpftime/libbpftime-syscall-server.so | grep " T "
0000000000066ac0 T close
0000000000066720 T epoll_create1
0000000000066580 T epoll_ctl
00000000000664d0 T epoll_wait
00000000000667c0 T ioctl
00000000000669f0 T mmap
0000000000066870 T mmap64
00000000000670b0 T munmap
0000000000066b50 T syscall
```

Non-dynamic symbols won't override symbols defined in injected executable.

More tests are needed..