### PR TITLE
Fix: debug log cannot be print when build in debug mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,12 @@ endif()
 
 # spdlog
 add_subdirectory(third_party/spdlog)
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    add_compile_definitions(SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_DEBUG)
+else()
+    add_compile_definitions(SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO)
+endif()
+
 
 set(SPDLOG_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,11 +133,14 @@ endif()
 
 # spdlog
 add_subdirectory(third_party/spdlog)
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+if(NOT DEFINED SPDLOG_ACTIVE_LEVEL)
+  if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_compile_definitions(SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_DEBUG)
-else()
+  else()
     add_compile_definitions(SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO)
+  endif()
 endif()
+
 
 
 set(SPDLOG_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include)

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,6 @@ build-wo-libbpf: ## build the package with iouring extension
 
 release: ## build the release version
 	cmake -Bbuild  -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
-				   -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO
 				   -DBUILD_BPFTIME_DAEMON=1
 	cmake --build build --config RelWithDebInfo --target install  -j$(JOBS)
 
@@ -72,7 +71,7 @@ release-with-llvm-jit: ## build the package, with llvm-jit
 
 release-with-static-lib: ## build the release version with libbpftime archive
 	cmake -Bbuild  -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
-				   -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO -DBPFTIME_BUILD_STATIC_LIB=ON
+				   -DBPFTIME_BUILD_STATIC_LIB=ON
 	cmake --build build --config RelWithDebInfo --target install  -j$(JOBS)
 
 build-vm: ## build only the core library

--- a/Makefile
+++ b/Makefile
@@ -61,11 +61,13 @@ build-wo-libbpf: ## build the package with iouring extension
 release: ## build the release version
 	cmake -Bbuild  -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
 				   -DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO
+				   -DBUILD_BPFTIME_DAEMON=1
 	cmake --build build --config RelWithDebInfo --target install  -j$(JOBS)
 
 release-with-llvm-jit: ## build the package, with llvm-jit
 	cmake -Bbuild  -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
 				   -DBPFTIME_LLVM_JIT=1
+				   -DBUILD_BPFTIME_DAEMON=1
 	cmake --build build --config RelWithDebInfo --target install -j$(JOBS)
 
 release-with-static-lib: ## build the release version with libbpftime archive

--- a/attach/CMakeLists.txt
+++ b/attach/CMakeLists.txt
@@ -1,8 +1,3 @@
-if(CMAKE_BUILD_TYPE STREQUAL "Debug")
-    add_definitions(-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_DEBUG)
-  else()
-    add_definitions(-DSPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_INFO)
-  endif()
 add_subdirectory(base_attach_impl)
 add_subdirectory(frida_uprobe_attach_impl)
 if(UNIX AND NOT APPLE)

--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -546,7 +546,8 @@ bool bpftime_shm::is_exist_fake_fd(int fd) const
 bpftime_shm::bpftime_shm(const char *shm_name, shm_open_type type)
 	: open_type(type)
 {
-	size_t memory_size = get_agent_config().shm_memory_size;
+	// Get the config from env because the shared memory is not initialized
+	size_t memory_size = get_agent_config_from_env().shm_memory_size;
 	if (type == shm_open_type::SHM_OPEN_ONLY) {
 		SPDLOG_DEBUG("start: bpftime_shm for client setup");
 		// open the shm


### PR DESCRIPTION
<!--# Pull Request Template-->

## Description

Sometimes `SPDLOG_LEVEL=debug` cannot be printed even if we build in Debug mode.

## Type of change

<!--Please delete options that are not relevant.-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
