### PR TITLE
feat: add unit tests from kernel

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -81,6 +81,10 @@ jobs:
               enable: false
             examples:
               path: tailcall_minimal
+          - privilege_options:
+              enable: false
+            examples:
+              path: malloc
         privilege_options:
           - options: "--privileged -v /sys/kernel/debug/:/sys/kernel/debug:rw -v /sys/kernel/tracing:/sys/kernel/tracing:rw"
             enable: true
@@ -194,11 +198,11 @@ jobs:
         run: |
           export PATH=$PATH:~/.bpftime
           bpftime --help
-      - name: Setup tmate session
-        if: "${{matrix.container.name == 'fedora' && matrix.enable_jit && matrix.examples.path == 'malloc'}}"
-        uses: mxschmitt/action-tmate@v3
-        with:
-          limit-access-to-actor: false
+      # - name: Setup tmate session
+      #   if: "${{matrix.container.name == 'fedora' && matrix.enable_jit && matrix.examples.path == 'malloc'}}"
+      #   uses: mxschmitt/action-tmate@v3
+      #   with:
+      #     limit-access-to-actor: false
       - name: Test CLI - attach by running (syscall_trace)
         if: matrix.examples.syscall_trace
         shell: bash

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -70,7 +70,7 @@ jobs:
       image: "manjusakalza/bpftime-base-image:${{matrix.container.image}}"
       options: " ${{matrix.privilege_options.options}}"
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         exclude:
           - privilege_options:
@@ -194,6 +194,11 @@ jobs:
         run: |
           export PATH=$PATH:~/.bpftime
           bpftime --help
+      - name: Setup tmate session
+        if: "${{matrix.container.name == 'fedora' && matrix.enable_jit && matrix.examples.path == 'malloc'}}"
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: false
       - name: Test CLI - attach by running (syscall_trace)
         if: matrix.examples.syscall_trace
         shell: bash

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -213,7 +213,8 @@ jobs:
           cd example/${{matrix.examples.path}}
           python3 $ROOT/.github/script/run_example.py "${{matrix.examples.executable}}" "${{matrix.examples.victim}}" "${{matrix.examples.expected_str}}" "/github/home/.bpftime/bpftime -i /github/home/.bpftime" 0
       - name: Setup tmate session
-        if: "${{ failure() }}"
+        # Setup SSH when manually triggered and failing, so we can debug CI more conveniently
+        if: "${{ failure() && github.event_name == 'workflow_dispatch' }}"
         uses: mxschmitt/action-tmate@v3
         with:
-          limit-access-to-actor: false
+          limit-access-to-actor: true

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -70,7 +70,7 @@ jobs:
       image: "manjusakalza/bpftime-base-image:${{matrix.container.image}}"
       options: " ${{matrix.privilege_options.options}}"
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         exclude:
           - privilege_options:

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -198,11 +198,6 @@ jobs:
         run: |
           export PATH=$PATH:~/.bpftime
           bpftime --help
-      # - name: Setup tmate session
-      #   if: "${{matrix.container.name == 'fedora' && matrix.enable_jit && matrix.examples.path == 'malloc'}}"
-      #   uses: mxschmitt/action-tmate@v3
-      #   with:
-      #     limit-access-to-actor: false
       - name: Test CLI - attach by running (syscall_trace)
         if: matrix.examples.syscall_trace
         shell: bash
@@ -217,3 +212,8 @@ jobs:
           ROOT=$(pwd)
           cd example/${{matrix.examples.path}}
           python3 $ROOT/.github/script/run_example.py "${{matrix.examples.executable}}" "${{matrix.examples.victim}}" "${{matrix.examples.expected_str}}" "/github/home/.bpftime/bpftime -i /github/home/.bpftime" 0
+      - name: Setup tmate session
+        if: "${{ failure() }}"
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: false

--- a/.github/workflows/test-runtime.yml
+++ b/.github/workflows/test-runtime.yml
@@ -37,6 +37,8 @@ jobs:
       run: |
         cmake -DTEST_LCOV=ON -DBPFTIME_LLVM_JIT=YES -DBPFTIME_ENABLE_UNIT_TESTING=YES -DCMAKE_BUILD_TYPE=Debug -B build
         cmake --build build --config Debug --target bpftime_runtime_tests -j$(nproc)
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
     - name: Test Runtime
       if: "matrix.container == 'ubuntu-2204'"
       run:  ./build/runtime/unit-test/bpftime_runtime_tests

--- a/.github/workflows/test-runtime.yml
+++ b/.github/workflows/test-runtime.yml
@@ -42,10 +42,6 @@ jobs:
       run: |
         cmake -DTEST_LCOV=ON -DBPFTIME_LLVM_JIT=YES -DBPFTIME_ENABLE_UNIT_TESTING=YES -DCMAKE_BUILD_TYPE=Debug -B build
         cmake --build build --config Debug --target bpftime_runtime_tests -j$(nproc)
-    # - name: Setup tmate session
-    #   uses: mxschmitt/action-tmate@v3
-    #   with:
-    #     limit-access-to-actor: false
     - name: Test Runtime
       run:  ./build/runtime/unit-test/bpftime_runtime_tests
     

--- a/.github/workflows/test-runtime.yml
+++ b/.github/workflows/test-runtime.yml
@@ -42,6 +42,7 @@ jobs:
       run:  ./build/runtime/unit-test/bpftime_runtime_tests
     - name: Test Runtime
       if: "matrix.container == 'fedora-39'"
+      # "No space left on device"...
       run:  ./build/runtime/unit-test/bpftime_runtime_tests "~[large_memory]"
     
     - name: Generate runtime coverage (Ubuntu)

--- a/.github/workflows/test-runtime.yml
+++ b/.github/workflows/test-runtime.yml
@@ -38,7 +38,12 @@ jobs:
         cmake -DTEST_LCOV=ON -DBPFTIME_LLVM_JIT=YES -DBPFTIME_ENABLE_UNIT_TESTING=YES -DCMAKE_BUILD_TYPE=Debug -B build
         cmake --build build --config Debug --target bpftime_runtime_tests -j$(nproc)
     - name: Test Runtime
+      if: "matrix.container == 'ubuntu-2204'"
       run:  ./build/runtime/unit-test/bpftime_runtime_tests
+    - name: Test Runtime
+      if: "matrix.container == 'fedora-39'"
+      run:  ./build/runtime/unit-test/bpftime_runtime_tests "~[large_memory]"
+    
     - name: Generate runtime coverage (Ubuntu)
       if: "matrix.container == 'ubuntu-2204'"
       run: |

--- a/.github/workflows/test-runtime.yml
+++ b/.github/workflows/test-runtime.yml
@@ -26,6 +26,7 @@ jobs:
         submodules: 'recursive'
     - name: Remount shm dev
       # The size of /dev/shm defaults to be 64M, but boost won't detect this at all, leaving bus error to us..
+      # So we remount it to make it larger
       run: |
         mount -o remount,size=1G /dev/shm
     - name: Install lcov

--- a/.github/workflows/test-runtime.yml
+++ b/.github/workflows/test-runtime.yml
@@ -24,6 +24,10 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'recursive'
+    - name: Remount shm dev
+      # The size of /dev/shm defaults to be 64M, but boost won't detect this at all, leaving bus error to us..
+      run: |
+        mount -o remount,size=1G /dev/shm
     - name: Install lcov
       if: "matrix.container == 'ubuntu-2204'"
       run: |
@@ -37,17 +41,12 @@ jobs:
       run: |
         cmake -DTEST_LCOV=ON -DBPFTIME_LLVM_JIT=YES -DBPFTIME_ENABLE_UNIT_TESTING=YES -DCMAKE_BUILD_TYPE=Debug -B build
         cmake --build build --config Debug --target bpftime_runtime_tests -j$(nproc)
-    - name: Setup tmate session
-      uses: mxschmitt/action-tmate@v3
-      with:
-        limit-access-to-actor: false
+    # - name: Setup tmate session
+    #   uses: mxschmitt/action-tmate@v3
+    #   with:
+    #     limit-access-to-actor: false
     - name: Test Runtime
-      if: "matrix.container == 'ubuntu-2204'"
       run:  ./build/runtime/unit-test/bpftime_runtime_tests
-    - name: Test Runtime
-      if: "matrix.container == 'fedora-39'"
-      # "No space left on device"...
-      run:  ./build/runtime/unit-test/bpftime_runtime_tests "~[large_memory]"
     
     - name: Generate runtime coverage (Ubuntu)
       if: "matrix.container == 'ubuntu-2204'"

--- a/.github/workflows/test-runtime.yml
+++ b/.github/workflows/test-runtime.yml
@@ -39,6 +39,8 @@ jobs:
         cmake --build build --config Debug --target bpftime_runtime_tests -j$(nproc)
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3
+      with:
+        limit-access-to-actor: false
     - name: Test Runtime
       if: "matrix.container == 'ubuntu-2204'"
       run:  ./build/runtime/unit-test/bpftime_runtime_tests

--- a/attach/frida_uprobe_attach_impl/CMakeLists.txt
+++ b/attach/frida_uprobe_attach_impl/CMakeLists.txt
@@ -27,7 +27,7 @@ option(TEST_LCOV "option for lcov" OFF)
 add_executable(bpftime_frida_uprobe_attach_tests ${TEST_SOURCES})
 
 if (${TEST_LCOV}) 
-    target_compile_options(bpftime_frida_uprobe_attach_tests PRIVATE -fprofile-arcs -ftest-coverage)
+    target_compile_options(bpftime_frida_uprobe_attach_tests PRIVATE -fprofile-arcs -ftest-coverage -fprofile-update=atomic)
 endif()
 
 if(${ENABLE_EBPF_VERIFIER} AND NOT TARGET Catch2)

--- a/attach/syscall_trace_attach_impl/CMakeLists.txt
+++ b/attach/syscall_trace_attach_impl/CMakeLists.txt
@@ -32,7 +32,7 @@ option(TEST_LCOV "option for lcov" OFF)
 add_executable(bpftime_syscall_trace_attach_tests ${TEST_SOURCES})
 
 if (${TEST_LCOV}) 
-    target_compile_options(bpftime_syscall_trace_attach_tests PRIVATE -fprofile-arcs -ftest-coverage)
+    target_compile_options(bpftime_syscall_trace_attach_tests PRIVATE -fprofile-arcs -ftest-coverage -fprofile-update=atomic)
 endif()
 
 if(${ENABLE_EBPF_VERIFIER} AND NOT TARGET Catch2)

--- a/bpftime-verifier/CMakeLists.txt
+++ b/bpftime-verifier/CMakeLists.txt
@@ -38,7 +38,7 @@ option(TEST_LCOV "option for lcov" OFF)
 add_executable(bpftime_verifier_tests ${TEST_SOURCES})
 
 if (${TEST_LCOV}) 
-    target_compile_options(bpftime_verifier_tests PRIVATE -fprofile-arcs -ftest-coverage)
+    target_compile_options(bpftime_verifier_tests PRIVATE -fprofile-arcs -ftest-coverage -fprofile-update=atomic)
 endif()
 
 add_dependencies(bpftime_verifier_tests bpftime-verifier)

--- a/runtime/src/bpf_map/map_common_def.hpp
+++ b/runtime/src/bpf_map/map_common_def.hpp
@@ -5,7 +5,6 @@
  */
 #ifndef _MAP_COMMON_DEF_HPP
 #define _MAP_COMMON_DEF_HPP
-#include "linux/bpf.h"
 #include "spdlog/spdlog.h"
 #include <boost/container_hash/hash.hpp>
 #include <cinttypes>
@@ -69,9 +68,11 @@ struct bytes_vec_hasher {
 		return seed;
 	}
 };
+
 static inline bool check_update_flags(uint64_t flags)
 {
-	if (flags != BPF_ANY && flags != BPF_NOEXIST && flags != BPF_EXIST) {
+	if (flags != 0 /*BPF_ANY*/ && flags != 1 /*BPF_NOEXIST*/ &&
+	    flags != 2 /*BPF_EXIST*/) {
 		errno = EINVAL;
 		return false;
 	}

--- a/runtime/src/bpf_map/map_common_def.hpp
+++ b/runtime/src/bpf_map/map_common_def.hpp
@@ -5,6 +5,7 @@
  */
 #ifndef _MAP_COMMON_DEF_HPP
 #define _MAP_COMMON_DEF_HPP
+#include "linux/bpf.h"
 #include "spdlog/spdlog.h"
 #include <boost/container_hash/hash.hpp>
 #include <cinttypes>
@@ -68,6 +69,14 @@ struct bytes_vec_hasher {
 		return seed;
 	}
 };
+static inline bool check_update_flags(uint64_t flags)
+{
+	if (flags != BPF_ANY && flags != BPF_NOEXIST && flags != BPF_EXIST) {
+		errno = EINVAL;
+		return false;
+	}
+	return true;
+}
 } // namespace bpftime
 
 #endif

--- a/runtime/src/bpf_map/userspace/per_cpu_array_map.cpp
+++ b/runtime/src/bpf_map/userspace/per_cpu_array_map.cpp
@@ -4,6 +4,7 @@
  * All rights reserved.
  */
 #include "bpf_map/map_common_def.hpp"
+#include "linux/bpf.h"
 #include "spdlog/spdlog.h"
 #include <algorithm>
 #include <bpf_map/userspace/per_cpu_array_map.hpp>
@@ -39,7 +40,7 @@ void *per_cpu_array_map_impl::elem_lookup(const void *key)
 		}
 		uint32_t key_val = *(uint32_t *)key;
 		if (key_val >= max_ent) {
-			errno = E2BIG;
+			errno = ENOENT;
 			return nullptr;
 		}
 		return data_at(key_val, cpu);
@@ -49,6 +50,8 @@ void *per_cpu_array_map_impl::elem_lookup(const void *key)
 long per_cpu_array_map_impl::elem_update(const void *key, const void *value,
 					 uint64_t flags)
 {
+	if (!check_update_flags(flags))
+		return -1;
 	return ensure_on_current_cpu<long>([&](int cpu) -> long {
 		// return impl[cpu].elem_update(key, value, flags);
 		if (key == nullptr) {
@@ -56,6 +59,10 @@ long per_cpu_array_map_impl::elem_update(const void *key, const void *value,
 			return -1;
 		}
 		uint32_t key_val = *(uint32_t *)key;
+		if (key_val < max_ent && flags == BPF_NOEXIST) {
+			errno = EEXIST;
+			return -1;
+		}
 		if (key_val >= max_ent) {
 			errno = E2BIG;
 			return -1;
@@ -68,13 +75,12 @@ long per_cpu_array_map_impl::elem_update(const void *key, const void *value,
 
 long per_cpu_array_map_impl::elem_delete(const void *key)
 {
-	errno = ENOTSUP;
+	errno = EINVAL;
 	SPDLOG_DEBUG("Deleting of per cpu array is not supported");
 	return -1;
 }
 
-int per_cpu_array_map_impl::map_get_next_key(const void *key,
-						 void *next_key)
+int per_cpu_array_map_impl::map_get_next_key(const void *key, void *next_key)
 {
 	// Not found
 	if (key == nullptr || *(uint32_t *)key >= max_ent) {
@@ -100,7 +106,7 @@ void *per_cpu_array_map_impl::elem_lookup_userspace(const void *key)
 	}
 	uint32_t key_val = *(uint32_t *)key;
 	if (key_val >= max_ent) {
-		errno = E2BIG;
+		errno = ENOENT;
 		return nullptr;
 	}
 	return data_at(key_val, 0);
@@ -110,11 +116,17 @@ long per_cpu_array_map_impl::elem_update_userspace(const void *key,
 						   const void *value,
 						   uint64_t flags)
 {
+	if (!check_update_flags(flags))
+		return -1;
 	if (key == nullptr) {
 		errno = ENOENT;
 		return -1;
 	}
 	uint32_t key_val = *(uint32_t *)key;
+	if (key_val < max_ent && flags == BPF_NOEXIST) {
+		errno = EEXIST;
+		return -1;
+	}
 	if (key_val >= max_ent) {
 		errno = E2BIG;
 		return -1;
@@ -126,7 +138,7 @@ long per_cpu_array_map_impl::elem_update_userspace(const void *key,
 
 long per_cpu_array_map_impl::elem_delete_userspace(const void *key)
 {
-	errno = ENOTSUP;
+	errno = EINVAL;
 	SPDLOG_ERROR("Element delete is not supported by per cpu array");
 	return -1;
 }

--- a/runtime/src/bpf_map/userspace/per_cpu_array_map.cpp
+++ b/runtime/src/bpf_map/userspace/per_cpu_array_map.cpp
@@ -139,7 +139,7 @@ long per_cpu_array_map_impl::elem_update_userspace(const void *key,
 long per_cpu_array_map_impl::elem_delete_userspace(const void *key)
 {
 	errno = EINVAL;
-	SPDLOG_ERROR("Element delete is not supported by per cpu array");
+	SPDLOG_WARN("Element delete is not supported by per cpu array");
 	return -1;
 }
 

--- a/runtime/src/bpf_map/userspace/per_cpu_hash_map.cpp
+++ b/runtime/src/bpf_map/userspace/per_cpu_hash_map.cpp
@@ -14,14 +14,6 @@
 #include <unistd.h>
 #include "platform_utils.hpp"
 
-static inline bool check_update_flags(uint64_t flags)
-{
-	if (flags != BPF_ANY && flags != BPF_NOEXIST && flags != BPF_EXIST) {
-		errno = EINVAL;
-		return false;
-	}
-	return true;
-}
 
 namespace bpftime
 {

--- a/runtime/src/bpf_map/userspace/per_cpu_hash_map.cpp
+++ b/runtime/src/bpf_map/userspace/per_cpu_hash_map.cpp
@@ -4,28 +4,40 @@
  * All rights reserved.
  */
 #include "bpf_map/map_common_def.hpp"
+#include "linux/bpf.h"
 #include "spdlog/fmt/bin_to_hex.h"
 #include "spdlog/spdlog.h"
 #include <algorithm>
 #include <bpf_map/userspace/per_cpu_hash_map.hpp>
+#include <cerrno>
+#include <cstring>
 #include <unistd.h>
 #include "platform_utils.hpp"
+
+static inline bool check_update_flags(uint64_t flags)
+{
+	if (flags != BPF_ANY && flags != BPF_NOEXIST && flags != BPF_EXIST) {
+		errno = EINVAL;
+		return false;
+	}
+	return true;
+}
 
 namespace bpftime
 {
 per_cpu_hash_map_impl::per_cpu_hash_map_impl(
 	boost::interprocess::managed_shared_memory &memory, uint32_t key_size,
-	uint32_t value_size)
-	: per_cpu_hash_map_impl(memory, key_size, value_size,
+	uint32_t value_size, uint32_t max_entries)
+	: per_cpu_hash_map_impl(memory, key_size, value_size, max_entries,
 				sysconf(_SC_NPROCESSORS_ONLN))
 {
 }
 
 per_cpu_hash_map_impl::per_cpu_hash_map_impl(
 	boost::interprocess::managed_shared_memory &memory, uint32_t key_size,
-	uint32_t value_size, int ncpu)
+	uint32_t value_size, uint32_t max_entries, int ncpu)
 	: impl(memory.get_segment_manager()), key_size(key_size),
-	  value_size(value_size), ncpu(ncpu),
+	  value_size(value_size), ncpu(ncpu), _max_entries(max_entries),
 	  value_template(value_size * ncpu, memory.get_segment_manager()),
 	  key_templates(memory.get_segment_manager()),
 	  single_value_templates(memory.get_segment_manager())
@@ -64,6 +76,8 @@ void *per_cpu_hash_map_impl::elem_lookup(const void *key)
 long per_cpu_hash_map_impl::elem_update(const void *key, const void *value,
 					uint64_t flags)
 {
+	if (!check_update_flags(flags))
+		return -1;
 	int cpu = my_sched_getcpu();
 	SPDLOG_DEBUG("Per cpu update, key {}, value {}", (const char *)key,
 		     *(long *)value);
@@ -115,7 +129,7 @@ int per_cpu_hash_map_impl::map_get_next_key(const void *key, void *next_key)
 	}
 	// No need to be allocated at shm. Allocate as a local variable to make
 	// it thread safe, since we use sharable lock
-	bytes_vec key_vec = this->key_templates[0];
+	bytes_vec &key_vec = this->key_templates[0];
 	key_vec.assign((uint8_t *)key, (uint8_t *)key + key_size);
 
 	auto itr = impl.find(key_vec);
@@ -139,7 +153,7 @@ void *per_cpu_hash_map_impl::elem_lookup_userspace(const void *key)
 		errno = ENOENT;
 		return nullptr;
 	}
-	bytes_vec key_vec = this->key_templates[0];
+	bytes_vec &key_vec = this->key_templates[0];
 	key_vec.assign((uint8_t *)key, (uint8_t *)key + key_size);
 	if (auto itr = impl.find(key_vec); itr != impl.end()) {
 		SPDLOG_TRACE("Exit elem lookup of hash map: {}",
@@ -157,24 +171,54 @@ long per_cpu_hash_map_impl::elem_update_userspace(const void *key,
 						  const void *value,
 						  uint64_t flags)
 {
-	bytes_vec key_vec = this->key_templates[0];
+	if (!check_update_flags(flags))
+		return -1;
+	bytes_vec &key_vec = this->key_templates[0];
 	bytes_vec value_vec = this->value_template;
 	key_vec.assign((uint8_t *)key, (uint8_t *)key + key_size);
 	value_vec.assign((uint8_t *)value,
 			 (uint8_t *)value + value_size * ncpu);
-
-	if (auto itr = impl.find(key_vec); itr != impl.end()) {
-		itr->second = value_vec;
-	} else {
-		impl.insert(bi_map_value_ty(key_vec, value_vec));
+	bool elem_exists = impl.find(key_vec) != impl.end();
+	if (flags == BPF_NOEXIST && elem_exists) {
+		errno = EEXIST;
+		return -1;
 	}
+	if (flags == BPF_EXIST && !elem_exists) {
+		errno = ENOENT;
+		return -1;
+	}
+	if (elem_exists == false && impl.size() == _max_entries) {
+		errno = E2BIG;
+		return -1;
+	}
+	impl.insert_or_assign(key_vec, value_vec);
 	return 0;
 }
 long per_cpu_hash_map_impl::elem_delete_userspace(const void *key)
 {
-	bytes_vec key_vec = this->key_templates[0];
+	bytes_vec &key_vec = this->key_templates[0];
 	key_vec.assign((uint8_t *)key, (uint8_t *)key + key_size);
-	impl.erase(key_vec);
+	auto itr = impl.find(key_vec);
+	if (itr == impl.end()) {
+		errno = ENOENT;
+		return -1;
+	}
+	impl.erase(itr);
+	return 0;
+}
+
+long per_cpu_hash_map_impl::lookup_and_delete_userspace(const void *key,
+							void *value)
+{
+	bytes_vec &key_vec = this->key_templates[0];
+	key_vec.assign((uint8_t *)key, (uint8_t *)key + key_size);
+	auto itr = this->impl.find(key_vec);
+	if (itr == impl.end()) {
+		errno = ENOENT;
+		return -1;
+	}
+	memcpy(value, itr->second.data(), ncpu * value_size);
+	impl.erase(itr);
 	return 0;
 }
 } // namespace bpftime

--- a/runtime/src/bpf_map/userspace/per_cpu_hash_map.hpp
+++ b/runtime/src/bpf_map/userspace/per_cpu_hash_map.hpp
@@ -27,27 +27,36 @@ class per_cpu_hash_map_impl {
 				     std::equal_to<bytes_vec>, bi_map_allocator>;
 
 	using shm_hash_map_vec_allocator = boost::interprocess::allocator<
-		shm_hash_map, boost::interprocess::managed_shared_memory::segment_manager>;
-	using shm_hash_map_vec = boost::interprocess::vector<shm_hash_map, shm_hash_map_vec_allocator>;
-	
+		shm_hash_map,
+		boost::interprocess::managed_shared_memory::segment_manager>;
+	using shm_hash_map_vec =
+		boost::interprocess::vector<shm_hash_map,
+					    shm_hash_map_vec_allocator>;
+
 	using bytes_vec_vec_allocator = boost::interprocess::allocator<
-		bytes_vec, boost::interprocess::managed_shared_memory::segment_manager>;
-	using bytes_vec_vec = boost::interprocess::vector<bytes_vec, bytes_vec_vec_allocator>;
+		bytes_vec,
+		boost::interprocess::managed_shared_memory::segment_manager>;
+	using bytes_vec_vec =
+		boost::interprocess::vector<bytes_vec, bytes_vec_vec_allocator>;
 
 	shm_hash_map impl;
 	uint32_t key_size;
 	uint32_t value_size;
 	int ncpu;
+	uint32_t _max_entries;
 
 	bytes_vec value_template;
 	bytes_vec_vec key_templates, single_value_templates;
+
     public:
 	const static bool should_lock = false;
 
 	per_cpu_hash_map_impl(boost::interprocess::managed_shared_memory &memory,
-			      uint32_t key_size, uint32_t value_size);
+			      uint32_t key_size, uint32_t value_size,
+			      uint32_t max_entries);
 	per_cpu_hash_map_impl(boost::interprocess::managed_shared_memory &memory,
-			      uint32_t key_size, uint32_t value_size, int ncpu);
+			      uint32_t key_size, uint32_t value_size,
+			      uint32_t max_entries, int ncpu);
 	void *elem_lookup(const void *key);
 
 	long elem_update(const void *key, const void *value, uint64_t flags);
@@ -62,6 +71,15 @@ class per_cpu_hash_map_impl {
 				   uint64_t flags);
 
 	long elem_delete_userspace(const void *key);
+	long lookup_and_delete_userspace(const void *key, void *value);
+	uint32_t get_value_size() const
+	{
+		return value_size;
+	}
+	int getncpu() const
+	{
+		return ncpu;
+	}
 };
 } // namespace bpftime
 

--- a/runtime/src/bpf_map/userspace/var_hash_map.cpp
+++ b/runtime/src/bpf_map/userspace/var_hash_map.cpp
@@ -59,7 +59,7 @@ long var_size_hash_map_impl::elem_update(const void *key, const void *value,
 	}
 	key_vec.assign((uint8_t *)key, (uint8_t *)key + _key_size);
 	value_vec.assign((uint8_t *)value, (uint8_t *)value + _value_size);
-	bool element_exists = map_impl.contains(key_vec);
+	bool element_exists = map_impl.find(key_vec) != map_impl.end();
 	// Check if the element exists...
 	if (flags == BPF_NOEXIST && element_exists) {
 		errno = EEXIST;

--- a/runtime/src/bpf_map/userspace/var_hash_map.cpp
+++ b/runtime/src/bpf_map/userspace/var_hash_map.cpp
@@ -3,21 +3,31 @@
  * Copyright (c) 2022, eunomia-bpf org
  * All rights reserved.
  */
+#include "linux/bpf.h"
 #include "spdlog/spdlog.h"
 #include <bpf_map/userspace/var_hash_map.hpp>
 #include <algorithm>
+#include <cerrno>
+#include <cstring>
 #include <functional>
 #include <unistd.h>
+
+static bool is_good_update_flag(uint64_t flags)
+{
+	return flags == BPF_ANY || flags == BPF_EXIST || flags == BPF_NOEXIST;
+}
 
 namespace bpftime
 {
 
 var_size_hash_map_impl::var_size_hash_map_impl(managed_shared_memory &memory,
 					       uint32_t key_size,
-					       uint32_t value_size)
+					       uint32_t value_size,
+					       uint32_t max_entries)
 	: map_impl(10, bytes_vec_hasher(), std::equal_to<bytes_vec>(),
 		   bi_map_allocator(memory.get_segment_manager())),
 	  _key_size(key_size), _value_size(value_size),
+	  _max_entries(max_entries),
 	  key_vec(key_size, memory.get_segment_manager()),
 	  value_vec(value_size, memory.get_segment_manager())
 {
@@ -42,8 +52,29 @@ void *var_size_hash_map_impl::elem_lookup(const void *key)
 long var_size_hash_map_impl::elem_update(const void *key, const void *value,
 					 uint64_t flags)
 {
+	// Check flags
+	if (!is_good_update_flag(flags)) {
+		errno = EINVAL;
+		return -1;
+	}
 	key_vec.assign((uint8_t *)key, (uint8_t *)key + _key_size);
 	value_vec.assign((uint8_t *)value, (uint8_t *)value + _value_size);
+	bool element_exists = map_impl.contains(key_vec);
+	// Check if the element exists...
+	if (flags == BPF_NOEXIST && element_exists) {
+		errno = EEXIST;
+		return -1;
+	}
+	if (flags == BPF_EXIST && !element_exists) {
+		errno = ENOENT;
+		return -1;
+	}
+	// Ensure max_entries
+	if (element_exists == false && map_impl.size() == _max_entries) {
+		errno = E2BIG;
+		return -1;
+	}
+	// map_impl.
 	map_impl.insert_or_assign(key_vec, value_vec);
 	return 0;
 }
@@ -51,10 +82,26 @@ long var_size_hash_map_impl::elem_update(const void *key, const void *value,
 long var_size_hash_map_impl::elem_delete(const void *key)
 {
 	key_vec.assign((uint8_t *)key, (uint8_t *)key + _key_size);
-	map_impl.erase(key_vec);
+	auto itr = map_impl.find(key_vec);
+	if (itr == map_impl.end()) {
+		errno = ENOENT;
+		return -1;
+	}
+	map_impl.erase(itr);
 	return 0;
 }
-
+int var_size_hash_map_impl::lookup_and_delete(const void *key, void *value_out)
+{
+	key_vec.assign((uint8_t *)key, (uint8_t *)key + _key_size);
+	auto itr = map_impl.find(key_vec);
+	if (itr == map_impl.end()) {
+		errno = ENOENT;
+		return -1;
+	}
+	memcpy(value_out, &itr->second[0], _value_size);
+	map_impl.erase(itr);
+	return 0;
+}
 int var_size_hash_map_impl::map_get_next_key(const void *key, void *next_key)
 {
 	if (key == nullptr) {

--- a/runtime/src/bpf_map/userspace/var_hash_map.hpp
+++ b/runtime/src/bpf_map/userspace/var_hash_map.hpp
@@ -50,6 +50,10 @@ class var_size_hash_map_impl {
 	int map_get_next_key(const void *key, void *next_key);
 
 	int lookup_and_delete(const void *key, void *value_out);
+	uint32_t get_value_size() const
+	{
+		return _value_size;
+	}
 };
 
 } // namespace bpftime

--- a/runtime/src/bpf_map/userspace/var_hash_map.hpp
+++ b/runtime/src/bpf_map/userspace/var_hash_map.hpp
@@ -31,7 +31,7 @@ class var_size_hash_map_impl {
 	uint32_t _key_size;
 	uint32_t _value_size;
 	uint32_t _max_entries;
-
+	uint32_t flags;
 	// buffers used to access the key and value in hash map
 	bytes_vec key_vec;
 	bytes_vec value_vec;
@@ -39,7 +39,8 @@ class var_size_hash_map_impl {
     public:
 	const static bool should_lock = true;
 	var_size_hash_map_impl(managed_shared_memory &memory, uint32_t key_size,
-			       uint32_t value_size, uint32_t max_entries);
+			       uint32_t value_size, uint32_t max_entries,
+			       uint32_t flags);
 
 	void *elem_lookup(const void *key);
 

--- a/runtime/src/bpf_map/userspace/var_hash_map.hpp
+++ b/runtime/src/bpf_map/userspace/var_hash_map.hpp
@@ -30,6 +30,7 @@ class var_size_hash_map_impl {
 	shm_hash_map map_impl;
 	uint32_t _key_size;
 	uint32_t _value_size;
+	uint32_t _max_entries;
 
 	// buffers used to access the key and value in hash map
 	bytes_vec key_vec;
@@ -38,7 +39,7 @@ class var_size_hash_map_impl {
     public:
 	const static bool should_lock = true;
 	var_size_hash_map_impl(managed_shared_memory &memory, uint32_t key_size,
-			       uint32_t value_size);
+			       uint32_t value_size, uint32_t max_entries);
 
 	void *elem_lookup(const void *key);
 
@@ -47,6 +48,8 @@ class var_size_hash_map_impl {
 	long elem_delete(const void *key);
 
 	int map_get_next_key(const void *key, void *next_key);
+
+	int lookup_and_delete(const void *key, void *value_out);
 };
 
 } // namespace bpftime

--- a/runtime/src/handler/map_handler.cpp
+++ b/runtime/src/handler/map_handler.cpp
@@ -119,7 +119,7 @@ const void *bpf_map_handler::map_lookup_elem(const void *key,
 		return from_syscall ? do_lookup_userspace(impl) :
 				      do_lookup(impl);
 	}
-	#ifdef BPFTIME_BUILD_WITH_LIBBPF
+#ifdef BPFTIME_BUILD_WITH_LIBBPF
 	case bpf_map_type::BPF_MAP_TYPE_KERNEL_USER_ARRAY: {
 		auto impl = static_cast<array_map_kernel_user_impl *>(
 			map_impl_ptr.get());
@@ -145,7 +145,7 @@ const void *bpf_map_handler::map_lookup_elem(const void *key,
 			static_cast<prog_array_map_impl *>(map_impl_ptr.get());
 		return do_lookup(impl);
 	}
-	#endif 
+#endif
 	case bpf_map_type::BPF_MAP_TYPE_ARRAY_OF_MAPS: {
 		auto impl = static_cast<array_map_of_maps_impl *>(
 			map_impl_ptr.get());
@@ -213,7 +213,7 @@ long bpf_map_handler::map_update_elem(const void *key, const void *value,
 		return from_syscall ? do_update_userspace(impl) :
 				      do_update(impl);
 	}
-	#ifdef BPFTIME_BUILD_WITH_LIBBPF
+#ifdef BPFTIME_BUILD_WITH_LIBBPF
 	case bpf_map_type::BPF_MAP_TYPE_KERNEL_USER_ARRAY: {
 		auto impl = static_cast<array_map_kernel_user_impl *>(
 			map_impl_ptr.get());
@@ -239,7 +239,7 @@ long bpf_map_handler::map_update_elem(const void *key, const void *value,
 			static_cast<prog_array_map_impl *>(map_impl_ptr.get());
 		return do_update(impl);
 	}
-	#endif
+#endif
 	case bpf_map_type::BPF_MAP_TYPE_ARRAY_OF_MAPS: {
 		if (!from_syscall) {
 			// Map in maps only support update from syscall
@@ -300,7 +300,7 @@ int bpf_map_handler::bpf_map_get_next_key(const void *key, void *next_key,
 			map_impl_ptr.get());
 		return do_get_next_key(impl);
 	}
-	#if __linux__ && defined(BPFTIME_BUILD_WITH_LIBBPF)
+#if __linux__ && defined(BPFTIME_BUILD_WITH_LIBBPF)
 	case bpf_map_type::BPF_MAP_TYPE_KERNEL_USER_ARRAY: {
 		auto impl = static_cast<array_map_kernel_user_impl *>(
 			map_impl_ptr.get());
@@ -326,7 +326,7 @@ int bpf_map_handler::bpf_map_get_next_key(const void *key, void *next_key,
 			static_cast<prog_array_map_impl *>(map_impl_ptr.get());
 		return do_get_next_key(impl);
 	}
-	#endif
+#endif
 	case bpf_map_type::BPF_MAP_TYPE_ARRAY_OF_MAPS: {
 		auto impl = static_cast<array_map_of_maps_impl *>(
 			map_impl_ptr.get());
@@ -394,7 +394,7 @@ long bpf_map_handler::map_delete_elem(const void *key, bool from_syscall) const
 		return from_syscall ? do_delete_userspace(impl) :
 				      do_delete(impl);
 	}
-	#ifdef BPFTIME_BUILD_WITH_LIBBPF
+#ifdef BPFTIME_BUILD_WITH_LIBBPF
 	case bpf_map_type::BPF_MAP_TYPE_KERNEL_USER_ARRAY: {
 		auto impl = static_cast<array_map_kernel_user_impl *>(
 			map_impl_ptr.get());
@@ -420,7 +420,7 @@ long bpf_map_handler::map_delete_elem(const void *key, bool from_syscall) const
 			static_cast<prog_array_map_impl *>(map_impl_ptr.get());
 		return do_delete(impl);
 	}
-	#endif 
+#endif
 	case bpf_map_type::BPF_MAP_TYPE_ARRAY_OF_MAPS: {
 		if (!from_syscall) {
 			// Map in maps only support update from syscall
@@ -447,8 +447,9 @@ int bpf_map_handler::map_init(managed_shared_memory &memory)
 	auto container_name = get_container_name();
 	switch (type) {
 	case bpf_map_type::BPF_MAP_TYPE_HASH: {
-		map_impl_ptr = memory.construct<hash_map_impl>(
-			container_name.c_str())(memory, max_entries, key_size, value_size);
+		map_impl_ptr =
+			memory.construct<hash_map_impl>(container_name.c_str())(
+				memory, max_entries, key_size, value_size);
 		return 0;
 	}
 	case bpf_map_type::BPF_MAP_TYPE_ARRAY: {
@@ -488,10 +489,11 @@ int bpf_map_handler::map_init(managed_shared_memory &memory)
 	}
 	case bpf_map_type::BPF_MAP_TYPE_PERCPU_HASH: {
 		map_impl_ptr = memory.construct<per_cpu_hash_map_impl>(
-			container_name.c_str())(memory, key_size, value_size);
+			container_name.c_str())(memory, key_size, value_size,
+						max_entries);
 		return 0;
 	}
-	#ifdef BPFTIME_BUILD_WITH_LIBBPF
+#ifdef BPFTIME_BUILD_WITH_LIBBPF
 	case bpf_map_type::BPF_MAP_TYPE_KERNEL_USER_ARRAY: {
 		map_impl_ptr = memory.construct<array_map_kernel_user_impl>(
 			container_name.c_str())(memory, attr.kernel_bpf_map_id);
@@ -523,7 +525,7 @@ int bpf_map_handler::map_init(managed_shared_memory &memory)
 						max_entries);
 		return 0;
 	}
-	#endif
+#endif
 	case bpf_map_type::BPF_MAP_TYPE_ARRAY_OF_MAPS: {
 		map_impl_ptr = memory.construct<array_map_of_maps_impl>(
 			container_name.c_str())(memory, max_entries);
@@ -570,7 +572,7 @@ void bpf_map_handler::map_free(managed_shared_memory &memory)
 	case bpf_map_type::BPF_MAP_TYPE_PERCPU_HASH:
 		memory.destroy<per_cpu_hash_map_impl>(container_name.c_str());
 		break;
-	#ifdef BPFTIME_BUILD_WITH_LIBBPF
+#ifdef BPFTIME_BUILD_WITH_LIBBPF
 	case bpf_map_type::BPF_MAP_TYPE_KERNEL_USER_ARRAY:
 		memory.destroy<array_map_kernel_user_impl>(
 			container_name.c_str());
@@ -590,7 +592,7 @@ void bpf_map_handler::map_free(managed_shared_memory &memory)
 	case bpf_map_type::BPF_MAP_TYPE_PROG_ARRAY:
 		memory.destroy<prog_array_map_impl>(container_name.c_str());
 		break;
-	#endif
+#endif
 	default:
 		auto func_ptr = global_map_ops_table[(int)type].map_free;
 		if (func_ptr) {

--- a/runtime/unit-test/CMakeLists.txt
+++ b/runtime/unit-test/CMakeLists.txt
@@ -19,7 +19,8 @@ set(TEST_SOURCES
     maps/test_shm_hash_maps.cpp
     maps/test_external_map_ops.cpp
     maps/test_bpftime_hash_map.cpp
-
+    maps/kernel_unit_tests.cpp
+    
     test_bpftime_shm_json.cpp
     attach_with_ebpf/test_attach_filter_with_ebpf.cpp
     attach_with_ebpf/test_attach_uprobe_with_ebpf.cpp

--- a/runtime/unit-test/CMakeLists.txt
+++ b/runtime/unit-test/CMakeLists.txt
@@ -36,7 +36,7 @@ option(TEST_LCOV "option for lcov" OFF)
 add_executable(bpftime_runtime_tests ${TEST_SOURCES})
 
 if (${TEST_LCOV}) 
-    target_compile_options(bpftime_runtime_tests PRIVATE -fprofile-arcs -ftest-coverage)
+    target_compile_options(bpftime_runtime_tests PRIVATE -fprofile-arcs -ftest-coverage -fprofile-update=atomic)
 endif()
 
 set_property(TARGET bpftime_runtime_tests PROPERTY CXX_STANDARD 20)

--- a/runtime/unit-test/maps/kernel_unit_tests.cpp
+++ b/runtime/unit-test/maps/kernel_unit_tests.cpp
@@ -524,7 +524,7 @@ TEST_CASE("test_arraymap_percpu_many_keys (kernel)", "[kernel]")
 #define MAP_SIZE (32 * 1024)
 TEST_CASE("test_map_large (kernel)", "[kernel]")
 {
-	shm_initializer shm(SHM_NAME, true, 200 << 20);
+	shm_initializer shm(SHM_NAME, true, 150 << 20);
 	auto &mem = *shm.mem;
 	struct bigkey {
 		int a;
@@ -707,7 +707,7 @@ static void test_update_delete(unsigned int fn, int do_update,
 
 TEST_CASE("test_map_parallel (kernel)", "[kernel]")
 {
-	shm_initializer shm(SHM_NAME, true, 200 << 20);
+	shm_initializer shm(SHM_NAME, true, 150 << 20);
 	auto &mem = *shm.mem;
 
 	int i, key = 0, value = 0, j = 0;

--- a/runtime/unit-test/maps/kernel_unit_tests.cpp
+++ b/runtime/unit-test/maps/kernel_unit_tests.cpp
@@ -1,3 +1,4 @@
+#include "bpf_map/userspace/per_cpu_hash_map.hpp"
 #include "catch2/catch_test_macros.hpp"
 #include "linux/bpf.h"
 #include "unit-test/common_def.hpp"
@@ -5,6 +6,8 @@
 #include <boost/interprocess/interprocess_fwd.hpp>
 #include <boost/interprocess/managed_shared_memory.hpp>
 #include "bpf_map/userspace/var_hash_map.hpp"
+#include <cstring>
+#include <unistd.h>
 static const char *SHM_NAME = "_HASH_MAP_TEST";
 
 using namespace boost::interprocess;
@@ -105,4 +108,145 @@ TEST_CASE("Test hash map (kernel)")
 	REQUIRE(errno == ENOENT);
 	REQUIRE(map.map_get_next_key(&key, &next_key) < 0);
 	REQUIRE(errno == ENOENT);
+}
+
+TEST_CASE("test_hashmap_sizes (kernel)")
+{
+	shm_remove remover(SHM_NAME);
+	managed_shared_memory mem(boost::interprocess::create_only, SHM_NAME,
+				  20 << 20);
+	int i, j;
+
+	for (i = 1; i <= 512; i <<= 1)
+		for (j = 1; j <= 1 << 18; j <<= 1) {
+			var_size_hash_map_impl map(mem, i, j, 2);
+			usleep(10);
+		}
+}
+
+/** Macros from kernel source */
+#define __bpf_percpu_val_align __attribute__((__aligned__(8)))
+
+#define BPF_DECLARE_PERCPU(type, name)                                         \
+	struct {                                                               \
+		type v; /* padding */                                          \
+	} __bpf_percpu_val_align name[sysconf(_SC_NPROCESSORS_ONLN)]
+#define bpf_percpu(name, cpu) name[(cpu)].v
+
+TEST_CASE("test_hashmap_percpu (kernel)")
+{
+	shm_remove remover(SHM_NAME);
+	managed_shared_memory mem(boost::interprocess::create_only, SHM_NAME,
+				  20 << 20);
+
+	unsigned int nr_cpus = sysconf(_SC_NPROCESSORS_ONLN);
+	BPF_DECLARE_PERCPU(long, value);
+	long long key, next_key, first_key;
+	int expected_key_mask = 0;
+	int i;
+	per_cpu_hash_map_impl map(mem, sizeof(key),
+				  sizeof(bpf_percpu(value, 0)), 2);
+
+	for (i = 0; i < (int)nr_cpus; i++)
+		bpf_percpu(value, i) = i + 100;
+
+	key = 1;
+	/* Insert key=1 element. */
+	REQUIRE(!(expected_key_mask & key));
+	REQUIRE(map.elem_update_userspace(&key, value, BPF_ANY) == 0);
+
+	/* Lookup and delete elem key=1 and check value. */
+	REQUIRE((map.lookup_and_delete_userspace(&key, value) == 0 &&
+		 bpf_percpu(value, 0) == 100));
+
+	for (i = 0; i < (int)nr_cpus; i++)
+		bpf_percpu(value, i) = i + 100;
+
+	/* Insert key=1 element which should not exist. */
+	REQUIRE(map.elem_update_userspace(&key, value, BPF_NOEXIST) == 0);
+	expected_key_mask |= key;
+
+	/* BPF_NOEXIST means add new element if it doesn't exist. */
+	REQUIRE((map.elem_update_userspace(&key, value, BPF_NOEXIST) < 0 &&
+		 /* key=1 already exists. */
+		 errno == EEXIST));
+
+	/* -1 is an invalid flag. */
+	REQUIRE((map.elem_update(&key, value, -1) < 0 && errno == EINVAL));
+
+	const auto lookup_helper = [&](const void *key, void *value) -> long {
+		auto returned_value = map.elem_lookup_userspace(key);
+		if (!returned_value)
+			return -1;
+		memcpy(value, returned_value,
+		       map.get_value_size() * map.getncpu());
+		return 0;
+	};
+
+	/* Check that key=1 can be found. Value could be 0 if the lookup
+	 * was run from a different CPU.
+	 */
+	bpf_percpu(value, 0) = 1;
+	REQUIRE((lookup_helper(&key, value) == 0 &&
+		 bpf_percpu(value, 0) == 100));
+
+	key = 2;
+	/* Check that key=2 is not found. */
+	REQUIRE((lookup_helper(&key, value) < 0 && errno == ENOENT));
+
+	/* BPF_EXIST means update existing element. */
+	REQUIRE((map.elem_update_userspace(&key, value, BPF_EXIST) < 0 &&
+		 /* key=2 is not there. */
+		 errno == ENOENT));
+
+	/* Insert key=2 element. */
+	REQUIRE(!(expected_key_mask & key));
+	REQUIRE(map.elem_update_userspace(&key, value, BPF_NOEXIST) == 0);
+	expected_key_mask |= key;
+
+	/* key=1 and key=2 were inserted, check that key=0 cannot be
+	 * inserted due to max_entries limit.
+	 */
+	key = 0;
+	REQUIRE((map.elem_update_userspace(&key, value, BPF_NOEXIST) < 0 &&
+		 errno == E2BIG));
+
+	/* Check that key = 0 doesn't exist. */
+	REQUIRE((map.elem_delete_userspace(&key) < 0 && errno == ENOENT));
+
+	/* Iterate over two elements. */
+	REQUIRE((map.map_get_next_key(NULL, &first_key) == 0 &&
+		 ((expected_key_mask & first_key) == first_key)));
+	while (!map.map_get_next_key(&key, &next_key)) {
+		if (first_key) {
+			REQUIRE(next_key == first_key);
+			first_key = 0;
+		}
+		REQUIRE((expected_key_mask & next_key) == next_key);
+		expected_key_mask &= ~next_key;
+
+		REQUIRE(lookup_helper(&next_key, value) == 0);
+
+		for (i = 0; i < (int)nr_cpus; i++)
+			REQUIRE(bpf_percpu(value, i) == i + 100);
+
+		key = next_key;
+	}
+	REQUIRE(errno == ENOENT);
+
+	/* Update with BPF_EXIST. */
+	key = 1;
+	REQUIRE(map.elem_update_userspace(&key, value, BPF_EXIST) == 0);
+
+	/* Delete both elements. */
+	key = 1;
+	REQUIRE(map.elem_delete_userspace(&key) == 0);
+	key = 2;
+	REQUIRE(map.elem_delete_userspace(&key) == 0);
+	REQUIRE((map.elem_delete_userspace(&key) < 0 && errno == ENOENT));
+
+	key = 0;
+	/* Check that map is empty. */
+	REQUIRE((map.map_get_next_key(NULL, &next_key) < 0 && errno == ENOENT));
+	REQUIRE((map.map_get_next_key(&key, &next_key) < 0 && errno == ENOENT));
 }

--- a/runtime/unit-test/maps/kernel_unit_tests.cpp
+++ b/runtime/unit-test/maps/kernel_unit_tests.cpp
@@ -522,7 +522,7 @@ TEST_CASE("test_arraymap_percpu_many_keys (kernel)", "[kernel]")
 	}
 }
 #define MAP_SIZE (32 * 1024)
-TEST_CASE("test_map_large (kernel)", "[kernel]")
+TEST_CASE("test_map_large (kernel)", "[kernel][large_memory]")
 {
 	shm_initializer shm(SHM_NAME, true, 150 << 20);
 	auto &mem = *shm.mem;
@@ -705,7 +705,7 @@ static void test_update_delete(unsigned int fn, int do_update,
 	}
 }
 
-TEST_CASE("test_map_parallel (kernel)", "[kernel]")
+TEST_CASE("test_map_parallel (kernel)", "[kernel][large_memory]")
 {
 	shm_initializer shm(SHM_NAME, true, 150 << 20);
 	auto &mem = *shm.mem;

--- a/runtime/unit-test/maps/kernel_unit_tests.cpp
+++ b/runtime/unit-test/maps/kernel_unit_tests.cpp
@@ -1,0 +1,108 @@
+#include "catch2/catch_test_macros.hpp"
+#include "linux/bpf.h"
+#include "unit-test/common_def.hpp"
+#include <boost/interprocess/creation_tags.hpp>
+#include <boost/interprocess/interprocess_fwd.hpp>
+#include <boost/interprocess/managed_shared_memory.hpp>
+#include "bpf_map/userspace/var_hash_map.hpp"
+static const char *SHM_NAME = "_HASH_MAP_TEST";
+
+using namespace boost::interprocess;
+using namespace bpftime;
+
+TEST_CASE("Test hash map (kernel)")
+{
+	shm_remove remover(SHM_NAME);
+	managed_shared_memory mem(boost::interprocess::create_only, SHM_NAME,
+				  20 << 20);
+
+	long long key, next_key, first_key, value;
+	var_size_hash_map_impl map(mem, sizeof(key), sizeof(value), 2);
+	key = 1;
+	value = 1234;
+	/* Insert key=1 element. */
+	REQUIRE(map.elem_update(&key, &value, BPF_ANY) == 0);
+
+	value = 0;
+	/* BPF_NOEXIST means add new element if it doesn't exist. */
+	REQUIRE(map.elem_update(&key, &value, BPF_NOEXIST) < 0);
+	REQUIRE(/* key=1 already exists. */ errno == EEXIST);
+
+	/* -1 is an invalid flag. */
+	REQUIRE(map.elem_update(&key, &value, -1) < 0);
+	REQUIRE(errno == EINVAL);
+
+	/* Check that key=1 can be found. */
+	{
+		auto ptr = map.elem_lookup(&key);
+		REQUIRE(ptr != nullptr);
+		REQUIRE(*(long long *)ptr == 1234);
+	}
+
+	key = 2;
+	value = 1234;
+	/* Insert key=2 element. */
+	REQUIRE(map.elem_update(&key, &value, BPF_ANY) == 0);
+
+	/* Check that key=2 matches the value and delete it */
+	REQUIRE(map.lookup_and_delete(&key, &value) == 0);
+	REQUIRE(value == 1234);
+
+	/* Check that key=2 is not found. */
+	REQUIRE(map.elem_lookup(&key) == nullptr);
+	REQUIRE(errno == ENOENT);
+
+	/* BPF_EXIST means update existing element. */
+	REQUIRE(map.elem_update(&key, &value, BPF_EXIST) < 0);
+
+	REQUIRE(/* key=2 is not there. */
+		errno == ENOENT);
+
+	/* Insert key=2 element. */
+	REQUIRE(map.elem_update(&key, &value, BPF_NOEXIST) == 0);
+
+	/* key=1 and key=2 were inserted, check that key=0 cannot be
+	 * inserted due to max_entries limit.
+	 */
+	key = 0;
+	REQUIRE(map.elem_update(&key, &value, BPF_NOEXIST) < 0);
+	REQUIRE(errno == E2BIG);
+
+	/* Update existing element, though the map is full. */
+	key = 1;
+	REQUIRE(map.elem_update(&key, &value, BPF_EXIST) == 0);
+	key = 2;
+	REQUIRE(map.elem_update(&key, &value, BPF_ANY) == 0);
+	key = 3;
+	REQUIRE(map.elem_update(&key, &value, BPF_NOEXIST) < 0);
+	REQUIRE(errno == E2BIG);
+
+	/* Check that key = 0 doesn't exist. */
+	key = 0;
+	REQUIRE(map.elem_delete(&key) < 0);
+	REQUIRE(errno == ENOENT);
+	/* Iterate over two elements. */
+	REQUIRE(map.map_get_next_key(NULL, &first_key) == 0);
+	REQUIRE((first_key == 1 || first_key == 2));
+	REQUIRE(map.map_get_next_key(&key, &next_key) == 0);
+	REQUIRE((next_key == first_key));
+	REQUIRE(map.map_get_next_key(&next_key, &next_key) == 0);
+	REQUIRE(((next_key == 1 || next_key == 2) && (next_key != first_key)));
+	REQUIRE(map.map_get_next_key(&next_key, &next_key) < 0);
+	REQUIRE(errno == ENOENT);
+
+	/* Delete both elements. */
+	key = 1;
+	REQUIRE(map.elem_delete(&key) == 0);
+	key = 2;
+	REQUIRE(map.elem_delete(&key) == 0);
+	REQUIRE(map.elem_delete(&key) < 0);
+	REQUIRE(errno == ENOENT);
+
+	key = 0;
+	/* Check that map is empty. */
+	REQUIRE(map.map_get_next_key(NULL, &next_key) < 0);
+	REQUIRE(errno == ENOENT);
+	REQUIRE(map.map_get_next_key(&key, &next_key) < 0);
+	REQUIRE(errno == ENOENT);
+}

--- a/runtime/unit-test/maps/kernel_unit_tests.cpp
+++ b/runtime/unit-test/maps/kernel_unit_tests.cpp
@@ -657,7 +657,6 @@ static int map_delete_retriable(var_size_hash_map_impl &map, const void *key,
 			pthread_spinlock_guard guard(lock);
 			if (map.elem_delete(key) == 0)
 				break;
-			
 		}
 		if (!attempts || (errno != EAGAIN && errno != EBUSY))
 			return -errno;

--- a/runtime/unit-test/maps/test_bpftime_hash_map.cpp
+++ b/runtime/unit-test/maps/test_bpftime_hash_map.cpp
@@ -22,127 +22,138 @@
 using namespace boost::interprocess;
 using namespace bpftime;
 
-TEST_CASE("bpftime_hash_map basic operations", "[bpftime_hash_map]") {
-    managed_shared_memory segment(open_or_create, "bpftime_hash_map_test", 65536);
+TEST_CASE("bpftime_hash_map basic operations", "[bpftime_hash_map]")
+{
+	managed_shared_memory segment(open_or_create, "bpftime_hash_map_test",
+				      65536);
 
-    size_t num_buckets = 10;
-    size_t key_size = 4;  // Example key size
-    size_t value_size = 8; // Example value size
+	size_t num_buckets = 10;
+	size_t key_size = 4; // Example key size
+	size_t value_size = 8; // Example value size
 
-    bpftime_hash_map map(segment, num_buckets, key_size, value_size);
+	bpftime_hash_map map(segment, num_buckets, key_size, value_size);
 
-    SECTION("Insert and Lookup") {
-        int key1 = 1234;
-        int64_t value1 = 5678;
-        int key2 = 4321;
-        int64_t value2 = 8765;
+	SECTION("Insert and Lookup")
+	{
+		int key1 = 1234;
+		int64_t value1 = 5678;
+		int key2 = 4321;
+		int64_t value2 = 8765;
 
-        REQUIRE(map.elem_update(&key1, &value1) == true);
-        REQUIRE(map.elem_update(&key2, &value2) == true);
+		REQUIRE(map.elem_update(&key1, &value1) == true);
+		REQUIRE(map.elem_update(&key2, &value2) == true);
 
-        REQUIRE(map.elem_lookup(&key1) != nullptr);
-        REQUIRE(*(int64_t*)map.elem_lookup(&key1) == value1);
+		REQUIRE(map.elem_lookup(&key1) != nullptr);
+		REQUIRE(*(int64_t *)map.elem_lookup(&key1) == value1);
 
-        REQUIRE(map.elem_lookup(&key2) != nullptr);
-        REQUIRE(*(int64_t*)map.elem_lookup(&key2) == value2);
+		REQUIRE(map.elem_lookup(&key2) != nullptr);
+		REQUIRE(*(int64_t *)map.elem_lookup(&key2) == value2);
 
-        int key3 = 9999;
-        REQUIRE(map.elem_lookup(&key3) == nullptr);
-    }
+		int key3 = 9999;
+		REQUIRE(map.elem_lookup(&key3) == nullptr);
+	}
 
-    SECTION("Update existing element") {
-        int key = 1234;
-        int64_t value1 = 5678;
-        int64_t value2 = 8765;
+	SECTION("Update existing element")
+	{
+		int key = 1234;
+		int64_t value1 = 5678;
+		int64_t value2 = 8765;
 
-        REQUIRE(map.elem_update(&key, &value1) == true);
-        REQUIRE(map.elem_lookup(&key) != nullptr);
-        REQUIRE(*(int64_t*)map.elem_lookup(&key) == value1);
+		REQUIRE(map.elem_update(&key, &value1) == true);
+		REQUIRE(map.elem_lookup(&key) != nullptr);
+		REQUIRE(*(int64_t *)map.elem_lookup(&key) == value1);
 
-        REQUIRE(map.elem_update(&key, &value2) == true);
-        REQUIRE(map.elem_lookup(&key) != nullptr);
-        REQUIRE(*(int64_t*)map.elem_lookup(&key) == value2);
-    }
+		REQUIRE(map.elem_update(&key, &value2) == true);
+		REQUIRE(map.elem_lookup(&key) != nullptr);
+		REQUIRE(*(int64_t *)map.elem_lookup(&key) == value2);
+	}
 
-    SECTION("Delete element") {
-        int key1 = 1234;
-        int64_t value1 = 5678;
-        int key2 = 4321;
-        int64_t value2 = 8765;
+	SECTION("Delete element")
+	{
+		int key1 = 1234;
+		int64_t value1 = 5678;
+		int key2 = 4321;
+		int64_t value2 = 8765;
 
-        REQUIRE(map.elem_update(&key1, &value1) == true);
-        REQUIRE(map.elem_update(&key2, &value2) == true);
+		REQUIRE(map.elem_update(&key1, &value1) == true);
+		REQUIRE(map.elem_update(&key2, &value2) == true);
 
-        REQUIRE(map.elem_delete(&key1) == true);
-        REQUIRE(map.elem_lookup(&key1) == nullptr);
-        REQUIRE(map.elem_lookup(&key2) != nullptr);
-        REQUIRE(*(int64_t*)map.elem_lookup(&key2) == value2);
+		REQUIRE(map.elem_delete(&key1) == true);
+		REQUIRE(map.elem_lookup(&key1) == nullptr);
+		REQUIRE(map.elem_lookup(&key2) != nullptr);
+		REQUIRE(*(int64_t *)map.elem_lookup(&key2) == value2);
 
-        REQUIRE(map.elem_delete(&key2) == true);
-        REQUIRE(map.elem_lookup(&key2) == nullptr);
-    }
+		REQUIRE(map.elem_delete(&key2) == true);
+		REQUIRE(map.elem_lookup(&key2) == nullptr);
+	}
 
-    SECTION("Get element count") {
-        int key1 = 1234;
-        int64_t value1 = 5678;
-        int key2 = 4321;
-        int64_t value2 = 8765;
+	SECTION("Get element count")
+	{
+		int key1 = 1234;
+		int64_t value1 = 5678;
+		int key2 = 4321;
+		int64_t value2 = 8765;
 
-        REQUIRE(map.get_elem_count() == 0);
+		REQUIRE(map.get_elem_count() == 0);
 
-        REQUIRE(map.elem_update(&key1, &value1) == true);
-        REQUIRE(map.get_elem_count() == 1);
+		REQUIRE(map.elem_update(&key1, &value1) == true);
+		REQUIRE(map.get_elem_count() == 1);
 
-        REQUIRE(map.elem_update(&key2, &value2) == true);
-        REQUIRE(map.get_elem_count() == 2);
+		REQUIRE(map.elem_update(&key2, &value2) == true);
+		REQUIRE(map.get_elem_count() == 2);
 
-        REQUIRE(map.elem_delete(&key1) == true);
-        REQUIRE(map.get_elem_count() == 1);
+		REQUIRE(map.elem_delete(&key1) == true);
+		REQUIRE(map.get_elem_count() == 1);
 
-        REQUIRE(map.elem_delete(&key2) == true);
-        REQUIRE(map.get_elem_count() == 0);
-    }
+		REQUIRE(map.elem_delete(&key2) == true);
+		REQUIRE(map.get_elem_count() == 0);
+	}
 
-        SECTION("Insert more elements than num_buckets") {
-        int key;
-        int64_t value;
+	SECTION("Insert more elements than num_buckets")
+	{
+		int key;
+		int64_t value;
 
-        for (size_t i = 0; i < num_buckets; ++i) {
-            key = i;
-            value = i * 100;
-            REQUIRE(map.elem_update(&key, &value) == true);
-        }
+		for (size_t i = 0; i < num_buckets; ++i) {
+			key = i;
+			value = i * 100;
+			REQUIRE(map.elem_update(&key, &value) == true);
+		}
 
-        key = num_buckets;
-        value = num_buckets * 100;
-        REQUIRE(map.elem_update(&key, &value) == false); // Should fail as the map is full
+		key = num_buckets;
+		value = num_buckets * 100;
+		REQUIRE(map.elem_update(&key, &value) == false); // Should fail
+								 // as the map
+								 // is full
 
-        for (size_t i = 0; i < num_buckets; ++i) {
-            key = i;
-            REQUIRE(map.elem_lookup(&key) != nullptr);
-            REQUIRE(*(int64_t*)map.elem_lookup(&key) == i * 100);
-        }
-    }
+		for (size_t i = 0; i < num_buckets; ++i) {
+			key = i;
+			REQUIRE(map.elem_lookup(&key) != nullptr);
+			REQUIRE(*(int64_t *)map.elem_lookup(&key) ==
+				(int64_t)i * 100);
+		}
+	}
 
-    SECTION("Insert, delete, and re-insert elements") {
-        int key1 = 1234;
-        int64_t value1 = 5678;
-        int key2 = 4321;
-        int64_t value2 = 8765;
-        int key3 = 5678;
-        int64_t value3 = 4321;
+	SECTION("Insert, delete, and re-insert elements")
+	{
+		int key1 = 1234;
+		int64_t value1 = 5678;
+		int key2 = 4321;
+		int64_t value2 = 8765;
+		int key3 = 5678;
+		int64_t value3 = 4321;
 
-        REQUIRE(map.elem_update(&key1, &value1) == true);
-        REQUIRE(map.elem_update(&key2, &value2) == true);
+		REQUIRE(map.elem_update(&key1, &value1) == true);
+		REQUIRE(map.elem_update(&key2, &value2) == true);
 
-        REQUIRE(map.elem_delete(&key1) == true);
-        REQUIRE(map.elem_lookup(&key1) == nullptr);
+		REQUIRE(map.elem_delete(&key1) == true);
+		REQUIRE(map.elem_lookup(&key1) == nullptr);
 
-        REQUIRE(map.elem_update(&key3, &value3) == true);
-        REQUIRE(map.elem_lookup(&key3) != nullptr);
-        REQUIRE(*(int64_t*)map.elem_lookup(&key3) == value3);
+		REQUIRE(map.elem_update(&key3, &value3) == true);
+		REQUIRE(map.elem_lookup(&key3) != nullptr);
+		REQUIRE(*(int64_t *)map.elem_lookup(&key3) == value3);
 
-        REQUIRE(map.elem_lookup(&key2) != nullptr);
-        REQUIRE(*(int64_t*)map.elem_lookup(&key2) == value2);
-    }
+		REQUIRE(map.elem_lookup(&key2) != nullptr);
+		REQUIRE(*(int64_t *)map.elem_lookup(&key2) == value2);
+	}
 }

--- a/runtime/unit-test/maps/test_per_cpu_hash.cpp
+++ b/runtime/unit-test/maps/test_per_cpu_hash.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Test basic operations of hash map")
 
 	SECTION("Test writing from helpers, and read from userspace")
 	{
-		per_cpu_hash_map_impl map(mem, 4, 8);
+		per_cpu_hash_map_impl map(mem, 4, 8, 1 << 20);
 		for (uint32_t j = 0; j < ncpu; j++) {
 			ensure_on_certain_cpu<void>(j, [&]() {
 				for (uint32_t i = 0; i < 100; i++) {
@@ -64,7 +64,7 @@ TEST_CASE("Test basic operations of hash map")
 
 	SECTION("Test writing from userspace, and reading & updating from helpers")
 	{
-		per_cpu_hash_map_impl map(mem, 4, 8);
+		per_cpu_hash_map_impl map(mem, 4, 8, 1 << 20);
 		std::vector<uint64_t> buf(ncpu);
 		for (uint32_t j = 0; j < ncpu; j++) {
 			buf[j] = j;


### PR DESCRIPTION

This PR integrates some bpf unittests from kernel (https://elixir.bootlin.com/linux/latest/source/tools/testing/selftests/bpf) into bpftime.

These tests from `test_maps.c` are expected to work:
- [x] test_hashmap
- [x] test_hashmap_sizes
- [x] test_hashmap_percpu
- [x] test_hashmap_walk
- [x] test_arraymap
- [x] test_arraymap_percpu
- [x] test_arraymap_percpu_many_keys
- [x] test_map_large
- [x] test_map_stress
- [x] test_update_delete
- [x] test_map_parallel
- [x] test_map_rdonly
- [x] test_map_wronly_hash 

Note hash map tests are only implemented for var_size_hash_map_impl, also used pre-allocated nodes for performance increasing