### PR TITLE
fix: docker ci unable to run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:23.04
+FROM ubuntu:24.04
 WORKDIR /bpftime
 RUN apt-get update && apt-get install -y --no-install-recommends \
         libelf1 libelf-dev zlib1g-dev make cmake git libboost1.74-all-dev \


### PR DESCRIPTION
The old Dockerfile uses `ubuntu:23.04` which is not an LTS version, and has been deprecated now