### PR TITLE
feat:Prevent segmentation fault in probe_read & probe_write

### DIFF
--- a/.github/workflows/test-runtime.yml
+++ b/.github/workflows/test-runtime.yml
@@ -40,7 +40,7 @@ jobs:
   
     - name: Build
       run: |
-        cmake -DTEST_LCOV=ON -DBPFTIME_LLVM_JIT=YES -DBPFTIME_ENABLE_UNIT_TESTING=YES -DCMAKE_BUILD_TYPE=Debug -B build
+        cmake -DTEST_LCOV=ON -DBPFTIME_LLVM_JIT=YES -DBPFTIME_ENABLE_UNIT_TESTING=YES -DENABLE_PROBE_WRITE_CHECK=1 -DENABLE_PROBE_READ_CHECK=1 -DCMAKE_BUILD_TYPE=Debug -B build
         cmake --build build --config Debug --target bpftime_runtime_tests -j$(nproc)
     - name: Test Runtime
       run:  ./build/runtime/unit-test/bpftime_runtime_tests

--- a/.github/workflows/test-runtime.yml
+++ b/.github/workflows/test-runtime.yml
@@ -69,7 +69,7 @@ jobs:
     - name: build runtime with mpk enable
       run: |
         rm -rf build
-        cmake -Bbuild -DTEST_LCOV=ON -DBPFTIME_LLVM_JIT=YES  -DBPFTIME_ENABLE_UNIT_TESTING=YES -DBPFTIME_ENABLE_MPK=YES -DCMAKE_BUILD_TYPE=Debug
+        cmake -Bbuild -DTEST_LCOV=ON -DBPFTIME_LLVM_JIT=YES  -DBPFTIME_ENABLE_UNIT_TESTING=YES -DBPFTIME_ENABLE_MPK=YES -DCMAKE_BUILD_TYPE=Debug -DENABLE_PROBE_WRITE_CHECK=1 -DENABLE_PROBE_READ_CHECK=1
         cmake --build build --config Debug --target bpftime_runtime_tests -j$(nproc)
     - name: test runtime with mpk
       run:  ./build/runtime/unit-test/bpftime_runtime_tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,15 +86,6 @@ endif()
 
 message(STATUS "Started CMake for ${PROJECT_NAME} v${PROJECT_VERSION}...\n")
 
-# option to use probe read/write checks
-if(DEFINED ENABLE_PROBE_READ_CHECK)
-  add_compile_definitions(ENABLE_PROBE_READ_CHECK=1)
-endif()
-
-if(DEFINED ENABLE_PROBE_WRITE_CHECK)
-  add_compile_definitions(ENABLE_PROBE_WRITE_CHECK=1)
-endif()
-
 # if option to build without libbpf is set
 if(${BPFTIME_BUILD_WITH_LIBBPF})
   add_definitions(-DBPFTIME_BUILD_WITH_LIBBPF=1)
@@ -168,6 +159,15 @@ add_subdirectory(vm)
 add_subdirectory(attach)
 
 add_subdirectory(runtime)
+
+# option to use probe read/write checks
+if(DEFINED ENABLE_PROBE_READ_CHECK)
+  target_compile_definitions(runtime PRIVATE ENABLE_PROBE_READ_CHECK=1)
+endif()
+
+if(DEFINED ENABLE_PROBE_WRITE_CHECK)
+  target_compile_definitions(runtime PRIVATE ENABLE_PROBE_WRITE_CHECK=1)
+endif()
 
 # add to single archive if option is enabled
 if(${BPFTIME_BUILD_STATIC_LIB})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,15 @@ endif()
 
 message(STATUS "Started CMake for ${PROJECT_NAME} v${PROJECT_VERSION}...\n")
 
+# option to use probe read/write checks
+if(DEFINED ENABLE_PROBE_READ_CHECK)
+  add_compile_definitions(ENABLE_PROBE_READ_CHECK=1)
+endif()
+
+if(DEFINED ENABLE_PROBE_WRITE_CHECK)
+  add_compile_definitions(ENABLE_PROBE_WRITE_CHECK=1)
+endif()
+
 # if option to build without libbpf is set
 if(${BPFTIME_BUILD_WITH_LIBBPF})
   add_definitions(-DBPFTIME_BUILD_WITH_LIBBPF=1)

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ help:
 	@python3 -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
 
 build-unit-test:
+	cmake -Bbuild  -DBPFTIME_ENABLE_UNIT_TESTING=1 -DCMAKE_BUILD_TYPE:STRING=Debug -DENABLE_PROBE_WRITE_CHECK=1 -DENABLE_PROBE_READ_CHECK=1
+	cmake --build build --config Debug --target bpftime_runtime_tests bpftime_daemon_tests  -j$(JOBS)
+
+build-unit-test-without-probe-check:
 	cmake -Bbuild  -DBPFTIME_ENABLE_UNIT_TESTING=1 -DCMAKE_BUILD_TYPE:STRING=Debug
 	cmake --build build --config Debug --target bpftime_runtime_tests bpftime_daemon_tests  -j$(JOBS)
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -30,6 +30,8 @@ cmake -Bbuild -DLLVM_DIR=/usr/lib/llvm-15/cmake -DCMAKE_BUILD_TYPE:STRING=RelWit
 cmake --build build --config RelWithDebInfo --target install -j
 ```
 
+If you fail to build , notice LLVM version.
+
 ## build and run at a click
 
 Build the agent first. In project root:
@@ -195,7 +197,7 @@ Tested on `kernel version 6.2` and `Intel(R) Xeon(R) Gold 5418Y` CPU.
 
 ### Uprobe and read/write with `bpf_probe_write_user` and `bpf_probe_read_user`
 
-Userspace:
+Kernelspace:
 
 ```txt
 Benchmarking __bench_uprobe_uretprobe in thread 1
@@ -232,6 +234,8 @@ Average time usage 383.135720 ns, iter 100000 times
 Benchmarking __bench_write in thread 1
 Average time usage 389.037170 ns, iter 100000 times
 ```
+
+noted that the performance of `bpf_probe_read_user` and `bpf_probe_write_user` will be influenced by the option of `ENABLE_PROBE_WRITE_USER` and `ENABLE_PROBE_READ_USER`.
 
 ### maps operations
 

--- a/cmake/StandardSettings.cmake
+++ b/cmake/StandardSettings.cmake
@@ -88,3 +88,9 @@ option(BPFTIME_BUILD_STATIC_LIB "Whether to build a single static library for di
 
 # whether to build bpftime with libbpf and other linux headers
 option(BPFTIME_BUILD_WITH_LIBBPF "Whether to build with libbpf and other linux headers" ON)
+
+# whether to enable probe write check
+option(ENABLE_PROBE_WRITE_CHECK "Whether to enable probe write check" OFF)
+
+# whether to enable probe read check
+option(ENABLE_PROBE_READ_CHECK "Whether to enable probe read check" OFF)

--- a/runtime/src/bpf_helper.cpp
+++ b/runtime/src/bpf_helper.cpp
@@ -103,13 +103,11 @@ thread_local static void (*origin_segv_write_handler)(int, siginfo_t *,
 
 static void segv_read_handler(int sig, siginfo_t *siginfo, void *ctx)
 {
-	SPDLOG_INFO("segv_handler for probe_read called");
 	if (status_probe_read == PROBE_STATUS::NOT_RUNNING) {
-		SPDLOG_INFO("segv_handler for probe_read called 2");
 		if (origin_segv_read_handler != nullptr) {
 			origin_segv_read_handler(sig, siginfo, ctx);
 		} else {
-			SPDLOG_INFO("segv_handler for probe_read called 3");
+			SPDLOG_ERROR("no origin handler for probe_read");
 			throw std::runtime_error(
 				"segv_handler for probe_read called");
 		}
@@ -192,7 +190,9 @@ static void segv_write_handler(int sig, siginfo_t *siginfo, void *ctx)
 		if (origin_segv_write_handler) {
 			origin_segv_write_handler(sig, siginfo, ctx);
 		} else {
-			abort();
+			SPDLOG_ERROR("no origin handler for probe_write");
+			throw std::runtime_error(
+				"segv_handler for probe_write called");
 		}
 	} else if (status_probe_write == PROBE_STATUS::RUNNING_NO_ERROR) {
 		// set status to error

--- a/runtime/src/bpf_helper.cpp
+++ b/runtime/src/bpf_helper.cpp
@@ -101,6 +101,8 @@ thread_local static void (*origin_segv_read_handler)(int, siginfo_t *,
 thread_local static void (*origin_segv_write_handler)(int, siginfo_t *,
 						      void *) = nullptr;
 
+
+#ifdef ENABLE_PROBE_READ_CHECK
 static void segv_read_handler(int sig, siginfo_t *siginfo, void *ctx)
 {
 	if (status_probe_read == PROBE_STATUS::NOT_RUNNING) {
@@ -119,6 +121,7 @@ static void segv_read_handler(int sig, siginfo_t *siginfo, void *ctx)
 		*rip = (greg_t)&jump_point_read;
 	}
 }
+#endif
 
 int64_t bpftime_probe_read(uint64_t dst, int64_t size, uint64_t ptr, uint64_t,
 			   uint64_t)
@@ -183,6 +186,8 @@ int64_t bpftime_probe_read(uint64_t dst, int64_t size, uint64_t ptr, uint64_t,
 	return ret;
 }
 
+
+#ifdef ENABLE_PROBE_WRITE_CHECK
 static void segv_write_handler(int sig, siginfo_t *siginfo, void *ctx)
 {
 	SPDLOG_TRACE("segv_handler for probe_write called");
@@ -202,6 +207,7 @@ static void segv_write_handler(int sig, siginfo_t *siginfo, void *ctx)
 		*rip = (greg_t)&jump_point_write;
 	}
 }
+#endif
 
 int64_t bpftime_probe_write_user(uint64_t dst, uint64_t src, int64_t len,
 				 uint64_t, uint64_t)

--- a/runtime/unit-test/CMakeLists.txt
+++ b/runtime/unit-test/CMakeLists.txt
@@ -22,6 +22,7 @@ set(TEST_SOURCES
     maps/kernel_unit_tests.cpp
     
     test_bpftime_shm_json.cpp
+    test_probe.cpp
     attach_with_ebpf/test_attach_filter_with_ebpf.cpp
     attach_with_ebpf/test_attach_uprobe_with_ebpf.cpp
     attach_with_ebpf/test_helpers.cpp

--- a/runtime/unit-test/test_probe.cpp
+++ b/runtime/unit-test/test_probe.cpp
@@ -46,11 +46,11 @@ TEST_CASE("Test bpftime_probe_read") // test for bpftime_probe_read
 	for (size_t i = 0; i < len; i++) {
 		REQUIRE(dst[i] == src[i]);
 	}
-	ret = bpftime_probe_read((uint64_t)dst, size, (uint64_t)(NULL), 0, 0);
+	ret = bpftime_probe_read((uint64_t)dst, size, (uint64_t)(nullptr), 0, 0);
 	REQUIRE(ret == -EFAULT);
 
 	ret = 0;
-	ret = bpftime_probe_read((uint64_t)(NULL), size, (uint64_t)(NULL), 0, 0);
+	ret = bpftime_probe_read((uint64_t)(nullptr), size, (uint64_t)(nullptr), 0, 0);
 	REQUIRE(ret == -EFAULT);
 }
 
@@ -67,13 +67,12 @@ TEST_CASE("Test bpftime_probe_write_user") // test for bpftime_probe_write_user
 		REQUIRE(dst[i] == src[i]);
 	}
 
-	ret = bpftime_probe_write_user((uint64_t)(NULL), (uint64_t)(src), size,
+	ret = bpftime_probe_write_user((uint64_t)(nullptr), (uint64_t)(src), size,
 				       0, 0);
 	REQUIRE(ret == -EFAULT);
 
-	ret = bpftime_probe_write_user((uint64_t)dst, (uint64_t)(NULL), size, 0,
+	ret = bpftime_probe_write_user((uint64_t)dst, (uint64_t)(nullptr), size, 0,
 				       0);
-	SPDLOG_INFO("ret = {}", ret);
 	REQUIRE(ret == -EFAULT);
 
 	void *dst1 = (void *)(dst);

--- a/runtime/unit-test/test_probe.cpp
+++ b/runtime/unit-test/test_probe.cpp
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <unistd.h>
+#include <signal.h>
 
 extern "C" {
 
@@ -10,28 +11,6 @@ uint64_t bpftime_probe_read(uint64_t dst, uint64_t size, uint64_t ptr, uint64_t,
 			    uint64_t);
 uint64_t bpftime_probe_write_user(uint64_t dst, uint64_t src, uint64_t len,
 				  uint64_t, uint64_t);
-
-// prepare for future use
-long bpftime_strncmp(const char *s1, uint64_t s1_sz, const char *s2);
-uint64_t bpftime_get_prandom_u32(void);
-uint64_t bpftime_ktime_get_coarse_ns(uint64_t, uint64_t, uint64_t, uint64_t,
-				     uint64_t);
-uint64_t bpf_ktime_get_coarse_ns(uint64_t, uint64_t, uint64_t, uint64_t,
-				 uint64_t);
-uint64_t bpftime_ktime_get_ns(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
-uint64_t bpftime_get_current_pid_tgid(uint64_t, uint64_t, uint64_t, uint64_t,
-				      uint64_t);
-uint64_t bpf_get_current_uid_gid(uint64_t, uint64_t, uint64_t, uint64_t,
-				 uint64_t);
-uint64_t bpftime_get_current_comm(uint64_t buf, uint64_t size, uint64_t,
-				  uint64_t, uint64_t);
-uint64_t bpf_probe_read_str(uint64_t buf, uint64_t bufsz, uint64_t ptr,
-			    uint64_t, uint64_t);
-uint64_t bpftime_get_smp_processor_id();
-uint64_t bpftime_get_attach_cookie(uint64_t ctx, uint64_t, uint64_t, uint64_t,
-				   uint64_t);
-
-uint64_t bpftime_get_smp_processor_id();
 }
 
 TEST_CASE("Test bpftime_probe_read") // test for bpftime_probe_read
@@ -46,11 +25,13 @@ TEST_CASE("Test bpftime_probe_read") // test for bpftime_probe_read
 	for (size_t i = 0; i < len; i++) {
 		REQUIRE(dst[i] == src[i]);
 	}
-	ret = bpftime_probe_read((uint64_t)dst, size, (uint64_t)(nullptr), 0, 0);
+	ret = bpftime_probe_read((uint64_t)dst, size, (uint64_t)(nullptr), 0,
+				 0);
 	REQUIRE(ret == -EFAULT);
 
 	ret = 0;
-	ret = bpftime_probe_read((uint64_t)(nullptr), size, (uint64_t)(nullptr), 0, 0);
+	ret = bpftime_probe_read((uint64_t)(nullptr), size, (uint64_t)(nullptr),
+				 0, 0);
 	REQUIRE(ret == -EFAULT);
 }
 
@@ -59,20 +40,20 @@ TEST_CASE("Test bpftime_probe_write_user") // test for bpftime_probe_write_user
 	int dst[4] = { 0 };
 	int src[4] = { 1, 2, 3, 4 };
 	uint64_t size = sizeof(src);
-	int64_t ret = bpftime_probe_write_user((uint64_t)dst, (uint64_t)src, size,
-					   0, 0);
+	int64_t ret = bpftime_probe_write_user((uint64_t)dst, (uint64_t)src,
+					       size, 0, 0);
 	REQUIRE(ret == 0);
 	size_t len = 4;
 	for (size_t i = 0; i < len; i++) {
 		REQUIRE(dst[i] == src[i]);
 	}
 
-	ret = bpftime_probe_write_user((uint64_t)(nullptr), (uint64_t)(src), size,
-				       0, 0);
+	ret = bpftime_probe_write_user((uint64_t)(nullptr), (uint64_t)(src),
+				       size, 0, 0);
 	REQUIRE(ret == -EFAULT);
 
-	ret = bpftime_probe_write_user((uint64_t)dst, (uint64_t)(nullptr), size, 0,
-				       0);
+	ret = bpftime_probe_write_user((uint64_t)dst, (uint64_t)(nullptr), size,
+				       0, 0);
 	REQUIRE(ret == -EFAULT);
 
 	void *dst1 = (void *)(dst);
@@ -82,5 +63,24 @@ TEST_CASE("Test bpftime_probe_write_user") // test for bpftime_probe_write_user
 	REQUIRE(ret == 0);
 	for (size_t i = 0; i < len; i++) {
 		REQUIRE(((int *)dst1)[i] == ((int *)src1)[i]);
+	}
+}
+
+TEST_CASE("Test Probe read/write size valid or not ")
+{
+	int dst[4] = { 0 };
+	int src[4] = { 1, 2, 3, 4 };
+	uint64_t size = sizeof(src);
+	int64_t ret =
+		bpftime_probe_read((uint64_t)dst, -1, (uint64_t)src, 0, 0);
+	REQUIRE(ret == -EFAULT);
+	ret = bpftime_probe_write_user((uint64_t)dst, (uint64_t)src, -1, 0, 0);
+	REQUIRE(ret == -EFAULT);
+	ret = bpftime_probe_read((uint64_t)dst, -1, (uint64_t)(nullptr), 0, 0);
+	REQUIRE(ret == -EFAULT);
+	ret = bpftime_probe_read((uint64_t)dst, size, (uint64_t)(src), 0, 0);
+	REQUIRE(ret == 0);
+	for (size_t i = 0; i < 4; i++) {
+		REQUIRE(dst[i] == src[i]);
 	}
 }

--- a/runtime/unit-test/test_probe.cpp
+++ b/runtime/unit-test/test_probe.cpp
@@ -1,0 +1,87 @@
+#include "catch2/catch_test_macros.hpp"
+#include "spdlog/spdlog.h"
+#include <cstdlib>
+#include <cstring>
+#include <unistd.h>
+
+extern "C" {
+
+uint64_t bpftime_probe_read(uint64_t dst, uint64_t size, uint64_t ptr, uint64_t,
+			    uint64_t);
+uint64_t bpftime_probe_write_user(uint64_t dst, uint64_t src, uint64_t len,
+				  uint64_t, uint64_t);
+
+// prepare for future use
+long bpftime_strncmp(const char *s1, uint64_t s1_sz, const char *s2);
+uint64_t bpftime_get_prandom_u32(void);
+uint64_t bpftime_ktime_get_coarse_ns(uint64_t, uint64_t, uint64_t, uint64_t,
+				     uint64_t);
+uint64_t bpf_ktime_get_coarse_ns(uint64_t, uint64_t, uint64_t, uint64_t,
+				 uint64_t);
+uint64_t bpftime_ktime_get_ns(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
+uint64_t bpftime_get_current_pid_tgid(uint64_t, uint64_t, uint64_t, uint64_t,
+				      uint64_t);
+uint64_t bpf_get_current_uid_gid(uint64_t, uint64_t, uint64_t, uint64_t,
+				 uint64_t);
+uint64_t bpftime_get_current_comm(uint64_t buf, uint64_t size, uint64_t,
+				  uint64_t, uint64_t);
+uint64_t bpf_probe_read_str(uint64_t buf, uint64_t bufsz, uint64_t ptr,
+			    uint64_t, uint64_t);
+uint64_t bpftime_get_smp_processor_id();
+uint64_t bpftime_get_attach_cookie(uint64_t ctx, uint64_t, uint64_t, uint64_t,
+				   uint64_t);
+
+uint64_t bpftime_get_smp_processor_id();
+}
+
+TEST_CASE("Test bpftime_probe_read") // test for bpftime_probe_read
+{
+	int dst[4] = { 0 };
+	int src[4] = { 1, 2, 3, 4 };
+	uint64_t size = sizeof(src);
+	int64_t ret =
+		bpftime_probe_read((uint64_t)dst, size, (uint64_t)src, 0, 0);
+	REQUIRE(ret == 0);
+	size_t len = sizeof(src) / sizeof(src[0]);
+	for (size_t i = 0; i < len; i++) {
+		REQUIRE(dst[i] == src[i]);
+	}
+	ret = bpftime_probe_read((uint64_t)dst, size, (uint64_t)(NULL), 0, 0);
+	REQUIRE(ret == -EFAULT);
+
+	ret = 0;
+	ret = bpftime_probe_read((uint64_t)(NULL), size, (uint64_t)(NULL), 0, 0);
+	REQUIRE(ret == -EFAULT);
+}
+
+TEST_CASE("Test bpftime_probe_write_user") // test for bpftime_probe_write_user
+{
+	int dst[4] = { 0 };
+	int src[4] = { 1, 2, 3, 4 };
+	uint64_t size = sizeof(src);
+	int64_t ret = bpftime_probe_write_user((uint64_t)dst, (uint64_t)src, size,
+					   0, 0);
+	REQUIRE(ret == 0);
+	size_t len = 4;
+	for (size_t i = 0; i < len; i++) {
+		REQUIRE(dst[i] == src[i]);
+	}
+
+	ret = bpftime_probe_write_user((uint64_t)(NULL), (uint64_t)(src), size,
+				       0, 0);
+	REQUIRE(ret == -EFAULT);
+
+	ret = bpftime_probe_write_user((uint64_t)dst, (uint64_t)(NULL), size, 0,
+				       0);
+	SPDLOG_INFO("ret = {}", ret);
+	REQUIRE(ret == -EFAULT);
+
+	void *dst1 = (void *)(dst);
+	void *src1 = (void *)(src);
+	ret = bpftime_probe_write_user((uint64_t)dst1, (uint64_t)src1, size, 0,
+				       0);
+	REQUIRE(ret == 0);
+	for (size_t i = 0; i < len; i++) {
+		REQUIRE(((int *)dst1)[i] == ((int *)src1)[i]);
+	}
+}


### PR DESCRIPTION
<!--# Pull Request Template-->

## Description

We avoid core dump when accessing an illegal address (such as NULL). Now we will get different error code for such situation.

Fixes # (issue)

## Type of change

<!--Please delete options that are not relevant.-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

