### PR TITLE
fix: use boost_shm_string when an agent_config being setup on shared memory

### DIFF
--- a/.github/workflows/test-attach.yml
+++ b/.github/workflows/test-attach.yml
@@ -93,6 +93,7 @@ jobs:
           path: |
             ./coverage-syscall-trace.info
       - uses: codecov/codecov-action@v4
+        if: github.repository == 'eunomia-bpf/bpftime'
         with:
               fail_ci_if_error: true # optional (default = false)
               files: ./coverage-syscall-trace.info, ./coverage-uprobe.info # optional

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -280,6 +280,8 @@ jobs:
           path: |
             ./coverage-example.info
       - uses: codecov/codecov-action@v4
+        # Only upload when this workflow was run on the main repository
+        if: github.repository == 'eunomia-bpf/bpftime'
         with:
               fail_ci_if_error: true # optional (default = false)
               files: ./coverage-example.info

--- a/.github/workflows/test-runtime.yml
+++ b/.github/workflows/test-runtime.yml
@@ -94,6 +94,7 @@ jobs:
           ./coverage-runtime-mpk.info
 
     - uses: codecov/codecov-action@v4
+      if: github.repository == 'eunomia-bpf/bpftime'
       with:
             fail_ci_if_error: true # optional (default = false)
             files: ./coverage-runtime.info

--- a/daemon/user/bpftime_driver.cpp
+++ b/daemon/user/bpftime_driver.cpp
@@ -4,6 +4,7 @@
  * All rights reserved.
  */
 #include "bpftime_driver.hpp"
+#include "bpftime_config.hpp"
 #include <linux/bpf.h>
 #include <bpf/bpf.h>
 #include "ebpf_inst.h"
@@ -380,8 +381,8 @@ bpftime_driver::bpftime_driver(daemon_config cfg, struct bpf_tracer_bpf *obj)
 	config = cfg;
 	object = obj;
 	bpftime_initialize_global_shm(shm_open_type::SHM_REMOVE_AND_CREATE);
-	auto config = get_agent_config_from_env();
-	bpftime_set_agent_config(config);
+	auto config = construct_agent_config_from_env();
+	bpftime_set_agent_config(std::move(config));
 }
 
 bpftime_driver::~bpftime_driver()

--- a/runtime/include/bpftime_shm.hpp
+++ b/runtime/include/bpftime_shm.hpp
@@ -163,7 +163,7 @@ extern const shm_open_type global_shm_open_type;
 const bpftime::agent_config &bpftime_get_agent_config();
 
 // Set the runtime config in the shared memory.
-void bpftime_set_agent_config(const bpftime::agent_config &cfg);
+void bpftime_set_agent_config(struct bpftime::agent_config &&cfg);
 
 // Map ops for register external map types and operations
 //

--- a/runtime/src/bpftime_config.cpp
+++ b/runtime/src/bpftime_config.cpp
@@ -1,7 +1,6 @@
 #include "bpftime_config.hpp"
 #include "spdlog/spdlog.h"
 #include <string_view>
-#include <filesystem>
 
 using namespace bpftime;
 
@@ -39,7 +38,7 @@ static void process_helper_sv(const std::string_view &str, const char delimiter,
 	}
 }
 
-const agent_config bpftime::get_agent_config_from_env() noexcept
+agent_config bpftime::construct_agent_config_from_env() noexcept
 {
 	bpftime::agent_config agent_config;
 	if (const char *custom_helpers = getenv("BPFTIME_HELPER_GROUPS");
@@ -78,7 +77,7 @@ const agent_config bpftime::get_agent_config_from_env() noexcept
 
 	const char *logger_target = std::getenv("BPFTIME_LOG_OUTPUT");
 	if (logger_target != NULL) {
-		agent_config.logger_output_path = logger_target;
+		agent_config.set_logger_output_path(logger_target);
 	}
 	return agent_config;
 }

--- a/runtime/src/bpftime_shm_internal.hpp
+++ b/runtime/src/bpftime_shm_internal.hpp
@@ -48,6 +48,9 @@ class bpftime_shm {
 	// Record which pids are injected by agent
 	alive_agent_pids *injected_pids;
 
+	// local agent config can be used for test or local process
+	std::optional<struct agent_config> local_agent_config;
+
 #if BPFTIME_ENABLE_MPK
 	// mpk key for protect shm
 	bool is_mpk_init = false;
@@ -58,7 +61,7 @@ class bpftime_shm {
 	// Get the configuration object
 	const struct agent_config &get_agent_config();
 	// Set the configuration object
-	void set_agent_config(const struct agent_config &config);
+	void set_agent_config(struct agent_config &&config);
 	// Check whether a certain pid was already equipped with syscall tracer
 	// Using a set stored in the shared memory
 	bool check_syscall_trace_setup(int pid);

--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -78,11 +78,11 @@ syscall_context::syscall_context()
 	init_original_functions();
 	// FIXME: merge this into the runtime config
 	load_config_from_env();
-	auto runtime_config = bpftime::get_agent_config_from_env();
+	auto runtime_config = bpftime::construct_agent_config_from_env();
 	pthread_spin_init(&this->mocked_file_lock, 0);
 	SPDLOG_INFO("Init bpftime syscall mocking..");
 	SPDLOG_INFO("The log will be written to: {}",
-		    runtime_config.logger_output_path);
+		    runtime_config.get_logger_output_path());
 }
 
 void syscall_context::try_startup()

--- a/runtime/unit-test/CMakeLists.txt
+++ b/runtime/unit-test/CMakeLists.txt
@@ -23,6 +23,8 @@ set(TEST_SOURCES
     
     test_bpftime_shm_json.cpp
     test_probe.cpp
+    test_config.cpp
+    
     attach_with_ebpf/test_attach_filter_with_ebpf.cpp
     attach_with_ebpf/test_attach_uprobe_with_ebpf.cpp
     attach_with_ebpf/test_helpers.cpp

--- a/runtime/unit-test/maps/test_external_map_ops.cpp
+++ b/runtime/unit-test/maps/test_external_map_ops.cpp
@@ -57,7 +57,7 @@ TEST_CASE("Test basic operations of external hash map ops")
 	// update the ops to use the external map
 	bpftime::agent_config agent_config;
 	agent_config.allow_non_buildin_map_types = true;
-	bpftime_set_agent_config(agent_config);
+	bpftime_set_agent_config(std::move(agent_config));
 
 	cpp_map.clear();
 

--- a/runtime/unit-test/test_config.cpp
+++ b/runtime/unit-test/test_config.cpp
@@ -1,0 +1,25 @@
+#include <catch2/catch_test_macros.hpp>
+#include <bpftime_config.hpp>
+#include "./common_def.hpp"
+#include <boost/interprocess/interprocess_fwd.hpp>
+using namespace bpftime;
+using namespace boost::interprocess;
+static const char *SHM_NAME = "_BPFTIME_CONFIG_TEST";
+
+static std::string test_string = "aaaabbb";
+
+static std::string test_string_2 = "aaaassssbbb";
+
+TEST_CASE("Test bpftime agent_config")
+{
+	shm_remove remover(SHM_NAME);
+	managed_shared_memory mem(create_only, SHM_NAME, 20 << 20);
+
+	agent_config cfg;
+	cfg.set_logger_output_path(test_string.c_str());
+	REQUIRE(cfg.get_logger_output_path() == test_string);
+	cfg.change_to_shm_object(mem);
+	REQUIRE(cfg.get_logger_output_path() == test_string);
+	cfg.set_logger_output_path(test_string_2.c_str());
+	REQUIRE(cfg.get_logger_output_path() == test_string_2);
+}

--- a/tools/bpftimetool/main.cpp
+++ b/tools/bpftimetool/main.cpp
@@ -163,8 +163,8 @@ int main(int argc, char *argv[])
 		}
 		bpftime_initialize_global_shm(
 			shm_open_type::SHM_CREATE_OR_OPEN);
-		auto agent_config = get_agent_config_from_env();
-		bpftime_set_agent_config(agent_config);
+		auto agent_config = bpftime::construct_agent_config_from_env();
+		bpftime_set_agent_config(std::move(agent_config));
 		auto filename = std::string(argv[2]);
 		return bpftime_import_global_shm_from_json(filename.c_str());
 	} else if (cmd == "remove") {

--- a/tools/cli/main.cpp
+++ b/tools/cli/main.cpp
@@ -187,8 +187,8 @@ static void signal_handler(int sig)
 
 int main(int argc, const char **argv)
 {
-	const auto agent_config = bpftime::get_agent_config_from_env();
-	bpftime::bpftime_set_logger(agent_config.logger_output_path);
+	const auto agent_config = bpftime::construct_agent_config_from_env();
+	bpftime::bpftime_set_logger(agent_config.get_logger_output_path());
 	signal(SIGINT, signal_handler);
 	signal(SIGTSTP, signal_handler);
 	argparse::ArgumentParser program(argv[0]);


### PR DESCRIPTION
In the previous implementation, field `logger_output_path` in `agent_config` was in type `std::string`, but this struct will be put on shared memory when setting `BPFTIME_LOG_OUTPUT` on server side. This will crash any agent who tries to use configuration from shared memory.

This PR updates it, making it use `boost_shm_string` when the config struct was transfered to shared memory.