### PR TITLE
[NOT PLANNED]adapt nginx attach example with new agent_config

### DIFF
--- a/example/attach_implementation/controller/request_filter.bpf.c
+++ b/example/attach_implementation/controller/request_filter.bpf.c
@@ -20,7 +20,7 @@ static inline int str_startswith(const char *main, const char *pat)
 	}
 	return *pat == 0;
 }
-
+SEC("uprobe")
 int request_filter(struct request_filter_argument *arg)
 {
 	int result = 0;

--- a/runtime/src/bpftime_shm_internal.hpp
+++ b/runtime/src/bpftime_shm_internal.hpp
@@ -189,6 +189,10 @@ class bpftime_shm {
 	{
 		return open_type;
 	}
+	boost::interprocess::managed_shared_memory &get_segment()
+	{
+		return segment;
+	}
 };
 
 // memory region for maps and prog info


### PR DESCRIPTION
In the new `agent_config` design introduced in https://github.com/eunomia-bpf/bpftime/pull/371 , construct an `agent_config` without any argument will make it store strings on a local heap. If a user plan to store strings on shared memory, `agent_config` should be initialized with `boost::interprocess::managed_shared_memory &`. The nginx attach example didn't adapt this, this PR fixes it