### PR TITLE
Add simple attach impl to provide simpler way to register some basic attach impls

### DIFF
--- a/.github/script/run_nginx_attach_example.py
+++ b/.github/script/run_nginx_attach_example.py
@@ -1,0 +1,120 @@
+import pathlib
+import sys
+import asyncio
+import typing
+import signal
+import requests
+CONTROLLER_TIMEOUT = 30
+NGINX_TIMEOUT = 30
+
+
+async def handle_stdout(
+    stdout: asyncio.StreamReader,
+    notify: asyncio.Event,
+    title: str,
+    callback_all: typing.List[typing.Tuple[asyncio.Event, str]] = [],
+    check_error: bool = False,
+):
+    print("Monitoring output of", title)
+    while True:
+        t1 = asyncio.create_task(notify.wait())
+        t2 = asyncio.create_task(stdout.readline())
+        done, pending = await asyncio.wait(
+            [t1, t2],
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for item in pending:
+            item.cancel()
+        if t2 in done:
+            s = t2.result().decode()
+            print(f"{title}:", s, end="")
+            for callback in callback_all:
+                evt, sig = callback
+                if sig in s:
+                    evt.set()
+                    print("Callback triggered")
+            if check_error and "[error]" in s:
+                assert False, "Error occurred in agent!"
+        if t1 in done:
+            break
+        if stdout.at_eof():
+            break
+
+
+async def main():
+    nginx_bin, controller, attach_implementation_dir = sys.argv[1:]
+    attach_implementation_dir = pathlib.Path(
+        attach_implementation_dir).absolute()
+    print("Starting controller at", controller)
+    try:
+        controller = await asyncio.subprocess.create_subprocess_exec(
+            controller,
+            "/aaaa",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+        print("Waiting for controller to start..")
+        should_exit = asyncio.Event()
+        controller_started_signal = asyncio.Event()
+        controller_handler = asyncio.create_task(
+            handle_stdout(
+                controller.stdout,
+                should_exit,
+                "CONTROLLER",
+                [
+                    (controller_started_signal, "Epoll fd is")
+                ]
+            )
+        )
+        await asyncio.wait_for(controller_started_signal.wait(), CONTROLLER_TIMEOUT)
+        await asyncio.sleep(3)
+        print("Controller started!")
+
+        nginx = await asyncio.create_subprocess_exec(
+            nginx_bin,
+            "-p",
+            str(attach_implementation_dir),
+            "-c",
+            "./nginx.conf",
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            cwd=attach_implementation_dir
+        )
+        nginx_started_signal = asyncio.Event()
+        nginx_handler = asyncio.create_task(
+            handle_stdout(
+                nginx.stdout, should_exit, "NGINX", [
+                    (nginx_started_signal, "Module init (0 is success): 0")]
+            )
+        )
+        await asyncio.wait_for(nginx_started_signal.wait(), NGINX_TIMEOUT)
+        await asyncio.sleep(3)
+        print("nginx started!")
+        # Try sending some requests..
+        loop = asyncio.get_event_loop()
+        session = requests.Session()
+        session.trust_env = False
+        should_fail_request = await loop.run_in_executor(None, session.get, "http://127.0.0.1:9023/aaab")
+        print("Request /aaab")
+        print(should_fail_request.text)
+        assert should_fail_request.status_code == 403
+        should_succeed_request = await loop.run_in_executor(None, session.get, "http://127.0.0.1:9023/aaaaaab")
+        
+        print("Request /aaaaaabaaab")
+        print(should_succeed_request.text)
+        assert should_succeed_request.status_code == 200
+        print("Test done!")
+
+    finally:
+        should_exit.set()
+        try:
+            controller.send_signal(signal.SIGINT)
+            nginx.send_signal(signal.SIGINT)
+            await asyncio.gather(controller_handler, nginx_handler)
+            # for task in asyncio.all_tasks():
+            #     task.cancel()
+            await asyncio.gather(controller.communicate(), nginx.communicate())
+        except Exception as ex:
+            print(ex)
+if __name__ == "__main__":
+    asyncio.get_event_loop().run_until_complete(main())

--- a/.github/workflows/test-nginx-attach.yml
+++ b/.github/workflows/test-nginx-attach.yml
@@ -17,8 +17,8 @@ jobs:
           submodules: 'recursive'   
       - name: Install dependencies
         run: |
-          apt-get update -y
-          apt-get install -y lcov libzstd-dev libboost-all-dev gpg nginx
+          sudo apt-get update -y
+          sudo apt-get install -y lcov libzstd-dev libboost-all-dev gpg nginx
       - name: Build
         run: |
           cmake -DBPFTIME_LLVM_JIT=0 -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_ATTACH_IMPL_EXAMPLE=YES -B build -S .
@@ -28,4 +28,4 @@ jobs:
           nginx -v
       - name: Test
         run: |
-          python ./.github/script/run_nginx_attach_example.py nginx ./build/example/attach_implementation/controller/attach_impl_example_controller ./example/attach_implementation/
+          sudo python ./.github/script/run_nginx_attach_example.py nginx ./build/example/attach_implementation/controller/attach_impl_example_controller ./example/attach_implementation/

--- a/.github/workflows/test-nginx-attach.yml
+++ b/.github/workflows/test-nginx-attach.yml
@@ -11,14 +11,17 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    container: 
+      image: debian:12
+      options: --privileged -v /sys/kernel/debug/:/sys/kernel/debug:rw -v /sys/kernel/tracing:/sys/kernel/tracing:rw
     steps:
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'   
       - name: Install dependencies
         run: |
-          sudo apt-get update -y
-          sudo apt-get install -y lcov libzstd-dev libboost-all-dev gpg nginx libelf-dev
+          apt-get update -y
+          apt-get install -y lcov libzstd-dev libboost-all-dev gpg nginx libelf-dev
       - name: Build
         run: |
           cmake -DBPFTIME_LLVM_JIT=0 -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_ATTACH_IMPL_EXAMPLE=YES -B build -S .
@@ -28,4 +31,4 @@ jobs:
           nginx -v
       - name: Test
         run: |
-          sudo python ./.github/script/run_nginx_attach_example.py nginx ./build/example/attach_implementation/controller/attach_impl_example_controller ./example/attach_implementation/
+          python ./.github/script/run_nginx_attach_example.py nginx ./build/example/attach_implementation/controller/attach_impl_example_controller ./example/attach_implementation/

--- a/.github/workflows/test-nginx-attach.yml
+++ b/.github/workflows/test-nginx-attach.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update -y
-          apt-get install -y lcov libzstd-dev libboost-all-dev gpg nginx libelf-dev git cmake gcc g++ make clang llvm libpcre2-dev automake python3
+          apt-get install -y lcov libzstd-dev libboost-all-dev gpg nginx libelf-dev git cmake gcc g++ make clang llvm libpcre2-dev automake python3 python3-pip python3-requests
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'   

--- a/.github/workflows/test-nginx-attach.yml
+++ b/.github/workflows/test-nginx-attach.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update -y
-          apt-get install -y lcov libzstd-dev libboost-all-dev gpg nginx libelf-dev git cmake gcc g++ make clang llvm libpcre2-dev automake
+          apt-get install -y lcov libzstd-dev libboost-all-dev gpg nginx libelf-dev git cmake gcc g++ make clang llvm libpcre2-dev automake python3
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'   
@@ -31,4 +31,4 @@ jobs:
           nginx -v
       - name: Test
         run: |
-          python ./.github/script/run_nginx_attach_example.py nginx ./build/example/attach_implementation/controller/attach_impl_example_controller ./example/attach_implementation/
+          python3 ./.github/script/run_nginx_attach_example.py nginx ./build/example/attach_implementation/controller/attach_impl_example_controller ./example/attach_implementation/

--- a/.github/workflows/test-nginx-attach.yml
+++ b/.github/workflows/test-nginx-attach.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update -y
-          apt-get install -y lcov libzstd-dev libboost-all-dev gpg nginx libelf-dev git cmake gcc g++ make
+          apt-get install -y lcov libzstd-dev libboost-all-dev gpg nginx libelf-dev git cmake gcc g++ make clang llvm
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'   

--- a/.github/workflows/test-nginx-attach.yml
+++ b/.github/workflows/test-nginx-attach.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update -y
-          apt-get install -y lcov libzstd-dev libboost-all-dev gpg nginx libelf-dev git cmake gcc g++ make clang llvm
+          apt-get install -y lcov libzstd-dev libboost-all-dev gpg nginx libelf-dev git cmake gcc g++ make clang llvm libpcre2-dev automake
       - uses: actions/checkout@v2
         with:
           submodules: 'recursive'   

--- a/.github/workflows/test-nginx-attach.yml
+++ b/.github/workflows/test-nginx-attach.yml
@@ -1,0 +1,31 @@
+name: Build and test nginx attach implementation with integrated tests
+
+on:
+  workflow_dispatch:
+  push:
+    branches: "*"
+  pull_request: 
+    branches: "master"
+
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'   
+      - name: Install dependencies
+        run: |
+          apt-get update -y
+          apt-get install -y lcov libzstd-dev libboost-all-dev gpg nginx
+      - name: Build
+        run: |
+          cmake -DBPFTIME_LLVM_JIT=0 -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_ATTACH_IMPL_EXAMPLE=YES -B build -S .
+          cmake --build build --config Release --target attach_impl_example_nginx -j$(nproc)
+      - name: Display version of nginx
+        run: |
+          nginx -v
+      - name: Test
+        run: |
+          python ./.github/script/run_nginx_attach_example.py nginx ./build/example/attach_implementation/controller/attach_impl_example_controller ./example/attach_implementation/

--- a/.github/workflows/test-nginx-attach.yml
+++ b/.github/workflows/test-nginx-attach.yml
@@ -15,13 +15,13 @@ jobs:
       image: debian:12
       options: --privileged -v /sys/kernel/debug/:/sys/kernel/debug:rw -v /sys/kernel/tracing:/sys/kernel/tracing:rw
     steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: 'recursive'   
       - name: Install dependencies
         run: |
           apt-get update -y
-          apt-get install -y lcov libzstd-dev libboost-all-dev gpg nginx libelf-dev
+          apt-get install -y lcov libzstd-dev libboost-all-dev gpg nginx libelf-dev git cmake gcc g++ make
+      - uses: actions/checkout@v2
+        with:
+          submodules: 'recursive'   
       - name: Build
         run: |
           cmake -DBPFTIME_LLVM_JIT=0 -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_ATTACH_IMPL_EXAMPLE=YES -B build -S .

--- a/.github/workflows/test-nginx-attach.yml
+++ b/.github/workflows/test-nginx-attach.yml
@@ -1,4 +1,4 @@
-name: Build and test nginx attach implementation with integrated tests
+name: Integrated test for nginx attach implementation
 
 on:
   workflow_dispatch:
@@ -18,7 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y lcov libzstd-dev libboost-all-dev gpg nginx
+          sudo apt-get install -y lcov libzstd-dev libboost-all-dev gpg nginx libelf-dev
       - name: Build
         run: |
           cmake -DBPFTIME_LLVM_JIT=0 -DCMAKE_BUILD_TYPE:STRING=Release -DBUILD_ATTACH_IMPL_EXAMPLE=YES -B build -S .

--- a/attach/CMakeLists.txt
+++ b/attach/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(base_attach_impl)
 add_subdirectory(frida_uprobe_attach_impl)
+add_subdirectory(simple_attach_impl)
 if(UNIX AND NOT APPLE)
   add_subdirectory(syscall_trace_attach_impl)
   add_subdirectory(text_segment_transformer)

--- a/attach/simple_attach_impl/CMakeLists.txt
+++ b/attach/simple_attach_impl/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_library(
+    bpftime_simple_attach_impl STATIC
+    ./simple_attach_impl.cpp
+)
+
+add_dependencies(bpftime_simple_attach_impl bpftime_base_attach_impl spdlog::spdlog)
+set(SIMPLE_ATTACH_IMPL_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR} CACHE STRING "Include path of simple attach impl")
+
+target_include_directories(bpftime_simple_attach_impl PRIVATE ${SPDLOG_INCLUDE} ${SIMPLE_ATTACH_IMPL_INCLUDE} PUBLIC ${BASE_ATTACH_IMPL_INCLUDE})
+
+target_link_libraries(bpftime_simple_attach_impl PUBLIC bpftime_base_attach_impl spdlog::spdlog)

--- a/attach/simple_attach_impl/simple_attach_impl.cpp
+++ b/attach/simple_attach_impl/simple_attach_impl.cpp
@@ -47,7 +47,7 @@ int simple_attach_impl::trigger(const std::string &trigger_argument)
 		SPDLOG_WARN(
 			"Triggering unregistered simple_attach_impl type {}",
 			predefined_attach_type);
-		return 01;
+		return 1;
 	}
 	SPDLOG_DEBUG("Triggering simple_attach_impl with type {}",
 		     predefined_attach_type);

--- a/attach/simple_attach_impl/simple_attach_impl.cpp
+++ b/attach/simple_attach_impl/simple_attach_impl.cpp
@@ -1,0 +1,55 @@
+#include "simple_attach_impl.hpp"
+#include "spdlog/spdlog.h"
+
+using namespace bpftime::simple_attach;
+using namespace bpftime;
+
+int simple_attach_impl::create_attach_with_ebpf_callback(
+	attach::ebpf_run_callback &&cb,
+	const attach::attach_private_data &private_data, int attach_type)
+{
+	if (usable_id != -1) {
+		SPDLOG_ERROR("Simple attach impl only supports one instance");
+		return -1;
+	}
+	if (attach_type != predefined_attach_type) {
+		SPDLOG_ERROR(
+			"Trying to attach a simple_attach_impl with mismatched attach type, expected = {}, tried = {}",
+			predefined_attach_type, attach_type);
+		return -1;
+	}
+	auto &attach_private_data =
+		dynamic_cast<const simple_attach_private_data &>(private_data);
+	this->argument = attach_private_data.data;
+	this->ebpf_callback = cb;
+	usable_id = allocate_id();
+	SPDLOG_DEBUG("Registered through simple attach impl, type = {}",
+		     attach_type);
+	return usable_id;
+}
+
+int simple_attach_impl::detach_by_id(int id)
+{
+	if (usable_id == -1) {
+		SPDLOG_ERROR("Not attached yet");
+		return -1;
+	}
+	if (usable_id != id) {
+		SPDLOG_ERROR("Trying to detach an invalid id");
+		return -1;
+	}
+	usable_id = -1;
+	return 0;
+}
+int simple_attach_impl::trigger()
+{
+	if (usable_id == -1) {
+		SPDLOG_WARN(
+			"Triggering unregistered simple_attach_impl type {}",
+			predefined_attach_type);
+		return 01;
+	}
+	SPDLOG_DEBUG("Triggering simple_attach_impl with type {}",
+		     predefined_attach_type);
+	return this->callback(argument, ebpf_callback);
+}

--- a/attach/simple_attach_impl/simple_attach_impl.cpp
+++ b/attach/simple_attach_impl/simple_attach_impl.cpp
@@ -41,7 +41,7 @@ int simple_attach_impl::detach_by_id(int id)
 	usable_id = -1;
 	return 0;
 }
-int simple_attach_impl::trigger()
+int simple_attach_impl::trigger(const std::string &trigger_argument)
 {
 	if (usable_id == -1) {
 		SPDLOG_WARN(
@@ -51,5 +51,5 @@ int simple_attach_impl::trigger()
 	}
 	SPDLOG_DEBUG("Triggering simple_attach_impl with type {}",
 		     predefined_attach_type);
-	return this->callback(argument, ebpf_callback);
+	return this->callback(argument, trigger_argument, ebpf_callback);
 }

--- a/attach/simple_attach_impl/simple_attach_impl.hpp
+++ b/attach/simple_attach_impl/simple_attach_impl.hpp
@@ -1,0 +1,109 @@
+#ifndef _SIMPLE_ATTACH_IMPL
+#define _SIMPLE_ATTACH_IMPL
+
+#include "attach_private_data.hpp"
+#include "base_attach_impl.hpp"
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+namespace bpftime
+{
+namespace simple_attach
+{
+
+/// Callback type for a simple attach impl
+/// (Attach argument, callback to execute the eBPF program related to this
+/// attach) -> status code
+using callback_type = std::function<int(const std::string &,
+					const attach::ebpf_run_callback &)>;
+/// This is a wrapper for base_attach_impl, used together with other helpers in
+/// bpf_attach_ctx, to provide simpler but less flexible ways to register a
+/// custom attach impl
+/// Note that each instance of simple_attach_impl can only hold one attach at
+/// the same time.
+class simple_attach_impl : public attach::base_attach_impl {
+    public:
+	int create_attach_with_ebpf_callback(
+		attach::ebpf_run_callback &&cb,
+		const attach::attach_private_data &private_data,
+		int attach_type);
+	/// Trigger the event handled by this attach impl
+	int trigger();
+	int detach_by_id(int id);
+	bool is_attached() const
+	{
+		return usable_id != -1;
+	}
+
+	simple_attach_impl(callback_type &&callback, int attach_type)
+		: callback(callback), predefined_attach_type(attach_type)
+	{
+	}
+
+    private:
+	/// A callback provided by user, will be triggered if this attach type
+	/// was triggered
+	callback_type callback;
+	/// Specified attach type for this simple_attach_impl. It will be
+	/// checked when being attached.
+	int predefined_attach_type;
+
+	attach::ebpf_run_callback ebpf_callback;
+	int usable_id = -1;
+	std::string argument;
+};
+
+struct simple_attach_private_data : public attach::attach_private_data {
+	std::string data;
+	int initialize_from_string(const std::string_view &sv) override
+	{
+		data = sv;
+		return 0;
+	}
+};
+
+template <typename T>
+concept HasRegisterAttachImpl =
+	requires(T t, std::initializer_list<int> attach_types,
+		 std::unique_ptr<attach::base_attach_impl> impl,
+		 std::function<std::unique_ptr<attach::attach_private_data>(
+			 const std::string_view &, int &)>
+			 creator)
+{
+	{
+		t.register_attach_impl(std::move(attach_types), std::move(impl),
+				       creator)
+	} -> std::same_as<void>;
+};
+
+/// Adds an simple defined attach impl to the specified bpf_attach_ctx
+/// A simple attach impl consists up of a callback, an attach type integer, and
+/// a trigger. The callback will be called when the trigger function was called.
+/// The callback function will receive another callback to execute the desired
+/// eBPF program linked with this attach.
+template <class T>
+requires HasRegisterAttachImpl<T> static inline std::function<void()>
+add_simple_attach_impl_to_attach_ctx(int attach_type, callback_type &&callback,
+				     T &attach_ctx)
+{
+	auto simple_attach_impl = std::make_unique<class simple_attach_impl>(
+		std::move(callback), attach_type);
+	auto impl_ptr = simple_attach_impl.get();
+	auto result = [=]() { impl_ptr->trigger(); };
+
+	attach_ctx.register_attach_impl(
+		{ attach_type }, std::move(simple_attach_impl),
+		[](const std::string_view &sv, int &err) {
+			std::unique_ptr<attach::attach_private_data> priv_data =
+				std::make_unique<simple_attach_private_data>();
+			err = 0;
+			return priv_data;
+		});
+	return result;
+}
+
+} // namespace simple_attach
+} // namespace bpftime
+
+#endif

--- a/example/attach_implementation/CMakeLists.txt
+++ b/example/attach_implementation/CMakeLists.txt
@@ -4,10 +4,10 @@ add_library(
     ./nginx_plugin_adaptor/nginx_plugin_adaptor.cpp
 )
 
-add_dependencies(attach_impl_example_nginx_plugin_adaptor bpftime_base_attach_impl runtime spdlog::spdlog)
+add_dependencies(attach_impl_example_nginx_plugin_adaptor bpftime_simple_attach_impl runtime spdlog::spdlog)
 
-target_link_libraries(attach_impl_example_nginx_plugin_adaptor PRIVATE bpftime_base_attach_impl runtime spdlog::spdlog)
-target_include_directories(attach_impl_example_nginx_plugin_adaptor PRIVATE ${BPFTIME_RUNTIME_INCLUDE} ${SPDLOG_INCLUDE})
+target_link_libraries(attach_impl_example_nginx_plugin_adaptor PRIVATE bpftime_simple_attach_impl runtime spdlog::spdlog)
+target_include_directories(attach_impl_example_nginx_plugin_adaptor PRIVATE ${BPFTIME_RUNTIME_INCLUDE} ${SPDLOG_INCLUDE} ${SIMPLE_ATTACH_IMPL_INCLUDE})
 
 # add controller target
 add_subdirectory(controller)

--- a/example/attach_implementation/controller/controller.cpp
+++ b/example/attach_implementation/controller/controller.cpp
@@ -45,6 +45,8 @@ int main(int argc, const char **argv)
 	signal(SIGINT, sig_handler);
 	signal(SIGTERM, sig_handler);
 
+	SPDLOG_INFO("Allowed url prefix: {}", argv[1]);
+
 	SPDLOG_INFO("eBPF program at {}", ebpf_prog_path);
 	std::unique_ptr<bpftime_object, decltype(&bpftime_object_close)> obj(
 		bpftime_object_open(ebpf_prog_path), &bpftime_object_close);

--- a/example/attach_implementation/nginx_plugin_adaptor/nginx_plugin_adaptor.cpp
+++ b/example/attach_implementation/nginx_plugin_adaptor/nginx_plugin_adaptor.cpp
@@ -32,6 +32,8 @@ extern "C" int nginx_plugin_example_initialize()
 	spdlog::cfg::load_env_levels();
 	bpftime_initialize_global_shm(shm_open_type::SHM_OPEN_ONLY);
 	ctx_holder.emplace();
+	// Save the trigger function to a global variable, after that, we can
+	// call it when nginx received any requests.
 	trigger_event = simple_attach::add_simple_attach_impl_to_attach_ctx(
 		NGINX_REQUEST_FILTER_ATTACH_TYPE,
 		[&](const std::string &attach_argument,

--- a/example/attach_implementation/nginx_plugin_adaptor/nginx_plugin_adaptor.cpp
+++ b/example/attach_implementation/nginx_plugin_adaptor/nginx_plugin_adaptor.cpp
@@ -1,16 +1,10 @@
-#include "attach_private_data.hpp"
 #include "bpf_attach_ctx.hpp"
 #include "spdlog/cfg/env.h"
 #include "spdlog/spdlog.h"
 #include <base_attach_impl.hpp>
-#include <cerrno>
-#include <cstring>
 #include <functional>
-#include <memory>
 #include <optional>
-#include <string>
-#include <utility>
-
+#include <simple_attach_impl.hpp>
 using namespace bpftime;
 using namespace bpftime::attach;
 
@@ -20,107 +14,46 @@ using namespace bpftime::attach;
 
 static const int NGINX_REQUEST_FILTER_ATTACH_TYPE = 2001;
 
-static std::function<int(const char *)> global_url_filter;
-
-class nginx_request_filter_private_data : public attach_private_data {
-	friend class nginx_request_filter_attach_impl;
-	std::string bad_url;
-	int initialize_from_string(const std::string_view &sv)
-	{
-		bad_url = sv;
-		return 0;
-	}
-};
-
+static std::function<int(const std::string &)> trigger_event;
 struct request_filter_argument {
 	const char *url_to_check;
 	const char *accept_prefix;
-};
-
-class nginx_request_filter_attach_impl : public base_attach_impl {
-    public:
-	nginx_request_filter_attach_impl()
-	{
-		global_url_filter = [this](const char *url) -> int {
-			uint64_t ret;
-			request_filter_argument arg;
-			arg.accept_prefix = this->bad_url.c_str();
-			arg.url_to_check = url;
-			int err = this->cb.value()((void *)&arg, sizeof(arg),
-						   &ret);
-			if (unlikely(err < 0)) {
-				SPDLOG_ERROR("Failed to run ebpf program: {}",
-					     err);
-				return 0;
-			}
-			return ret;
-		};
-	}
-	std::optional<ebpf_run_callback> cb;
-	std::string bad_url;
-	int usable_id = -1;
-	int detach_by_id(int id)
-	{
-		if (id != usable_id) {
-			SPDLOG_ERROR("Bad id {}", id);
-			return -1;
-		}
-		cb = {};
-		usable_id = -1;
-		return 0;
-	}
-	int create_attach_with_ebpf_callback(
-		ebpf_run_callback &&cb, const attach_private_data &private_data,
-		int attach_type)
-	{
-		if (attach_type != NGINX_REQUEST_FILTER_ATTACH_TYPE) {
-			SPDLOG_ERROR("Unsupported attach type {}", attach_type);
-			return -ENOTSUP;
-		}
-		if (usable_id != -1) {
-			SPDLOG_ERROR(
-				"Only one nginx url filter could be attached");
-			return -EINVAL;
-		}
-		this->cb = std::move(cb);
-		bad_url = dynamic_cast<const nginx_request_filter_private_data &>(
-			      private_data)
-			      .bad_url;
-		SPDLOG_INFO("create_attach_with_ebpf_callback: Bad url is {}", bad_url);
-		usable_id = allocate_id();
-		return usable_id;
-	}
 };
 
 static std::optional<bpf_attach_ctx> ctx_holder;
 
 extern "C" int nginx_plugin_example_run_filter(const char *url)
 {
-	return global_url_filter(url);
+	return trigger_event(url);
 }
 
 extern "C" int nginx_plugin_example_initialize()
 {
 	spdlog::cfg::load_env_levels();
 	bpftime_initialize_global_shm(shm_open_type::SHM_OPEN_ONLY);
-	// ctx_holder.init();
 	ctx_holder.emplace();
-	auto nginx_req_filter_impl =
-		std::make_unique<nginx_request_filter_attach_impl>();
-	ctx_holder->register_attach_impl(
-		{ NGINX_REQUEST_FILTER_ATTACH_TYPE },
-		std::move(nginx_req_filter_impl),
-		[](const std::string_view &sv, int &err) {
-			std::unique_ptr<attach_private_data> priv_data =
-				std::make_unique<
-					nginx_request_filter_private_data>();
-			if (int e = priv_data->initialize_from_string(sv);
-			    e < 0) {
-				err = e;
-				return std::unique_ptr<attach_private_data>();
+	trigger_event = simple_attach::add_simple_attach_impl_to_attach_ctx(
+		NGINX_REQUEST_FILTER_ATTACH_TYPE,
+		[&](const std::string &attach_argument,
+		    const std::string &trigger_argument,
+		    const attach::ebpf_run_callback &run_ebpf_program) -> int {
+			uint64_t ret;
+			request_filter_argument arg;
+			arg.accept_prefix = attach_argument.c_str();
+			arg.url_to_check = trigger_argument.c_str();
+			SPDLOG_DEBUG("accept prefix={}, url to check = {}",
+				     arg.accept_prefix, arg.url_to_check);
+			int err = run_ebpf_program((void *)&arg, sizeof(arg),
+						   &ret);
+			if (unlikely(err < 0)) {
+				SPDLOG_ERROR("Failed to run ebpf program: {}",
+					     err);
+				return 0;
 			}
-			return priv_data;
-		});
+			return ret != 0;
+		},
+		*ctx_holder);
+
 	int res = ctx_holder->init_attach_ctx_from_handlers(
 		bpftime_get_agent_config());
 	if (res != 0) {

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -43,10 +43,12 @@ endif()
 # Create library, setup header and source files
 #
 find_package(Boost REQUIRED)
+
 # Find all headers and implementation files
 if(NOT DEFINED ARCH)
   set(ARCH ${CMAKE_SYSTEM_PROCESSOR})
 endif()
+
 message(STATUS "Building for architecture: ${ARCH}")
 
 set(sources
@@ -87,7 +89,6 @@ if(UNIX AND NOT APPLE AND BPFTIME_BUILD_WITH_LIBBPF)
   )
 endif()
 
-
 set(headers
   include/
 )
@@ -127,11 +128,12 @@ target_link_libraries(${PROJECT_NAME}
   spdlog::spdlog
   bpftime_base_attach_impl
 )
+
 if(${BPFTIME_BUILD_WITH_LIBBPF})
   add_dependencies(${PROJECT_NAME} bpftime_vm FridaGum spdlog::spdlog libbpf bpftime_base_attach_impl)
 else()
   add_dependencies(${PROJECT_NAME} bpftime_vm FridaGum spdlog::spdlog bpftime_base_attach_impl)
-endif()  
+endif()
 
 if(BPFTIME_ENABLE_IOURING_EXT)
   target_link_libraries(${PROJECT_NAME}
@@ -178,64 +180,64 @@ if(APPLE)
 endif()
 
 if(${BPFTIME_BUILD_WITH_LIBBPF})
-target_link_libraries(${PROJECT_NAME}
-  PUBLIC
-  ${LIBBPF_LIBRARIES}
-  ${FRIDA_GUM_INSTALL_DIR}/libfrida-gum.a
-  -lpthread
-  -lm
-  -ldl
-  -lz
-  -lelf
-  bpftime_base_attach_impl
-  ${EXTRA_LIBS}
-)
+  target_link_libraries(${PROJECT_NAME}
+    PUBLIC
+    ${LIBBPF_LIBRARIES}
+    ${FRIDA_GUM_INSTALL_DIR}/libfrida-gum.a
+    -lpthread
+    -lm
+    -ldl
+    -lz
+    -lelf
+    bpftime_base_attach_impl
+    ${EXTRA_LIBS}
+  )
 else()
-target_link_libraries(${PROJECT_NAME}
-  PUBLIC
-  ${FRIDA_GUM_INSTALL_DIR}/libfrida-gum.a
-  -lpthread
-  -lm
-  -ldl
-  -lz
-  bpftime_base_attach_impl
-  ${EXTRA_LIBS}
-)
+  target_link_libraries(${PROJECT_NAME}
+    PUBLIC
+    ${FRIDA_GUM_INSTALL_DIR}/libfrida-gum.a
+    -lpthread
+    -lm
+    -ldl
+    -lz
+    bpftime_base_attach_impl
+    ${EXTRA_LIBS}
+  )
 endif()
 
-
-
 if(BPFTIME_BUILD_WITH_LIBBPF)
-target_include_directories(${PROJECT_NAME} PUBLIC
-  ${LIBBPF_INCLUDE_DIRS}/uapi
-  ${LIBBPF_INCLUDE_DIRS}
-  ${FRIDA_GUM_INSTALL_DIR}
-  $<INSTALL_INTERFACE:runtime>
-  $<INSTALL_INTERFACE:runtime/src>
-  $<INSTALL_INTERFACE:include>
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
-)
+  target_include_directories(${PROJECT_NAME} PUBLIC
+    ${LIBBPF_INCLUDE_DIRS}/uapi
+    ${LIBBPF_INCLUDE_DIRS}
+    ${FRIDA_GUM_INSTALL_DIR}
+    $<INSTALL_INTERFACE:runtime>
+    $<INSTALL_INTERFACE:runtime/src>
+    $<INSTALL_INTERFACE:include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+  )
 else()
-target_include_directories(${PROJECT_NAME} PUBLIC
-  ${FRIDA_GUM_INSTALL_DIR}
-  $<INSTALL_INTERFACE:runtime>
-  $<INSTALL_INTERFACE:runtime/src>
-  $<INSTALL_INTERFACE:include>
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
-)
+  target_include_directories(${PROJECT_NAME} PUBLIC
+    ${FRIDA_GUM_INSTALL_DIR}
+    $<INSTALL_INTERFACE:runtime>
+    $<INSTALL_INTERFACE:runtime/src>
+    $<INSTALL_INTERFACE:include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+  )
 endif()
 
 message(DEBUG "Successfully added all dependencies and linked against them.")
 
 set(BPFTIME_RUNTIME_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/include ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
-if (BPFTIME_BUILD_WITH_LIBBPF)
-add_subdirectory(object)
+if(BPFTIME_BUILD_WITH_LIBBPF)
+  add_subdirectory(object)
 endif()
+
 add_subdirectory(agent)
 add_subdirectory(syscall-server)
+
 #
 # Unit testing setup
 #
@@ -246,7 +248,7 @@ if(BPFTIME_ENABLE_UNIT_TESTING AND BPFTIME_BUILD_WITH_LIBBPF)
   add_subdirectory(unit-test)
 endif()
 
-if (${TEST_LCOV}) 
+if(${TEST_LCOV})
   target_compile_options(${PROJECT_NAME} PUBLIC -fprofile-arcs -ftest-coverage -fprofile-update=atomic)
-  target_link_options(${PROJECT_NAME} PUBLIC  -fprofile-arcs)
+  target_link_options(${PROJECT_NAME} PUBLIC -fprofile-arcs)
 endif()


### PR DESCRIPTION

This PR adds a new attach type, named `simple_attach_impl`, which is a simple wrapper around `base_attach_impl`. By calling a function `add_simple_attach_impl_to_attach_ctx`, a user can simply register a single-instance, external event triggered attach implementation (such as an nginx url filter).

Behavior of the new attach wrapper can be seen at `example/attach_implementation/controller/controller.cpp`. Only need to provide a callback function (under this case).

This PR will also adds an unit test workflow to execute nginx attach.