### PR TITLE
Implement `bpf_get_stackid`

### DIFF
--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -202,6 +202,12 @@ jobs:
             syscall_trace: false
             expected_str: "bpf:"
             name: usdt_minimal
+          - path: get_stack_id_example
+            executable: ./get_stack_id_example
+            victim: ./victim
+            syscall_trace: false
+            expected_str: "Function: malloc enter"
+            name: get_stack_id_example
 
     steps:
       - uses: actions/checkout@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,10 @@ add_subdirectory(third_party/spdlog)
 
 if(NOT DEFINED SPDLOG_ACTIVE_LEVEL)
   add_compile_definitions(SPDLOG_ACTIVE_LEVEL=SPDLOG_LEVEL_TRACE)
+  message(STATUS "Setting SPDLOG_ACTIVE_LEVEL to SPDLOG_LEVEL_TRACE")
+else()
+  add_compile_definitions(SPDLOG_ACTIVE_LEVEL=${SPDLOG_ACTIVE_LEVEL})
+  message(STATUS "Setting SPDLOG_ACTIVE_LEVEL to ${SPDLOG_ACTIVE_LEVEL}")
 endif()
 
 set(SPDLOG_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR}/third_party/spdlog/include)

--- a/attach/base_attach_impl/base_attach_impl.hpp
+++ b/attach/base_attach_impl/base_attach_impl.hpp
@@ -1,6 +1,7 @@
 #ifndef _BPFTIME_BASE_ATTACH_IMPL_HPP
 #define _BPFTIME_BASE_ATTACH_IMPL_HPP
 
+#include "spdlog/spdlog.h"
 #include <cstdint>
 #include <functional>
 #include <optional>
@@ -50,6 +51,15 @@ class base_attach_impl {
 	virtual void
 	register_custom_helpers(ebpf_helper_register_callback register_callback)
 	{
+	}
+
+	/// Call some features provide by specified attach implementation.
+	virtual void *call_attach_specific_function(std::string name,
+						    void *data)
+	{
+		SPDLOG_WARN(
+			"Not implemented yet: call_attach_specific_function");
+		return nullptr;
 	}
 
 	virtual ~base_attach_impl(){};

--- a/attach/base_attach_impl/base_attach_impl.hpp
+++ b/attach/base_attach_impl/base_attach_impl.hpp
@@ -54,7 +54,7 @@ class base_attach_impl {
 	}
 
 	/// Call some features provide by specified attach implementation.
-	virtual void *call_attach_specific_function(std::string name,
+	virtual void *call_attach_specific_function(const std::string &name,
 						    void *data)
 	{
 		SPDLOG_WARN(

--- a/attach/frida_uprobe_attach_impl/CMakeLists.txt
+++ b/attach/frida_uprobe_attach_impl/CMakeLists.txt
@@ -24,6 +24,7 @@ set(TEST_SOURCES
     test/test_attach_with_unified_interface.cpp
     test/test_attach_private_data_parsing.cpp
     test/test_base_attach_impl.cpp
+    test/test_back_trace.cpp
 )
 option(TEST_LCOV "option for lcov" OFF)
 add_executable(bpftime_frida_uprobe_attach_tests ${TEST_SOURCES})

--- a/attach/frida_uprobe_attach_impl/include/frida_uprobe_attach_impl.hpp
+++ b/attach/frida_uprobe_attach_impl/include/frida_uprobe_attach_impl.hpp
@@ -91,7 +91,7 @@ class frida_attach_impl final : public base_attach_impl {
 	frida_attach_impl &operator=(const frida_attach_impl &) = delete;
 	void register_custom_helpers(
 		ebpf_helper_register_callback register_callback) override;
-	void *call_attach_specific_function(std::string name,
+	void *call_attach_specific_function(const std::string& name,
 					    void *data) override;
 
     private:

--- a/attach/frida_uprobe_attach_impl/include/frida_uprobe_attach_impl.hpp
+++ b/attach/frida_uprobe_attach_impl/include/frida_uprobe_attach_impl.hpp
@@ -7,6 +7,7 @@
 #define _BPFTIME_FRIDA_ATTACH_MANAGER_HPP
 
 #include <functional>
+#include <optional>
 #include <variant>
 #include <frida_register_def.hpp>
 #include <memory>
@@ -59,6 +60,7 @@ struct ebpf_callback_args {
 using frida_attach_entry_callback =
 	std::variant<callback_variant, ebpf_callback_args>;
 
+extern thread_local std::optional<void *> current_thread_gum_cpu_context;
 // The frida uprobe attach implementation
 class frida_attach_impl final : public base_attach_impl {
     public:
@@ -80,15 +82,17 @@ class frida_attach_impl final : public base_attach_impl {
 	int detach_by_func_addr(const void *func);
 
 	// Virtual functions
-	int detach_by_id(int id);
+	int detach_by_id(int id) override;
 	// Create an attach entry with ebpf callback
 	int create_attach_with_ebpf_callback(
 		ebpf_run_callback &&cb, const attach_private_data &private_data,
-		int attach_type);
+		int attach_type) override;
 	frida_attach_impl(const frida_attach_impl &) = delete;
 	frida_attach_impl &operator=(const frida_attach_impl &) = delete;
 	void register_custom_helpers(
-		ebpf_helper_register_callback register_callback);
+		ebpf_helper_register_callback register_callback) override;
+	void *call_attach_specific_function(std::string name,
+					    void *data) override;
 
     private:
 	void *interceptor;

--- a/attach/frida_uprobe_attach_impl/src/frida_internal_attach_entry.cpp
+++ b/attach/frida_uprobe_attach_impl/src/frida_internal_attach_entry.cpp
@@ -160,7 +160,12 @@ extern "C" void *__bpftime_frida_attach_manager__override_handler()
 	auto arg4 = gum_invocation_context_get_nth_argument(ctx, 4);
 	ufunc_func func = (ufunc_func)ctx->function;
 
+	SPDLOG_DEBUG("Setting current thread gum cpu context");
+	current_thread_gum_cpu_context = ctx->cpu_context;
+
 	hook_entry->run_filter_callback(regs);
+	SPDLOG_DEBUG("Resetting current thread gum cpu context");
+	current_thread_gum_cpu_context.reset();
 	if (hook_entry->is_overrided) {
 		auto value = (uintptr_t)hook_entry->user_ret;
 		SPDLOG_DEBUG("Using override return value: {}", value);
@@ -197,7 +202,14 @@ static void uprobe_listener_on_enter(GumInvocationListener *listener,
 	bpftime::pt_regs regs;
 	ctx = gum_interceptor_get_current_invocation();
 	convert_gum_cpu_context_to_pt_regs(*ctx->cpu_context, regs);
+
+	SPDLOG_DEBUG("Setting current thread gum cpu context");
+	current_thread_gum_cpu_context = ctx->cpu_context;
+
 	hook_entry->iterate_uprobe_callbacks(regs);
+
+	SPDLOG_DEBUG("Resetting current thread gum cpu context");
+	current_thread_gum_cpu_context.reset();
 }
 
 static void uprobe_listener_on_leave(GumInvocationListener *listener,

--- a/attach/frida_uprobe_attach_impl/src/frida_uprobe_attach_impl.cpp
+++ b/attach/frida_uprobe_attach_impl/src/frida_uprobe_attach_impl.cpp
@@ -290,7 +290,7 @@ void frida_attach_impl::register_custom_helpers(
 void *frida_attach_impl::call_attach_specific_function(std::string name,
 						       void *data)
 {
-	SPDLOG_INFO("Calling frida attach impl specified feature: {}", name);
+	SPDLOG_DEBUG("Calling frida attach impl specified feature: {}", name);
 	if (name == "generate_stack") {
 		if (!current_thread_gum_cpu_context.has_value()) {
 			SPDLOG_ERROR("There is no frida hook running");
@@ -318,7 +318,7 @@ void *frida_attach_impl::call_attach_specific_function(std::string name,
 			auto frame_addr = array.items[i];
 			result->push_back((uint64_t)(uintptr_t)frame_addr);
 		}
-		SPDLOG_INFO("Got {} stack traces", result->size());
+		SPDLOG_DEBUG("Got {} stack traces", result->size());
 		g_object_unref(tracer);
 		return result;
 

--- a/attach/frida_uprobe_attach_impl/src/frida_uprobe_attach_impl.cpp
+++ b/attach/frida_uprobe_attach_impl/src/frida_uprobe_attach_impl.cpp
@@ -287,7 +287,7 @@ void frida_attach_impl::register_custom_helpers(
 			  (void *)bpftime_get_retval);
 }
 
-void *frida_attach_impl::call_attach_specific_function(std::string name,
+void *frida_attach_impl::call_attach_specific_function(const std::string& name,
 						       void *data)
 {
 	SPDLOG_DEBUG("Calling frida attach impl specified feature: {}", name);

--- a/attach/frida_uprobe_attach_impl/test/test_attach_with_unified_interface.cpp
+++ b/attach/frida_uprobe_attach_impl/test/test_attach_with_unified_interface.cpp
@@ -10,7 +10,7 @@
 
 using namespace bpftime::attach;
 
-extern "C" uint64_t
+extern "C" __attribute__((__noinline__)) uint64_t
 __bpftime_test_attach_with_unified_interface_func(uint64_t a, uint64_t b)
 {
 	return a + b;

--- a/attach/frida_uprobe_attach_impl/test/test_back_trace.cpp
+++ b/attach/frida_uprobe_attach_impl/test/test_back_trace.cpp
@@ -1,0 +1,86 @@
+#include "catch2/catch_test_macros.hpp"
+#include "frida-gum.h"
+#include "frida_register_def.hpp"
+#include "frida_uprobe_attach_impl.hpp"
+#include "spdlog/spdlog.h"
+#include <cstdint>
+#include <cmath>
+#include <string>
+using namespace bpftime;
+using namespace attach;
+
+extern "C" __attribute__((__noinline__)) uint64_t
+__bpftime_test_attach_with_back_trace__func5(uint64_t x)
+{
+	asm("");
+	uint64_t result = 0;
+	for (int i = 1; i <= x; i++) {
+		result += (uint64_t)sqrt(i);
+	}
+	return result;
+}
+
+extern "C" __attribute__((__noinline__)) uint64_t
+__bpftime_test_attach_with_back_trace__func4(uint64_t x)
+{
+	asm("");
+	return __bpftime_test_attach_with_back_trace__func5(x) + 1;
+}
+
+extern "C" __attribute__((__noinline__)) uint64_t
+__bpftime_test_attach_with_back_trace__func3(uint64_t x)
+{
+	asm("");
+	return __bpftime_test_attach_with_back_trace__func4(x) + 2;
+}
+
+extern "C" __attribute__((__noinline__)) uint64_t
+__bpftime_test_attach_with_back_trace__func2(uint64_t x)
+{
+	asm("");
+	return __bpftime_test_attach_with_back_trace__func3(x) + 3;
+}
+
+extern "C" __attribute__((__noinline__)) uint64_t
+__bpftime_test_attach_with_back_trace__func1(uint64_t x)
+{
+	asm("");
+	return __bpftime_test_attach_with_back_trace__func2(x) + 4;
+}
+
+TEST_CASE("Test with backtrace")
+{
+	frida_attach_impl impl;
+	bool invoked = false;
+	impl.create_uprobe_at(
+		(void *)&__bpftime_test_attach_with_back_trace__func5,
+		[&](const pt_regs &regs) {
+			invoked = true;
+			auto stack = (std::vector<uint64_t> *)
+					     impl.call_attach_specific_function(
+						     "generate_stack", nullptr);
+			for (int i = 0; i < 4; i++) {
+				auto addr = stack->at(i);
+				GumReturnAddressDetails frame_details;
+				REQUIRE(gum_return_address_details_from_address(
+						(GumReturnAddress)addr,
+						&frame_details) == true);
+				GumDebugSymbolDetails debug_details;
+				REQUIRE(gum_symbol_details_from_address(
+						(GumReturnAddress)addr,
+						&debug_details) == true);
+				SPDLOG_INFO("symbol name {}",
+					    debug_details.symbol_name);
+				auto expected_name =
+					std::string(
+						"__bpftime_test_attach_with_back_trace__func") +
+					std::to_string(4 - i);
+				REQUIRE(std::string(debug_details.symbol_name)
+						.starts_with(expected_name));
+			}
+
+			delete stack;
+		});
+	REQUIRE(__bpftime_test_attach_with_back_trace__func1(100) == 635);
+	REQUIRE(invoked == true);
+}

--- a/example/get_stack_id_example/.gitignore
+++ b/example/get_stack_id_example/.gitignore
@@ -1,0 +1,12 @@
+.vscode
+package.json
+*.o
+*.skel.json
+*.skel.yaml
+package.yaml
+ecli
+malloc
+.output
+test
+victim
+/get_stack_id_example

--- a/example/get_stack_id_example/Makefile
+++ b/example/get_stack_id_example/Makefile
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: (LGPL-2.1 OR BSD-2-Clause)
+OUTPUT := .output
+CLANG ?= clang
+LIBBPF_SRC := $(abspath ../../third_party/libbpf/src)
+BPFTOOL_SRC := $(abspath ../../third_party/bpftool/src)
+LIBBPF_OBJ := $(abspath $(OUTPUT)/libbpf.a)
+BPFTOOL_OUTPUT ?= $(abspath $(OUTPUT)/bpftool)
+BPFTOOL ?= $(BPFTOOL_OUTPUT)/bootstrap/bpftool
+ARCH ?= $(shell uname -m | sed 's/x86_64/x86/' \
+			 | sed 's/arm.*/arm/' \
+			 | sed 's/aarch64/arm64/' \
+			 | sed 's/ppc64le/powerpc/' \
+			 | sed 's/mips.*/mips/' \
+			 | sed 's/riscv64/riscv/' \
+			 | sed 's/loongarch64/loongarch/')
+VMLINUX := ../../third_party/vmlinux/$(ARCH)/vmlinux.h
+# Use our own libbpf API headers and Linux UAPI headers distributed with
+# libbpf to avoid dependency on system-wide headers, which could be missing or
+# outdated
+INCLUDES := -I$(OUTPUT) -I../../third_party/libbpf/include/uapi -I$(dir $(VMLINUX))
+CFLAGS := -g -Wall
+ALL_LDFLAGS := $(LDFLAGS) $(EXTRA_LDFLAGS)
+
+APPS = get_stack_id_example # minimal minimal_legacy uprobe kprobe fentry usdt sockfilter tc ksyscall
+
+CARGO ?= $(shell which cargo)
+ifeq ($(strip $(CARGO)),)
+BZS_APPS :=
+else
+BZS_APPS := # profile
+APPS += $(BZS_APPS)
+# Required by libblazesym
+ALL_LDFLAGS += -lrt -ldl -lpthread -lm
+endif
+
+# Get Clang's default includes on this system. We'll explicitly add these dirs
+# to the includes list when compiling with `-target bpf` because otherwise some
+# architecture-specific dirs will be "missing" on some architectures/distros -
+# headers such as asm/types.h, asm/byteorder.h, asm/socket.h, asm/sockios.h,
+# sys/cdefs.h etc. might be missing.
+#
+# Use '-idirafter': Don't interfere with include mechanics except where the
+# build would have failed anyways.
+CLANG_BPF_SYS_INCLUDES ?= $(shell $(CLANG) -v -E - </dev/null 2>&1 \
+	| sed -n '/<...> search starts here:/,/End of search list./{ s| \(/.*\)|-idirafter \1|p }')
+
+ifeq ($(V),1)
+	Q =
+	msg =
+else
+	Q = @
+	msg = @printf '  %-8s %s%s\n'					\
+		      "$(1)"						\
+		      "$(patsubst $(abspath $(OUTPUT))/%,%,$(2))"	\
+		      "$(if $(3), $(3))";
+	MAKEFLAGS += --no-print-directory
+endif
+
+define allow-override
+  $(if $(or $(findstring environment,$(origin $(1))),\
+            $(findstring command line,$(origin $(1)))),,\
+    $(eval $(1) = $(2)))
+endef
+
+$(call allow-override,CC,$(CROSS_COMPILE)cc)
+$(call allow-override,LD,$(CROSS_COMPILE)ld)
+
+.PHONY: all
+all: $(APPS) victim
+
+victim: victim.c
+	gcc victim.c -o victim -Wall -g
+
+.PHONY: clean
+clean:
+	$(call msg,CLEAN)
+	$(Q)rm -rf $(OUTPUT) $(APPS)
+
+$(OUTPUT) $(OUTPUT)/libbpf $(BPFTOOL_OUTPUT):
+	$(call msg,MKDIR,$@)
+	$(Q)mkdir -p $@
+
+# Build libbpf
+$(LIBBPF_OBJ): $(wildcard $(LIBBPF_SRC)/*.[ch] $(LIBBPF_SRC)/Makefile) | $(OUTPUT)/libbpf
+	$(call msg,LIB,$@)
+	$(Q)$(MAKE) -C $(LIBBPF_SRC) BUILD_STATIC_ONLY=1		      \
+		    OBJDIR=$(dir $@)/libbpf DESTDIR=$(dir $@)		      \
+		    INCLUDEDIR= LIBDIR= UAPIDIR=			      \
+		    install
+
+# Build bpftool
+$(BPFTOOL): | $(BPFTOOL_OUTPUT)
+	$(call msg,BPFTOOL,$@)
+	$(Q)$(MAKE) ARCH= CROSS_COMPILE= OUTPUT=$(BPFTOOL_OUTPUT)/ -C $(BPFTOOL_SRC) bootstrap
+
+
+$(LIBBLAZESYM_SRC)/target/release/libblazesym.a::
+	$(Q)cd $(LIBBLAZESYM_SRC) && $(CARGO) build --features=cheader,dont-generate-test-files --release
+
+$(LIBBLAZESYM_OBJ): $(LIBBLAZESYM_SRC)/target/release/libblazesym.a | $(OUTPUT)
+	$(call msg,LIB, $@)
+	$(Q)cp $(LIBBLAZESYM_SRC)/target/release/libblazesym.a $@
+
+$(LIBBLAZESYM_HEADER): $(LIBBLAZESYM_SRC)/target/release/libblazesym.a | $(OUTPUT)
+	$(call msg,LIB,$@)
+	$(Q)cp $(LIBBLAZESYM_SRC)/target/release/blazesym.h $@
+
+# Build BPF code
+$(OUTPUT)/%.bpf.o: %.bpf.c $(LIBBPF_OBJ) $(wildcard %.h) $(VMLINUX) | $(OUTPUT) $(BPFTOOL)
+	$(call msg,BPF,$@)
+	$(Q)$(CLANG) -Xlinker --export-dynamic -g -O2 -target bpf -D__TARGET_ARCH_$(ARCH)		      \
+		     $(INCLUDES) $(CLANG_BPF_SYS_INCLUDES)		      \
+		     -c $(filter %.c,$^) -o $(patsubst %.bpf.o,%.tmp.bpf.o,$@)
+	$(Q)$(BPFTOOL) gen object $@ $(patsubst %.bpf.o,%.tmp.bpf.o,$@)
+
+# Generate BPF skeletons
+$(OUTPUT)/%.skel.h: $(OUTPUT)/%.bpf.o | $(OUTPUT) $(BPFTOOL)
+	$(call msg,GEN-SKEL,$@)
+	$(Q)$(BPFTOOL) gen skeleton $< > $@
+
+# Build user-space code
+$(patsubst %,$(OUTPUT)/%.o,$(APPS)): %.o: %.skel.h
+
+$(OUTPUT)/%.o: %.c $(wildcard %.h) | $(OUTPUT)
+	$(call msg,CC,$@)
+	$(Q)$(CC) $(CFLAGS) $(INCLUDES) -c $(filter %.c,$^) -o $@
+
+$(patsubst %,$(OUTPUT)/%.o,$(BZS_APPS)): $(LIBBLAZESYM_HEADER)
+
+$(BZS_APPS): $(LIBBLAZESYM_OBJ)
+
+# Build application binary
+$(APPS): %: $(OUTPUT)/%.o $(LIBBPF_OBJ) | $(OUTPUT)
+	$(call msg,BINARY,$@)
+	$(Q)$(CC) $(CFLAGS) $^ $(ALL_LDFLAGS) -lelf -lz -o $@
+
+# delete failed targets
+.DELETE_ON_ERROR:
+
+# keep intermediate (.skel.h, .bpf.o, etc) targets
+.SECONDARY:

--- a/example/get_stack_id_example/README.md
+++ b/example/get_stack_id_example/README.md
@@ -1,0 +1,70 @@
+# malloc trace
+
+This code is a BPF (Berkeley Packet Filter) program written in C, often used for tracing and monitoring activities in the Linux kernel. BPF allows you to run custom programs within the kernel without modifying its source code. The code you provided creates a BPF program that uses a BPF map to count the number of times the `malloc` function is called within a specified cgroup.
+
+```c
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include "bits.bpf.h"
+#include "maps.bpf.h"
+
+struct {
+    __uint(type, BPF_MAP_TYPE_HASH);
+    __uint(max_entries, 1024);
+    __type(key, u64);
+    __type(value, u64);
+} libc_malloc_calls_total SEC(".maps");
+
+SEC("uprobe/libc.so.6:malloc")
+int do_count(struct pt_regs *ctx)
+{
+    u64 cgroup_id = bpf_get_current_cgroup_id();
+
+    increment_map(&libc_malloc_calls_total, &cgroup_id, 1);
+
+    return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";
+```
+
+from <https://github.com/cloudflare/ebpf_exporter/blob/master/examples/uprobe.bpf.c>
+
+Here's a breakdown of the code:
+
+1. **Headers Inclusion**:
+   - `<vmlinux.h>`: Provides access to kernel data structures and definitions.
+   - `<bpf/bpf_helpers.h>`: Includes helper functions and macros for BPF programs.
+   - `"bits.bpf.h"`: Custom header file (assumed to contain additional definitions).
+   - `"maps.bpf.h"`: Custom header file (assumed to contain definitions related to BPF maps).
+
+2. **Definition of BPF Map**:
+   The code defines a BPF map named `libc_malloc_calls_total` using the `struct` syntax. This map is of type `BPF_MAP_TYPE_HASH` (hash map) with a maximum of 1024 entries. The keys and values are of type `u64` (unsigned 64-bit integer).
+
+3. **Map Definition Attributes**:
+   The attributes specified within the map definition (`__uint`, `__type`) set properties of the map, such as its type, maximum number of entries, and types of keys and values.
+
+4. **BPF Program**:
+   - The program is associated with a `uprobe` on the `malloc` function in the `libc.so.6` library.
+   - The `do_count` function is executed when the `malloc` function is called.
+   - It retrieves the current cgroup ID using `bpf_get_current_cgroup_id()`.
+   - Then, it increments the `libc_malloc_calls_total` map with the cgroup ID as the key and increments the associated value by 1.
+
+5. **License Information**:
+   The `LICENSE[]` array contains the license information for the BPF program. In this case, the program is licensed under the GPL (GNU General Public License).
+
+The purpose of this BPF program is to track and count the number of `malloc` calls that occur within specific cgroups in the Linux kernel. It uses a BPF hash map to store and update the counts. This can be useful for monitoring memory allocation patterns and resource usage within different cgroups.
+
+## how to run
+
+server
+
+```sh
+LD_PRELOAD=build/runtime/syscall-server/libbpftime-syscall-server.so example/malloc/malloc
+```
+
+client
+
+```sh
+LD_PRELOAD=build/runtime/agent/libbpftime-agent.so example/malloc/victim
+```

--- a/example/get_stack_id_example/README.md
+++ b/example/get_stack_id_example/README.md
@@ -1,6 +1,6 @@
-# malloc trace
+# get_stack_id_example
 
-This code is a BPF (Berkeley Packet Filter) program written in C, often used for tracing and monitoring activities in the Linux kernel. BPF allows you to run custom programs within the kernel without modifying its source code. The code you provided creates a BPF program that uses a BPF map to count the number of times the `malloc` function is called within a specified cgroup.
+This code is a BPF (Berkeley Packet Filter) program written in C, designed to demonstrate stack trace collection using stack IDs. BPF allows you to run custom programs within the kernel without modifying its source code. The code provided creates a BPF program that uses a BPF map to store and count unique stack traces.
 
 ```c
 #include <vmlinux.h>

--- a/example/get_stack_id_example/get_stack_id_example.bpf.c
+++ b/example/get_stack_id_example/get_stack_id_example.bpf.c
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <vmlinux.h>
+#include <bpf/bpf_helpers.h>
+#include <bpf/bpf_tracing.h>
+#include "./get_stack_id_example.h"
+
+#define MAX_STACK_DEPTH 20
+
+struct {
+	__uint(type, BPF_MAP_TYPE_STACK_TRACE);
+	__uint(key_size, sizeof(u32));
+	__uint(value_size, MAX_STACK_DEPTH * sizeof(u64));
+	__uint(max_entries, 1000);
+} stack_traces SEC(".maps");
+
+struct {
+	__uint(type, BPF_MAP_TYPE_RINGBUF);
+	__uint(max_entries, 256 * 1024);
+} rb SEC(".maps");
+
+SEC("uprobe/libc.so.6:malloc")
+int malloc_enter(struct pt_regs *ctx)
+{
+	struct event *e;
+
+	e = bpf_ringbuf_reserve(&rb, sizeof(*e), 0);
+	if (!e) {
+		return 0;
+	}
+
+	e->pid = bpf_get_current_pid_tgid() >> 32;
+	e->stack_id = bpf_get_stackid(ctx, &stack_traces, BPF_F_USER_STACK);
+	e->operation = MALLOC_ENTER;
+	bpf_ringbuf_submit(e, 0);
+
+	return 0;
+}
+
+SEC("uprobe/libc.so.6:free")
+int free_enter(struct pt_regs *ctx)
+{
+	struct event *e;
+
+	e = bpf_ringbuf_reserve(&rb, sizeof(*e), 0);
+	if (!e) {
+		return 0;
+	}
+
+	e->pid = bpf_get_current_pid_tgid() >> 32;
+	e->stack_id = bpf_get_stackid(ctx, &stack_traces, BPF_F_USER_STACK);
+	e->operation = FREE_ENTER;
+	bpf_ringbuf_submit(e, 0);
+
+	return 0;
+}
+
+char LICENSE[] SEC("license") = "GPL";

--- a/example/get_stack_id_example/get_stack_id_example.c
+++ b/example/get_stack_id_example/get_stack_id_example.c
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: GPL-2.0
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <string.h>
+#include <errno.h>
+#include <signal.h>
+#include <sys/resource.h>
+#include <bpf/libbpf.h>
+#include <bpf/bpf.h>
+#include "get_stack_id_example.skel.h"
+#include "./get_stack_id_example.h"
+
+#define MAX_STACK_DEPTH 20
+
+static volatile bool exiting = false;
+
+static void sig_handler(int sig)
+{
+	exiting = true;
+}
+
+static int libbpf_print_fn(enum libbpf_print_level level, const char *format,
+			   va_list args)
+{
+	return vfprintf(stderr, format, args);
+}
+
+static int handle_event(void *ctx, void *data, size_t data_sz)
+{
+	const struct event *e = data;
+	int i, stack_map_fd = *(int *)ctx;
+	uint64_t stack[MAX_STACK_DEPTH] = {};
+
+	const char *func_to_call;
+	if (e->operation == MALLOC_ENTER)
+		func_to_call = "malloc enter";
+	else if (e->operation == FREE_ENTER)
+		func_to_call = "free enter";
+	else
+		func_to_call = "unknown";
+	printf("PID: %d, Function: %s", e->pid, func_to_call);
+
+	printf("\n");
+
+	if (e->stack_id >= 0) {
+		int err =
+			bpf_map_lookup_elem(stack_map_fd, &e->stack_id, stack);
+		printf("got err=%d\n",err);
+		if (err == 0) {
+			printf("Call stack:\n");
+			for (i = 0; i < MAX_STACK_DEPTH && stack[i]; i++) {
+				printf("  %#lx\n", stack[i]);
+			}
+		} else {
+			printf("Failed to get stack trace for stack_id=%d\n",
+			       e->stack_id);
+		}
+	} else {
+		printf("No stack trace available (stack_id=%d)\n", e->stack_id);
+	}
+	printf("\n");
+
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	struct get_stack_id_example_bpf *skel;
+	int err, stack_map_fd;
+	struct ring_buffer *rb = NULL;
+
+	/* Set up libbpf errors and debug info callback */
+	libbpf_set_print(libbpf_print_fn);
+
+	/* Cleaner handling of Ctrl-C */
+	signal(SIGINT, sig_handler);
+	signal(SIGTERM, sig_handler);
+
+	/* Load and verify BPF application */
+	skel = get_stack_id_example_bpf__open();
+	if (!skel) {
+		fprintf(stderr, "Failed to open BPF skeleton\n");
+		return 1;
+	}
+
+	/* Load BPF programs */
+	err = get_stack_id_example_bpf__load(skel);
+	if (err) {
+		fprintf(stderr, "Failed to load BPF skeleton: %d\n", err);
+		goto cleanup;
+	}
+
+	/* Attach tracepoints */
+	err = get_stack_id_example_bpf__attach(skel);
+	if (err) {
+		fprintf(stderr, "Failed to attach BPF skeleton: %d\n", err);
+		goto cleanup;
+	}
+
+	/* Get file descriptor for the stack_traces map */
+	stack_map_fd = bpf_map__fd(skel->maps.stack_traces);
+
+	/* Set up ring buffer polling */
+	rb = ring_buffer__new(bpf_map__fd(skel->maps.rb), handle_event,
+			      &stack_map_fd, NULL);
+	if (!rb) {
+		err = -1;
+		fprintf(stderr, "Failed to create ring buffer\n");
+		goto cleanup;
+	}
+
+	/* Process events */
+	printf("Successfully started! Tracing malloc/free in ./victim...\n");
+	while (!exiting) {
+		err = ring_buffer__poll(rb, 100 /* timeout, ms */);
+		if (err == -EINTR) {
+			err = 0;
+			break;
+		}
+		if (err < 0) {
+			fprintf(stderr, "Error polling ring buffer: %d\n", err);
+			break;
+		}
+	}
+
+cleanup:
+	ring_buffer__free(rb);
+	get_stack_id_example_bpf__destroy(skel);
+	return err < 0 ? -err : 0;
+}

--- a/example/get_stack_id_example/get_stack_id_example.h
+++ b/example/get_stack_id_example/get_stack_id_example.h
@@ -1,0 +1,16 @@
+#ifndef _get_stack_id_example_H
+#define _get_stack_id_example_H
+
+enum event_operation {
+	MALLOC_ENTER,
+	FREE_ENTER,
+
+};
+
+struct event {
+	int pid;
+	int stack_id;
+	void *addr;
+	enum event_operation operation;
+};
+#endif

--- a/example/get_stack_id_example/victim.c
+++ b/example/get_stack_id_example/victim.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(int argc, char *argv[]) {
+    while(1) {
+        void *p = malloc(1024);
+        printf("continue malloc...\n");
+        usleep(1000 * 1000);
+        free(p);
+    }
+    return 0;
+}

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -77,6 +77,7 @@ set(sources
   src/bpf_map/userspace/per_cpu_array_map.cpp
   src/bpf_map/userspace/per_cpu_hash_map.cpp
   src/bpf_map/userspace/prog_array.cpp
+  src/bpf_map/userspace/stack_trace_map.cpp
   extension/extension_helper.cpp
 )
 

--- a/runtime/agent/agent.cpp
+++ b/runtime/agent/agent.cpp
@@ -58,6 +58,11 @@ union bpf_attach_ctx_holder {
 };
 static bpf_attach_ctx_holder ctx_holder;
 
+bpf_attach_ctx &get_global_attach_ctx()
+{
+	return ctx_holder.ctx;
+}
+
 syscall_hooker_func_t orig_hooker;
 
 extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident);

--- a/runtime/include/bpf_attach_ctx.hpp
+++ b/runtime/include/bpf_attach_ctx.hpp
@@ -12,6 +12,7 @@
 #include <initializer_list>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <string_view>
 #include <utility>
@@ -54,6 +55,16 @@ class bpf_attach_ctx {
 	int destroy_instantiated_attach_link(int link_id);
 	// Destroy all instantiated attach links
 	int destroy_all_attach_links();
+	std::optional<attach::base_attach_impl *>
+	get_attach_impl_by_attach_type(int attach_type)
+	{
+		if (auto itr = attach_impls.find(attach_type);
+		    itr != attach_impls.end()) {
+			return itr->second.first;
+		} else {
+			return {};
+		}
+	}
 
     private:
 	constexpr static int CURRENT_ID_OFFSET = 65536;

--- a/runtime/src/bpf_map/map_common_def.hpp
+++ b/runtime/src/bpf_map/map_common_def.hpp
@@ -10,6 +10,7 @@
 #include <cinttypes>
 #include <boost/interprocess/managed_shared_memory.hpp>
 #include <boost/interprocess/containers/vector.hpp>
+#include <cstdint>
 #include <functional>
 #include "platform_utils.hpp"
 
@@ -19,6 +20,9 @@ namespace bpftime
 using bytes_vec_allocator = boost::interprocess::allocator<
 	uint8_t, boost::interprocess::managed_shared_memory::segment_manager>;
 using bytes_vec = boost::interprocess::vector<uint8_t, bytes_vec_allocator>;
+using uint64_vec_allocator = boost::interprocess::allocator<
+	uint64_t, boost::interprocess::managed_shared_memory::segment_manager>;
+using uint64_vec = boost::interprocess::vector<uint64_t, uint64_vec_allocator>;
 
 template <class T>
 static inline T ensure_on_current_cpu(std::function<T(int cpu)> func)
@@ -66,6 +70,13 @@ struct bytes_vec_hasher {
 		for (auto x : vec)
 			hash_combine(seed, x);
 		return seed;
+	}
+};
+
+struct uint32_hasher {
+	size_t operator()(uint32_t const &data) const
+	{
+		return data;
 	}
 };
 

--- a/runtime/src/bpf_map/userspace/array_map.hpp
+++ b/runtime/src/bpf_map/userspace/array_map.hpp
@@ -30,6 +30,7 @@ class array_map_impl {
 	int map_get_next_key(const void *key, void *next_key);
 
 	void *get_raw_data() const;
+	friend class stack_trace_map_impl;
 };
 
 } // namespace bpftime

--- a/runtime/src/bpf_map/userspace/stack_trace_map.cpp
+++ b/runtime/src/bpf_map/userspace/stack_trace_map.cpp
@@ -101,16 +101,19 @@ int stack_trace_map_impl::fill_stack_trace(const std::vector<uint64_t> &stk,
 	} else {
 		bool equals = true;
 		if (!compare_only_by_hash) {
+			SPDLOG_DEBUG("Checking equality by content..");
 			equals = equals && itr->second.size() == stk.size();
 			if (!equals) {
 				equals = equals &&
 					 std::equal(stk.begin(), stk.end(),
 						    itr->second.begin());
 			}
+		} else {
+			SPDLOG_DEBUG("Checking equality by hash..");
 		}
 		SPDLOG_DEBUG("equals={}", equals);
 		if (equals) {
-			SPDLOG_DEBUG("Early return due to same hash");
+			SPDLOG_DEBUG("Early return due to equals");
 			return to_put_hash;
 		}
 		if (discard_old_one) {

--- a/runtime/src/bpf_map/userspace/stack_trace_map.cpp
+++ b/runtime/src/bpf_map/userspace/stack_trace_map.cpp
@@ -42,11 +42,21 @@ void *stack_trace_map_impl::elem_lookup(const void *key)
 		return nullptr;
 	}
 	uint32_t index = *(int *)key;
+	SPDLOG_DEBUG("Performing stack trace lookup with key={}", index);
+
 	auto itr = this->data.find(index);
 	if (itr == data.end()) {
 		errno = ENOENT;
+		SPDLOG_DEBUG(
+			"Performing stack trace lookup with key={}, not found, ENOENT",
+			index);
+
 		return nullptr;
 	}
+	SPDLOG_DEBUG(
+		"Performing stack trace lookup with key={}, found, data size {}",
+		index, itr->second.size());
+
 	return itr->second.data();
 }
 

--- a/runtime/src/bpf_map/userspace/stack_trace_map.cpp
+++ b/runtime/src/bpf_map/userspace/stack_trace_map.cpp
@@ -1,0 +1,124 @@
+#include "bpf_map/map_common_def.hpp"
+#include "spdlog/spdlog.h"
+#include <algorithm>
+#include <boost/container_hash/hash_fwd.hpp>
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <stdexcept>
+
+#include "stack_trace_map.hpp"
+using namespace bpftime;
+
+stack_trace_map_impl::stack_trace_map_impl(
+	boost::interprocess::managed_shared_memory &memory, uint32_t key_size,
+	uint32_t value_size, uint32_t max_entries)
+	: max_entries(max_entries),
+	  data(max_entries, uint32_hasher(), std::equal_to<uint32_t>(),
+	       stack_trace_map::map_allocator(memory.get_segment_manager())),
+	  key_buf(value_size / 8, memory.get_segment_manager())
+{
+	if (key_size != 4) {
+		SPDLOG_ERROR("Key size of stack trace map must be 4");
+		throw std::runtime_error(
+			"Key size of stack trace map must be 4");
+	}
+	if (value_size % 8 != 0) {
+		SPDLOG_ERROR(
+			"value_size of stack_trace_map must be a multiple of 8, unexpected: {}",
+			value_size);
+		throw std::runtime_error("Invalid value_size");
+	}
+	max_stack_entries = value_size / 8;
+}
+
+void *stack_trace_map_impl::elem_lookup(const void *key)
+{
+	if (key == nullptr) {
+		errno = EINVAL;
+		SPDLOG_ERROR(
+			"You can't lookup a stack trace map with NULL key");
+		return nullptr;
+	}
+	uint32_t index = *(int *)key;
+	auto itr = this->data.find(index);
+	if (itr == data.end()) {
+		errno = ENOENT;
+		return nullptr;
+	}
+	return itr->second.data();
+}
+
+long stack_trace_map_impl::elem_update(const void *key, const void *value,
+				       uint64_t flags)
+{
+	SPDLOG_ERROR("You can't update a stack trace map");
+	return -ENOTSUP;
+}
+
+long stack_trace_map_impl::elem_delete(const void *key)
+{
+	if (key == nullptr) {
+		SPDLOG_ERROR(
+			"You can't lookup a stack trace map with NULL key");
+		errno = EINVAL;
+		return -1;
+	}
+	uint32_t index = *(int *)key;
+	if (auto itr = data.find(index); itr != data.end()) {
+		data.erase(itr);
+	} else {
+		errno = ENOENT;
+		return -1;
+	}
+
+	return 0;
+}
+
+int stack_trace_map_impl::map_get_next_key(const void *key, void *next_key)
+{
+	errno = ENOTSUP;
+	SPDLOG_ERROR("get_next_key is not supported by stack_trace_map");
+	return -1;
+}
+
+int stack_trace_map_impl::fill_stack_trace(const std::vector<uint64_t> &stk,
+					   bool discard_old_one,
+					   bool compare_only_by_hash)
+{
+	auto to_put_hash =
+		stack_trace_map::hash_stack_trace(stk) % this->max_entries;
+	auto itr = this->data.find(to_put_hash);
+	key_buf.resize(stk.size());
+	std::copy(stk.begin(), stk.end(), key_buf.begin());
+	SPDLOG_DEBUG("Filling stack trace, to_put_hash={}, stack_trace_size={}",
+		     to_put_hash, key_buf.size());
+	if (itr == this->data.end()) {
+		data.emplace(stack_trace_map::value_ty(to_put_hash, key_buf));
+		SPDLOG_DEBUG("Set new stack map entry");
+		return to_put_hash;
+	} else {
+		bool equals = true;
+		if (!compare_only_by_hash) {
+			equals = equals && itr->second.size() == stk.size();
+			if (!equals) {
+				equals = equals &&
+					 std::equal(stk.begin(), stk.end(),
+						    itr->second.begin());
+			}
+		}
+		SPDLOG_DEBUG("equals={}", equals);
+		if (equals) {
+			SPDLOG_DEBUG("Early return due to same hash");
+			return to_put_hash;
+		}
+		if (discard_old_one) {
+			SPDLOG_DEBUG(
+				"Discarding existsing stack trace entry..");
+			itr->second = key_buf;
+		}
+		SPDLOG_DEBUG("Got hash {}", to_put_hash);
+		return to_put_hash;
+	}
+}

--- a/runtime/src/bpf_map/userspace/stack_trace_map.hpp
+++ b/runtime/src/bpf_map/userspace/stack_trace_map.hpp
@@ -1,0 +1,66 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (c) 2022, eunomia-bpf org
+ * All rights reserved.
+ */
+#ifndef _STACK_TRACE_MAP_HPP
+#define _STACK_TRACE_MAP_HPP
+#include <boost/interprocess/allocators/allocator.hpp>
+#include <boost/unordered_map.hpp>
+#include <bpf_map/map_common_def.hpp>
+#include <cstdint>
+#include <functional>
+#include <utility>
+
+namespace bpftime
+{
+namespace stack_trace_map
+{
+
+using value_ty = std::pair<const uint32_t, uint64_vec>;
+using map_allocator = boost::interprocess::allocator<
+	value_ty, boost::interprocess::managed_shared_memory::segment_manager>;
+
+using stack_trace_hashmap =
+	boost::unordered_map<uint32_t, uint64_vec, uint32_hasher,
+			     std::equal_to<uint32_t>, map_allocator>;
+template <class T> static inline uint64_t hash_stack_trace(const T &stk)
+{
+	using boost::hash_combine;
+	size_t seed = 0;
+	hash_combine(seed, stk.size());
+	for (auto x : stk)
+		hash_combine(seed, x);
+	return seed;
+}
+
+} // namespace stack_trace_map
+
+// implementation of array map
+class stack_trace_map_impl {
+	uint64_t max_stack_entries;
+	uint64_t max_entries;
+	stack_trace_map::stack_trace_hashmap data;
+
+	uint64_vec key_buf;
+
+    public:
+	const static bool should_lock = true;
+	stack_trace_map_impl(boost::interprocess::managed_shared_memory &memory,
+			     uint32_t key_size, uint32_t value_size,
+			     uint32_t max_entries);
+
+	void *elem_lookup(const void *key);
+
+	long elem_update(const void *key, const void *value, uint64_t flags);
+
+	long elem_delete(const void *key);
+
+	int map_get_next_key(const void *key, void *next_key);
+
+	int fill_stack_trace(const std::vector<uint64_t> &stk,
+			     bool discard_old_one, bool compare_only_by_hash);
+};
+
+} // namespace bpftime
+#endif

--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -385,6 +385,24 @@ bool bpftime_shm::is_epoll_fd(int fd) const
 	return std::holds_alternative<bpftime::epoll_handler>(handler);
 }
 
+bool bpftime_shm::is_stack_trace_map_fd(int fd) const
+{
+	if (!is_map_fd(fd))
+		return false;
+	auto &map_impl = std::get<bpf_map_handler>(manager->get_handler(fd));
+	return map_impl.type == bpf_map_type::BPF_MAP_TYPE_STACK_TRACE;
+}
+std::optional<stack_trace_map_impl *>
+bpftime_shm::try_get_stack_trace_impl(int fd) const
+{
+	if (!is_stack_trace_map_fd(fd)) {
+		SPDLOG_ERROR("Expected fd {} to be an stack trace map fd", fd);
+		return {};
+	}
+	auto &map_handler = std::get<bpf_map_handler>(manager->get_handler(fd));
+	return map_handler.try_get_stack_trace_map_impl();
+}
+
 bool bpftime_shm::is_map_fd(int fd) const
 {
 	if (manager == nullptr || fd < 0 ||
@@ -713,17 +731,18 @@ int bpftime_shm::dup_bpf_map(int oldfd, int newfd)
 	if (!manager) {
 		return -1;
 	}
-	
+
 	// Get the original map handler
 	auto &handler =
-		std::get<bpftime::bpf_map_handler>(manager->get_handler(oldfd));	
+		std::get<bpftime::bpf_map_handler>(manager->get_handler(oldfd));
 	std::string new_name = std::string("dup_") + handler.name.c_str();
 	// Create a new handler with the same parameters
 	return manager->set_handler(
 		newfd,
-		bpftime::bpf_map_handler(newfd, new_name.c_str(), segment, handler.attr), // Copy construct the handler
-		segment
-	);
+		bpftime::bpf_map_handler(newfd, new_name.c_str(), segment,
+					 handler.attr), // Copy construct the
+							// handler
+		segment);
 }
 
 const handler_manager *bpftime_shm::get_manager() const

--- a/runtime/src/bpftime_shm_internal.hpp
+++ b/runtime/src/bpftime_shm_internal.hpp
@@ -7,6 +7,7 @@
 #define _BPFTIME_SHM_INTERNAL
 #include "bpf_map/userspace/array_map.hpp"
 #include "bpf_map/userspace/ringbuf_map.hpp"
+#include "bpf_map/userspace/stack_trace_map.hpp"
 #include <boost/interprocess/managed_shared_memory.hpp>
 #include <cstddef>
 #include <functional>
@@ -82,9 +83,14 @@ class bpftime_shm {
 	bool is_map_fd(int fd) const;
 	bool is_ringbuf_map_fd(int fd) const;
 	bool is_array_map_fd(int fd) const;
+
 	bool is_shared_perf_event_array_map_fd(int fd) const;
 	bool is_perf_event_handler_fd(int fd) const;
 	bool is_software_perf_event_handler_fd(int fd) const;
+
+	bool is_stack_trace_map_fd(int fd) const;
+	std::optional<stack_trace_map_impl *>
+	try_get_stack_trace_impl(int fd) const;
 
 	int find_minimal_unused_fd() const
 	{

--- a/runtime/src/handler/map_handler.hpp
+++ b/runtime/src/handler/map_handler.hpp
@@ -7,6 +7,7 @@
 #define _MAP_HANDLER
 #include "bpf_map/userspace/array_map.hpp"
 #include "bpf_map/userspace/ringbuf_map.hpp"
+#include "bpf_map/userspace/stack_trace_map.hpp"
 #include "bpftime_shm.hpp"
 #include "spdlog/spdlog.h"
 #include <boost/interprocess/managed_shared_memory.hpp>
@@ -192,6 +193,13 @@ class bpf_map_handler {
 	std::optional<array_map_impl *> try_get_array_map_impl() const;
 	std::optional<perf_event_array_kernel_user_impl *>
 	try_get_shared_perf_event_array_map_impl() const;
+
+	std::optional<stack_trace_map_impl *>
+	try_get_stack_trace_map_impl() const;
+	pthread_spinlock_t &get_raw_spin_lock() const
+	{
+		return map_lock;
+	}
 
     private:
 	int id = 0;

--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -5,6 +5,7 @@
  */
 #include "bpftime_logger.hpp"
 #include "bpftime_shm.hpp"
+#include "spdlog/cfg/env.h"
 #include <cstdio>
 #include <ebpf-vm.h>
 #include "syscall_context.hpp"
@@ -83,6 +84,7 @@ syscall_context::syscall_context()
 	SPDLOG_INFO("Init bpftime syscall mocking..");
 	SPDLOG_INFO("The log will be written to: {}",
 		    runtime_config.get_logger_output_path());
+	spdlog::cfg::load_env_levels();
 }
 
 void syscall_context::try_startup()
@@ -315,8 +317,10 @@ long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 	switch (cmd) {
 	case BPF_MAP_CREATE: {
 		if (run_with_kernel) {
-			std::string map_info = fmt::format("Creating kernel map type={}, name={}, key_size={}, value_size={}", 
-				attr->map_type, attr->map_name, attr->key_size, attr->value_size);
+			std::string map_info = fmt::format(
+				"Creating kernel map type={}, name={}, key_size={}, value_size={}",
+				attr->map_type, attr->map_name, attr->key_size,
+				attr->value_size);
 			SPDLOG_DEBUG("{}", map_info);
 			int fd = orig_syscall_fn(__NR_bpf, (long)cmd,
 						 (long)(uintptr_t)attr,
@@ -324,8 +328,10 @@ long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 			SPDLOG_DEBUG("Created kernel map finished, fd={}", fd);
 			return create_kernel_bpf_map(fd);
 		}
-		std::string map_info = fmt::format("Creating map type={}, name={}, key_size={}, value_size={}", 
-			attr->map_type, attr->map_name, attr->key_size, attr->value_size);
+		std::string map_info = fmt::format(
+			"Creating map type={}, name={}, key_size={}, value_size={}",
+			attr->map_type, attr->map_name, attr->key_size,
+			attr->value_size);
 		SPDLOG_DEBUG("{}", map_info);
 		int id = bpftime_maps_create(
 			-1 /* let the shm alloc fd for us */, attr->map_name,
@@ -350,7 +356,7 @@ long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 	}
 	case BPF_MAP_LOOKUP_ELEM: {
 		SPDLOG_DEBUG("Looking up map {}, key={:x}", attr->map_fd,
-			    (uintptr_t)attr->key);
+			     (uintptr_t)attr->key);
 		if (run_with_kernel) {
 			return orig_syscall_fn(__NR_bpf, (long)cmd,
 					       (long)(uintptr_t)attr,
@@ -374,8 +380,8 @@ long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 	}
 	case BPF_MAP_UPDATE_ELEM: {
 		SPDLOG_DEBUG("Updating map {}, key={:x}, value={:x}, flags={}",
-			    attr->map_fd, (uintptr_t)attr->key,
-			    (uintptr_t)attr->value, attr->flags);
+			     attr->map_fd, (uintptr_t)attr->key,
+			     (uintptr_t)attr->value, attr->flags);
 		if (run_with_kernel) {
 			return orig_syscall_fn(__NR_bpf, (long)cmd,
 					       (long)(uintptr_t)attr,
@@ -388,7 +394,7 @@ long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 	}
 	case BPF_MAP_DELETE_ELEM: {
 		SPDLOG_DEBUG("Deleting map {}, key={:x}", attr->map_fd,
-			    (uintptr_t)attr->key);
+			     (uintptr_t)attr->key);
 		if (run_with_kernel) {
 			return orig_syscall_fn(__NR_bpf, (long)cmd,
 					       (long)(uintptr_t)attr,
@@ -399,7 +405,7 @@ long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 	}
 	case BPF_MAP_GET_NEXT_KEY: {
 		SPDLOG_DEBUG("Getting next key for map {}, key={:x}",
-			    attr->map_fd, (uintptr_t)attr->key);
+			     attr->map_fd, (uintptr_t)attr->key);
 		if (run_with_kernel) {
 			return orig_syscall_fn(__NR_bpf, (long)cmd,
 					       (long)(uintptr_t)attr,
@@ -854,10 +860,12 @@ int syscall_context::handle_dup3(int oldfd, int newfd, int flags)
 {
 	SPDLOG_DEBUG("Calling mocked dup3 {}, {}", oldfd, newfd);
 	if (!enable_mock || run_with_kernel)
-		return orig_syscall_fn(__NR_dup3, (long)oldfd, (long)newfd, (long)flags);
+		return orig_syscall_fn(__NR_dup3, (long)oldfd, (long)newfd,
+				       (long)flags);
 	try_startup();
 	if (bpftime_is_map_fd(oldfd)) {
 		return bpftime_maps_dup(oldfd, newfd);
 	}
-	return orig_syscall_fn(__NR_dup3, (long)oldfd, (long)newfd, (long)flags);
+	return orig_syscall_fn(__NR_dup3, (long)oldfd, (long)newfd,
+			       (long)flags);
 }

--- a/runtime/unit-test/CMakeLists.txt
+++ b/runtime/unit-test/CMakeLists.txt
@@ -20,6 +20,7 @@ set(TEST_SOURCES
     maps/test_external_map_ops.cpp
     maps/test_bpftime_hash_map.cpp
     maps/kernel_unit_tests.cpp
+    maps/test_stack_trace_map.cpp
     
     test_bpftime_shm_json.cpp
     test_probe.cpp

--- a/runtime/unit-test/maps/test_stack_trace_map.cpp
+++ b/runtime/unit-test/maps/test_stack_trace_map.cpp
@@ -1,0 +1,94 @@
+#include "bpf_map/userspace/stack_trace_map.hpp"
+#include "catch2/catch_test_macros.hpp"
+#include "spdlog/cfg/env.h"
+#include "unit-test/common_def.hpp"
+#include <algorithm>
+#include <cerrno>
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <random>
+#include <vector>
+static const char *SHM_NAME = "BPFTIME_TEST_STACK_TRACE_MAP";
+using namespace bpftime;
+using namespace boost::interprocess;
+
+TEST_CASE("Test stack trace map 1")
+{
+	shm_remove remover(SHM_NAME);
+	managed_shared_memory mem(create_only, SHM_NAME, 20 << 20);
+
+	stack_trace_map_impl impl(mem, 4, 255 * 8, 10000);
+	std::vector<uint64_t> test_stack{ 1, 2, 3, 4, 5 };
+
+	int id1 = impl.fill_stack_trace(test_stack, false, false);
+	REQUIRE(id1 >= 0);
+	{
+		uint64_t *query_result = (uint64_t *)impl.elem_lookup(&id1);
+		REQUIRE(query_result != nullptr);
+		for (size_t i = 0; i < test_stack.size(); i++)
+			REQUIRE(query_result[i] == test_stack[i]);
+	}
+	REQUIRE(impl.elem_delete(&id1) == 0);
+	REQUIRE((impl.elem_lookup(&id1) == nullptr && errno == ENOENT));
+}
+static std::map<int, std::vector<std::vector<uint64_t> > >
+make_collision(int max_entries, int total_count, int vector_size)
+{
+	std::mt19937 gen((std::random_device()()));
+	std::uniform_int_distribution<uint32_t> rand(1, 1000);
+	std::map<int, std::vector<std::vector<uint64_t> > > result;
+	for (int i = 0; i < total_count; i++) {
+		while (true) {
+			std::vector<uint64_t> curr;
+			for (int j = 0; j < vector_size; j++) {
+				curr.push_back(rand(gen));
+			}
+			int hash = stack_trace_map::hash_stack_trace(curr) %
+				   max_entries;
+			result[hash].push_back(curr);
+			if (result[hash].size() >= 5)
+				break;
+		}
+	}
+	return result;
+}
+TEST_CASE("Test stack trace map 2")
+{
+	spdlog::cfg::load_env_levels();
+
+	shm_remove remover(SHM_NAME);
+	managed_shared_memory mem(create_only, SHM_NAME, 20 << 20);
+
+	stack_trace_map_impl impl(mem, 4, 255 * 8, 1000);
+
+	auto generated = make_collision(1000, 10000, 3);
+	{
+		bool has_collision = false;
+		for (const auto &item : generated)
+			if (item.second.size() > 1)
+				has_collision = true;
+		REQUIRE(has_collision);
+	}
+	auto stk1 = generated.begin()->second.at(0);
+	int id1 = impl.fill_stack_trace(stk1, false, false);
+	REQUIRE(id1 >= 0);
+	// Make some collision
+	auto stk2 = generated.begin()->second.at(1);
+
+	int id2 = impl.fill_stack_trace(stk2, false, true);
+	REQUIRE(id1 == id2);
+	// The query result should be the same as id1
+	{
+		auto result = (uint64_t *)impl.elem_lookup(&id2);
+		REQUIRE(std::equal(stk1.begin(), stk1.end(), result));
+	}
+
+	auto stk3 = generated.begin()->second.at(2);
+	int id3 = impl.fill_stack_trace(stk3, true, true);
+	// The query result should be the same as id3
+	{
+		auto result = (uint64_t *)impl.elem_lookup(&id3);
+		REQUIRE(std::equal(stk3.begin(), stk3.end(), result));
+	}
+}


### PR DESCRIPTION
This PR implements `bpf_get_stack` and `bpf_get_stackid`, by using FridaGum to retrive call stacks. 
- Adds map type `BPF_MAP_TYPE_STACK_TRACE`, which is a variant of hash map, it can be used to get stack trace through `bpf_get_stackid`
- Adds function `virtual void *call_attach_specific_function(std::string name, void *data)` on `base_attach_impl`, to call attach-specified functions. With this runtime can call frida_uprobe_attach_impl without depending on it