### PR TITLE
Update CITATION.cff and README.md to reflect new paper

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,53 +11,44 @@ authors:
   - given-names: Yusheng
     family-names: Zheng
     email: yunwei356@gmail.com
+    affiliation: UC Santa Cruz
   - given-names: Tong
     family-names: Yu
+    affiliation: eunomia-bpf Community
   - given-names: Yiwei
     family-names: Yang
+    affiliation: UC Santa Cruz
   - given-names: Yanpeng
     family-names: Hu
-  - given-names: XiaoZheng
+    affiliation: ShanghaiTech University
+  - given-names: Xiaozheng
     family-names: Lai
-  - given-names: Andrew
+    affiliation: South China University of Technology
+  - given-names: Dan
+    family-names: Williams
+    affiliation: Virginia Tech
+  - given-names: Andi
     family-names: Quinn
+    affiliation: UC Santa Cruz
 identifiers:
   - type: url
-    value: 'https://arxiv.org/abs/2311.07923'
+    value: 'https://www.usenix.org/conference/osdi25/presentation/zheng-yusheng'
     description: >-
-      bpftime: userspace eBPF Runtime for Uprobe, Syscall
-      and Kernel-User Interactions
+      Extending Applications Safely and Efficiently
 repository-code: 'https://github.com/eunomia-bpf/bpftime'
 url: 'https://eunomia.dev/bpftime/'
 abstract: >-
-  In kernel-centric operations, the uprobe component of eBPF
-  frequently encounters performance bottlenecks, largely
-  attributed to the overheads borne by context switches.
-  Transitioning eBPF operations to user space bypasses these
-  hindrances, thereby optimizing performance. This also
-  enhances configurability and obviates the necessity for
-  root access or privileges for kernel eBPF, subsequently
-  minimizing the kernel attack surface. This paper
-  introduces bpftime, a novel user-space eBPF runtime, which
-  leverages binary rewriting to implement uprobe and syscall
-  hook capabilities. Through bpftime, userspace uprobes
-  achieve a 10x speed enhancement compared to their kernel
-  counterparts without requiring dual context switches.
-  Additionally, this runtime facilitates the programmatic
-  hooking of syscalls within a process, both safely and
-  efficiently. Bpftime can be seamlessly attached to any
-  running process, limiting the need for either a restart or
-  manual recompilation. Our implementation also extends to
-  interprocess eBPF Maps within shared memory, catering to
-  summary aggregation or control plane communication
-  requirements. Compatibility with existing eBPF toolchains
-  such as clang and libbpf is maintained, not only
-  simplifying the development of user-space eBPF without
-  necessitating any modifications but also supporting CO-RE
-  through BTF. Through bpftime, we not only enhance uprobe
-  performance but also extend the versatility and
-  user-friendliness of eBPF runtime in user space, paving
-  the way for more efficient and secure kernel operations.
+  This paper introduces the Extension Interface Model (EIM) and
+  bpftime, a framework for safer and more efficient application
+  extension. EIM treats extension features as resources, allowing
+  managers to specify exact resource needs. bpftime uses eBPF-style
+  verification, hardware isolation, and dynamic binary rewriting
+  to achieve efficiency and compatibility with the existing eBPF
+  ecosystem. The system demonstrates the approach across 6 use
+  cases involving security, performance monitoring, and configuration
+  exploration. By operating in userspace, bpftime achieves significant
+  performance improvements while maintaining safety guarantees and
+  compatibility with existing eBPF toolchains.
 keywords:
   - userspace
   - plugin

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,145 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+bpftime is a high-performance userspace eBPF runtime and general extension framework. It enables running eBPF programs in userspace for observability, networking, GPU, and other use cases, achieving up to 10x better performance than kernel eBPF for certain operations.
+
+## Common Development Commands
+
+### Build Commands
+
+```bash
+# Build with tests and all components (Debug mode)
+make build
+
+# Build release version
+make release
+
+# Build with LLVM JIT support
+make release-with-llvm-jit
+
+# Build with static library
+make release-with-static-lib
+
+# Clean build artifacts
+make clean
+
+# Build specific components
+cmake --build build --target <target_name>
+```
+
+### Testing Commands
+
+```bash
+# Run all unit tests
+make unit-test
+
+# Run runtime tests only
+make unit-test-runtime
+
+# Run daemon tests only
+make unit-test-daemon
+
+# Build eBPF test programs (from runtime/test/bpf)
+make -C runtime/test/bpf
+
+# Run specific test binary
+./build/runtime/unit-test/bpftime_runtime_tests
+./build/daemon/test/bpftime_daemon_tests
+```
+
+### Running Examples
+
+```bash
+# Build example programs
+make -C example/malloc
+
+# Load and run eBPF program
+export PATH=$PATH:~/.bpftime/
+bpftime load ./example/malloc/malloc
+bpftime start ./example/malloc/victim
+
+# Attach to running process (requires sudo)
+sudo bpftime attach <pid>
+```
+
+### Development Tools
+
+```bash
+# Install to system (after build)
+sudo cmake --install build
+
+# Build with specific features
+cmake -Bbuild -DBPFTIME_ENABLE_IOURING_EXT=1  # IO uring support
+cmake -Bbuild -DBPFTIME_LLVM_JIT=1           # LLVM JIT backend
+cmake -Bbuild -DBPFTIME_ENABLE_MPK=1         # Memory Protection Keys
+```
+
+## Architecture & Code Structure
+
+### Component Organization
+
+The codebase is organized into distinct components that interact through well-defined interfaces:
+
+1. **`vm/`** - Virtual Machine implementations
+   - `vm-core/`: Core VM interface and abstractions
+   - `llvm-jit/`: LLVM-based JIT/AOT compiler (high performance)
+   - Supports multiple backends (LLVM JIT, ubpf)
+
+2. **`runtime/`** - Core runtime functionality
+   - `include/`: Public APIs and interfaces
+   - `src/handler/`: Handler pattern for managing eBPF objects (programs, maps, links)
+   - `src/bpf_map/`: Map implementations (hash, array, ringbuf, etc.)
+   - `syscall-server/`: Intercepts eBPF syscalls for compatibility
+   - `agent/`: Library injected into target processes
+
+3. **`attach/`** - Event attachment mechanisms
+   - `base_attach_impl/`: Abstract interface for all attach types
+   - `frida_uprobe_attach_impl/`: Dynamic instrumentation via Frida
+   - `syscall_trace_attach_impl/`: Syscall interception
+   - `nv_attach_impl/`: CUDA/GPU event attachment
+
+4. **`daemon/`** - System monitoring and kernel interaction
+   - Monitors kernel eBPF operations
+   - Can redirect to userspace runtime
+
+5. **`bpftime-verifier/`** - Safety verification
+   - Wraps PREVAIL verifier for userspace
+   - Optional kernel verifier integration
+
+### Key Architectural Patterns
+
+1. **Shared Memory Architecture**: Uses boost::interprocess for zero-copy IPC between processes
+   - Central `handler_manager` registry in shared memory
+   - File descriptor abstraction for kernel compatibility
+
+2. **Handler Pattern**: All eBPF objects (programs, maps, links) managed through handlers
+   - Consistent interface for create/destroy/access
+   - Enables cross-process object sharing
+
+3. **Modular Attach System**: New event sources added by implementing `base_attach_impl`
+   - Each attach type provides its own helpers
+   - Supports custom context preparation
+
+4. **VM Abstraction**: Multiple VM backends through common interface
+   - Switch between interpreter/JIT/AOT transparently
+   - Extensible helper function registration
+
+### Important Files and Interfaces
+
+- `runtime/include/bpftime.hpp`: Main runtime API
+- `runtime/include/bpftime_shm.hpp`: Shared memory management
+- `vm/vm-core/include/ebpf-vm.h`: VM interface
+- `attach/base_attach_impl/base_attach_impl.hpp`: Attach interface
+- `runtime/src/handler/handler_manager.hpp`: Central object registry
+
+### Development Workflow
+
+1. **Adding new functionality**: Check existing patterns in similar components
+2. **Testing**: Add unit tests in component's test directory
+3. **eBPF programs**: Use standard clang/libbpf toolchain, test with both userspace and kernel
+4. **Performance**: Consider shared memory overhead, prefer batch operations
+
+The architecture prioritizes performance (bypassing kernel), compatibility (same APIs as kernel eBPF), and extensibility (modular design for new features).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 🔌 [Examples & Use Cases](#examples--use-cases) \
 ⌨️ [Linux Plumbers 23 talk](https://lpc.events/event/17/contributions/1639/) \
 📖 [Slides](https://eunomia.dev/bpftime/documents/userspace-ebpf-bpftime-lpc.pdf) \
-📚 [Arxiv preprint](https://arxiv.org/abs/2311.07923)
+📚 [OSDI '25 Paper](https://www.usenix.org/conference/osdi25/presentation/zheng-yusheng)
 
 [**Checkout our documents in eunomia.dev!**](https://eunomia.dev/bpftime/)
 
@@ -154,7 +154,7 @@ Current hook implementation is based on binary rewriting and the underly techniq
 
 The hook can be easily replaced with other DBI methods or frameworks, or add more hook mechanisms in the future.
 
-See our draft arxiv paper [bpftime: userspace eBPF Runtime for Uprobe, Syscall and Kernel-User Interactions](https://arxiv.org/abs/2311.07923) for details.
+See our OSDI '25 paper [Extending Applications Safely and Efficiently](https://www.usenix.org/conference/osdi25/presentation/zheng-yusheng) for details.
 
 ### **Performance Benchmarks**
 
@@ -219,16 +219,15 @@ This project is licensed under the MIT License.
 Have any questions or suggestions on future development? Free free to open an issue or contact
 <yunwei356@gmail.com> !
 
-Our arxiv preprint: <https://arxiv.org/abs/2311.07923>
+Our OSDI '25 paper: <https://www.usenix.org/conference/osdi25/presentation/zheng-yusheng>
 
 ```txt
-@misc{zheng2023bpftime,
-      title={bpftime: userspace eBPF Runtime for Uprobe, Syscall and Kernel-User Interactions}, 
-      author={Yusheng Zheng and Tong Yu and Yiwei Yang and Yanpeng Hu and XiaoZheng Lai and Andrew Quinn},
-      year={2023},
-      eprint={2311.07923},
-      archivePrefix={arXiv},
-      primaryClass={cs.OS}
+@inproceedings{zheng2025extending,
+  title={Extending Applications Safely and Efficiently},
+  author={Zheng, Yusheng and Yu, Tong and Yang, Yiwei and Hu, Yanpeng and Lai, Xiaozheng and Williams, Dan and Quinn, Andi},
+  booktitle={19th USENIX Symposium on Operating Systems Design and Implementation (OSDI 25)},
+  pages={557--574},
+  year={2025}
 }
 ```
 


### PR DESCRIPTION
This pull request updates the project's documentation to reflect the publication of the work in OSDI '25 and revises author affiliations and abstract details in the `CITATION.cff` file. Additionally, it updates a submodule reference. Below are the key changes:

### Documentation Updates
* Updated references in `README.md` to replace mentions of the Arxiv preprint with the OSDI '25 paper, including links, descriptions, and citation details. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L14-R14) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L157-R157) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L222-R230)

### Citation Metadata Updates
* Added affiliations for authors in the `CITATION.cff` file and updated the abstract to align with the content of the OSDI '25 paper.

### Submodule Update
* Updated the `vm/llvm-jit` submodule to a new commit reference.