### PR TITLE
feat: Add ARM64 Docker support and build test script

### DIFF
--- a/runtime/syscall-server/syscall_server_main.cpp
+++ b/runtime/syscall-server/syscall_server_main.cpp
@@ -4,7 +4,11 @@
  * All rights reserved.
  */
 #include "syscall_context.hpp"
+#if defined(__aarch64__)
+#include <asm-generic/unistd.h>
+#else
 #include <asm/unistd_64.h>
+#endif
 #include <boost/interprocess/exceptions.hpp>
 #include <cstdio>
 #if __linux__

--- a/tools/Dockerfile.arm
+++ b/tools/Dockerfile.arm
@@ -1,0 +1,50 @@
+FROM --platform=linux/arm64 ubuntu:22.04
+
+# Prevent interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install build dependencies for bpftime (based on Dockerfile.ubuntu)
+RUN apt-get update && apt-get install -y \
+    g++-aarch64-linux-gnu \
+    gcc-aarch64-linux-gnu \
+    make \
+    libyaml-cpp-dev \
+    wget \
+    pkg-config \
+    zlib1g-dev \
+    clang \
+    llvm-15-dev \
+    gcc-12 \
+    g++-12 \
+    libelf-dev \
+    python3-pytest \
+    systemtap-sdt-dev \
+    llvm \
+    git \
+    qemu-user \
+    cmake \
+    binutils-dev \
+    libboost1.74-all-dev \
+    python3 \
+    gcc \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set LLVM and compiler versions for ARM64 build
+# Using default gcc/g++ to avoid segmentation fault with gcc-12 on ARM64
+ENV LLVM_ROOT=/usr/lib/llvm-15
+ENV CC=gcc
+ENV CXX=g++
+ENV ARCH=arm64
+
+# Set working directory
+WORKDIR /bpftime
+
+# Copy the project
+COPY . .
+
+# Initialize git submodules
+RUN git config --global --add safe.directory /bpftime && \
+    git submodule update --init --recursive || true
+
+# Build command - use release mode with parallel compilation
+CMD ["sh", "-c", "JOBS=$(nproc) make release -j$JOBS"]

--- a/tools/test_arm_build.sh
+++ b/tools/test_arm_build.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# Complete ARM build test script for bpftime
+# Run this script from the project root: ./tools/test_arm_build.sh
+set -e
+
+echo "=== Testing bpftime ARM64 Build in Docker ==="
+echo "Running from: $(pwd)"
+echo
+
+echo "1. Building Docker image for ARM64..."
+docker build --platform linux/arm64 -f tools/Dockerfile.arm -t bpftime-arm .
+echo "✓ Docker image built successfully"
+
+echo
+echo "2. Testing bpftime build (Release mode)..."
+echo "   This may take a while on ARM64 emulation..."
+echo "   Using parallel compilation with -j flag..."
+docker run --platform linux/arm64 --rm bpftime-arm sh -c "cd /bpftime && make clean && make release -j\$(nproc)"
+if [ $? -eq 0 ]; then
+    echo "✓ bpftime built successfully in release mode"
+else
+    echo "✗ bpftime build failed"
+    exit 1
+fi
+
+echo
+echo "3. Building example eBPF programs..."
+docker run --platform linux/arm64 --rm bpftime-arm sh -c "cd /bpftime/example/malloc && make clean && make -j\$(nproc)"
+if [ $? -eq 0 ]; then
+    echo "✓ Example eBPF programs built successfully"
+else
+    echo "✗ Example eBPF programs build failed"
+    exit 1
+fi
+
+echo
+echo "=== ARM64 Build Test Complete ==="
+echo "✓ All build tests passed successfully!"
+echo
+echo "bpftime has been verified to build on ARM64 architecture:"
+echo "- All components build successfully"
+echo "- Example programs compile correctly"
+echo "- Core binaries are generated as expected"


### PR DESCRIPTION
- Introduced Dockerfile for ARM64 builds, including necessary dependencies.
- Added a script to automate the ARM64 build testing process in Docker.
- Updated syscall_server_main.cpp to conditionally include headers for AArch64 architecture.
