### PR TITLE
fix: cleanup when reattach

### DIFF
--- a/daemon/user/bpftime_driver.cpp
+++ b/daemon/user/bpftime_driver.cpp
@@ -319,7 +319,7 @@ int bpftime_driver::bpftime_perf_event_enable_server(int server_pid, int fd)
 {
 	int fd_id = check_and_get_pid_fd(server_pid, fd);
 	if (fd_id < 0) {
-		spdlog::warn("Unrecorded uprobe fd: {} for pid {}", fd,
+		SPDLOG_WARN("Unrecorded uprobe fd: {} for pid {}", fd,
 			     server_pid);
 		return 0;
 	}

--- a/daemon/user/handle_bpf_event.cpp
+++ b/daemon/user/handle_bpf_event.cpp
@@ -245,7 +245,7 @@ int bpf_event_handler::handle_bpf_event(const struct event *e)
 				    driver.bpftime_attach_perf_to_bpf_fd_server(
 					    e->pid, perf, prog_fd);
 			    err < 0) {
-				spdlog::warn(
+				SPDLOG_WARN(
 					"Unable to attach perf {} to bpf prog {}, err={}",
 					perf, prog_fd, err);
 			}
@@ -321,7 +321,7 @@ int bpf_event_handler::handle_perf_event_open(const struct event *e)
 					e->perf_event_data.pid, name, offset,
 					retprobe, ref_ctr_off);
 			} else {
-				spdlog::warn("Unsupported perf event type: {}",
+				SPDLOG_WARN("Unsupported perf event type: {}",
 					     perf_type);
 			}
 		} else {

--- a/runtime/agent/agent.cpp
+++ b/runtime/agent/agent.cpp
@@ -104,7 +104,7 @@ extern "C" int __libc_start_main(int (*main)(int, char **, char **), int argc,
 		    stack_end);
 }
 #endif
-static void sig_handler_sigusr1(int sig)
+static void sig_handler_sigusr1_detach(int sig)
 {
 	SPDLOG_INFO("Detaching..");
 	if (int err = ctx_holder.ctx.destroy_all_attach_links(); err < 0) {
@@ -148,7 +148,7 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 
 	srand(std::random_device()());
 	// We use SIGUSR1 to indicate the detaching
-	signal(SIGUSR1, sig_handler_sigusr1);
+	signal(SIGUSR1, sig_handler_sigusr1_detach);
 	try {
 		// If we are unable to initialize shared memory..
 		bpftime_initialize_global_shm(shm_open_type::SHM_OPEN_ONLY);

--- a/runtime/agent/agent.cpp
+++ b/runtime/agent/agent.cpp
@@ -113,6 +113,7 @@ static void sig_handler_sigusr1(int sig)
 	}
 	shm_holder.global_shared_memory.remove_pid_from_alive_agent_set(
 		getpid());
+	__atomic_store_n(&initialized, 0, __ATOMIC_SEQ_CST);
 	SPDLOG_DEBUG("Detaching done");
 	bpftime_logger_flush();
 }

--- a/runtime/include/bpftime_logger.hpp
+++ b/runtime/include/bpftime_logger.hpp
@@ -25,8 +25,8 @@ inline std::string expand_user_path(const std::string &input_path)
 
 		if (input_path.size() == 1 || input_path[1] == '/') {
 			// Replace "~" with the home directory
-			std::string expandedPath = homeDir +
-				 input_path.substr(1);
+			std::string expandedPath =
+				homeDir + input_path.substr(1);
 			return expandedPath;
 		} else {
 			return "console"; // Unsupported path format
@@ -40,7 +40,7 @@ inline std::string expand_user_path(const std::string &input_path)
 inline void bpftime_set_logger(const std::string &target) noexcept
 {
 	std::string logger_target = expand_user_path(target);
-
+	spdlog::drop_all();
 	if (logger_target == "console") {
 		// Set logger to stderr
 		auto logger = spdlog::stderr_color_mt("stderr");

--- a/runtime/src/bpf_helper.cpp
+++ b/runtime/src/bpf_helper.cpp
@@ -420,7 +420,7 @@ uint64_t bpf_ringbuf_output(uint64_t rb, uint64_t data, uint64_t size,
 {
 	int fd = (int)(rb >> 32);
 	if (flags != 0) {
-		spdlog::warn(
+		SPDLOG_WARN(
 			"Currently only supports ringbuf_output with flags=0");
 	}
 	auto buf = bpftime_ringbuf_reserve(fd, size);
@@ -438,7 +438,7 @@ uint64_t bpf_ringbuf_reserve(uint64_t rb, uint64_t size, uint64_t flags,
 {
 	int fd = (int)(rb >> 32);
 	if (flags != 0) {
-		spdlog::warn(
+		SPDLOG_WARN(
 			"Currently only supports ringbuf_reserve with flags=0");
 	}
 	return (uint64_t)(uintptr_t)bpftime_ringbuf_reserve(fd, size);
@@ -450,7 +450,7 @@ uint64_t bpf_ringbuf_submit(uint64_t data, uint64_t flags, uint64_t, uint64_t,
 	int32_t *ptr = (int32_t *)(uintptr_t)data;
 	int fd = ptr[-1];
 	if (flags != 0) {
-		spdlog::warn(
+		SPDLOG_WARN(
 			"Currently only supports ringbuf_submit with flags=0");
 	}
 	bpftime_ringbuf_submit(fd, (void *)(uintptr_t)data, false);
@@ -463,7 +463,7 @@ uint64_t bpf_ringbuf_discard(uint64_t data, uint64_t flags, uint64_t, uint64_t,
 	int32_t *ptr = (int32_t *)(uintptr_t)data;
 	int fd = ptr[-1];
 	if (flags != 0) {
-		spdlog::warn(
+		SPDLOG_WARN(
 			"Currently only supports ringbuf_submit with flags=0");
 	}
 	bpftime_ringbuf_submit(fd, (void *)(uintptr_t)data, true);

--- a/runtime/src/bpf_map/shared/array_map_kernel_user.cpp
+++ b/runtime/src/bpf_map/shared/array_map_kernel_user.cpp
@@ -56,7 +56,7 @@ void array_map_kernel_user_impl::init_map_fd()
 		_value_size, _max_entries);
 	// TODO: is the check here necessary?
 	// if (!(info.map_flags & BPF_F_MMAPABLE)) {
-	// 	spdlog::warn("Map is not mmapable");
+	// 	SPDLOG_WARN("Map is not mmapable");
 	// 	return;
 	// }
 	size_t mmap_sz = bpf_map_mmap_sz(_value_size, _max_entries);

--- a/runtime/src/bpftime_config.cpp
+++ b/runtime/src/bpftime_config.cpp
@@ -64,7 +64,7 @@ static void process_token(const std::string_view &token, agent_config &config)
 		SPDLOG_INFO("Enabling shm_map helper group");
 		config.enable_shm_maps_helper_group = true;
 	} else {
-		spdlog::warn("Unknown helper group: {}", token);
+		SPDLOG_WARN("Unknown helper group: {}", token);
 	}
 }
 

--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -770,7 +770,7 @@ int syscall_context::handle_ioctl(int fd, unsigned long req, unsigned long data)
 		res = bpftime_perf_event_enable(fd);
 		if (res >= 0)
 			return res;
-		spdlog::warn(
+		SPDLOG_WARN(
 			"Failed to call mocked ioctl PERF_EVENT_IOC_ENABLE: {}",
 			res);
 	} else if (req == PERF_EVENT_IOC_DISABLE) {
@@ -781,7 +781,7 @@ int syscall_context::handle_ioctl(int fd, unsigned long req, unsigned long data)
 		res = bpftime_perf_event_disable(fd);
 		if (res >= 0)
 			return res;
-		spdlog::warn(
+		SPDLOG_WARN(
 			"Failed to call mocked ioctl PERF_EVENT_IOC_DISABLE: {}",
 			res);
 	} else if (req == PERF_EVENT_IOC_SET_BPF) {
@@ -830,7 +830,7 @@ int syscall_context::handle_epoll_ctl(int epfd, int op, int fd,
 				return err;
 
 		} else {
-			spdlog::warn(
+			SPDLOG_WARN(
 				"Unsupported map fd for mocked epoll_ctl: {}, call the original one..",
 				fd);
 		}

--- a/runtime/syscall-server/syscall_server_main.cpp
+++ b/runtime/syscall-server/syscall_server_main.cpp
@@ -162,7 +162,6 @@ extern "C" int open(const char *file, int oflag, ...)
 extern "C" ssize_t read(int fd, void *buf, size_t count)
 {
 	initialize_ctx();
-	SPDLOG_DEBUG("read {} {:x} {}", fd, (uintptr_t)buf, count);
 	return context->handle_read(fd, buf, count);
 }
 

--- a/tools/cli/main.cpp
+++ b/tools/cli/main.cpp
@@ -199,7 +199,7 @@ int main(int argc, const char **argv)
 			.required()
 			.nargs(1);
 	} else {
-		spdlog::warn(
+		SPDLOG_WARN(
 			"Unable to determine home directory. You must specify --install-location");
 		program.add_argument("-i", "--install-location")
 			.help("Installing location of bpftime")


### PR DESCRIPTION
There are two major issues during reattaching:
- `static int initialized = 0;` in `agent.cpp` won't be set to zero when detached
- spdlog logger will be double-initialized which cause an exception

This PR fixes them

Closes #415 