### PR TITLE
fix: Resolve compilation failure when BPFTIME_ENABLE_CUDA_ATTACH=1

### DIFF
--- a/runtime/src/handler/map_handler.cpp
+++ b/runtime/src/handler/map_handler.cpp
@@ -804,6 +804,7 @@ int bpf_map_handler::map_init(managed_shared_memory &memory)
 				"CUDA context for thread {} has been set to {:x}",
 				gettid(), (uintptr_t)context);
 		}
+		SPDLOG_INFO(
 			"Map {} (nv_gpu_ringbuf_map_impl) has space for thread count {}",
 			container_name.c_str(), attr.gpu_thread_count);
 		map_impl_ptr = memory.construct<nv_gpu_ringbuf_map_impl>(
@@ -899,11 +900,6 @@ void bpf_map_handler::map_free(managed_shared_memory &memory) const
 		memory.destroy<lpm_trie_map_impl>(container_name.c_str());
 		break;
 	
-#endif
-#if defined(BPFTIME_ENABLE_CUDA_ATTACH)
-	case bpf_map_type::BPF_MAP_TYPE_NV_GPU_ARRAY_MAP:
-		memory.destroy<nv_gpu_array_map_impl>(container_name.c_str());
-		break;
 #endif
 #if defined(BPFTIME_ENABLE_CUDA_ATTACH)
 	case bpf_map_type::BPF_MAP_TYPE_NV_GPU_ARRAY_MAP:


### PR DESCRIPTION
When BPFTIME_ENABLE_CUDA_ATTACH=1, there are some compilation errors:

```
61.82 /bpftime/runtime/src/handler/map_handler.cpp: In member function 'int bpftime::bpf_map_handler::map_init(bpftime::managed_shared_memory&)':
61.82 /bpftime/runtime/src/handler/map_handler.cpp:807:25: warning: left operand of comma operator has no effect [-Wunused-value]
61.82   807 |                         "Map {} (nv_gpu_ringbuf_map_impl) has space for thread count {}",
61.82       |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
61.82 /bpftime/runtime/src/handler/map_handler.cpp:808:70: error: expected ';' before ')' token
61.82   808 |                         container_name.c_str(), attr.gpu_thread_count);
61.82       |                                                                      ^
61.82       |                                                                      ;
61.82 /bpftime/runtime/src/handler/map_handler.cpp:808:54: warning: right operand of comma operator has no effect [-Wunused-value]
61.82   808 |                         container_name.c_str(), attr.gpu_thread_count);
61.82       |                                                 ~~~~~^~~~~~~~~~~~~~~~
61.83 /bpftime/runtime/src/handler/map_handler.cpp: In member function 'void bpftime::bpf_map_handler::map_free(bpftime::managed_shared_memory&) const':
61.83 /bpftime/runtime/src/handler/map_handler.cpp:909:9: error: duplicate case value
61.83   909 |         case bpf_map_type::BPF_MAP_TYPE_NV_GPU_ARRAY_MAP:
61.83       |         ^~~~
61.83 /bpftime/runtime/src/handler/map_handler.cpp:904:9: note: previously used here
61.83   904 |         case bpf_map_type::BPF_MAP_TYPE_NV_GPU_ARRAY_MAP:
61.83       |         ^~~~
63.05 gmake[2]: *** [runtime/CMakeFiles/runtime.dir/build.make:104: runtime/CMakeFiles/runtime.dir/src/handler/map_handler.cpp.o] Error 1
```

This PR fixes them
