### PR TITLE
gpu: fix memtrace example 

### DIFF
--- a/attach/nv_attach_impl/nv_attach_impl.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl.cpp
@@ -60,7 +60,9 @@ int nv_attach_impl::create_attach_with_ebpf_callback(
 	if (attach_type == ATTACH_CUDA_PROBE) {
 		if (std::get<std::string>(data.code_addr_or_func_name) ==
 		    "__memcapture") {
-			SPDLOG_INFO("Recording memcapture in nv_attach_impl");
+			SPDLOG_INFO(
+				"Recording memcapture in nv_attach_impl, instructions count = {}",
+				data.instructions.size());
 			auto id = this->allocate_id();
 			hook_entries[id] = nv_attach_entry{
 				.type = nv_attach_cuda_memcapture{},

--- a/example/gpu/cuda-counter/cuda_probe.bpf.c
+++ b/example/gpu/cuda-counter/cuda_probe.bpf.c
@@ -34,7 +34,7 @@ static const u64 (*bpf_get_block_dim)(u64 *x, u64 *y, u64 *z) = (void *)504;
 static const u64 (*bpf_get_thread_idx)(u64 *x, u64 *y, u64 *z) = (void *)505;
 
 SEC("kprobe/_Z9vectorAddPKfS0_Pf")
-int probe__cuda()
+int cuda__probe()
 {
 	u32 pid = bpf_get_current_pid_tgid() >> 32;
 	u64 ts = bpf_get_globaltimer();
@@ -58,7 +58,7 @@ int probe__cuda()
 }
 
 SEC("kretprobe/_Z9vectorAddPKfS0_Pf")
-int retprobe__cuda()
+int cuda__retprobe()
 {
 	u64 x, y, z;
 	bpf_get_block_idx(&x, &y, &z);

--- a/example/gpu/kernelretsnoop/kernelretsnoop.bpf.c
+++ b/example/gpu/kernelretsnoop/kernelretsnoop.bpf.c
@@ -29,7 +29,7 @@ struct data {
 };
 
 SEC("kretprobe/_Z9vectorAddPKfS0_Pf")
-int retprobe__cuda()
+int cuda__retprobe()
 {
 	struct data data;
 

--- a/example/gpu/launchlate/launchlate.bpf.c
+++ b/example/gpu/launchlate/launchlate.bpf.c
@@ -82,7 +82,7 @@ static __always_inline u32 get_hist_bin(u64 delta_ns)
 
 // GPU-side probe - tracks when kernel actually executes on GPU
 SEC("kprobe/_Z9vectorAddPKfS0_Pf")
-int probe__cuda()
+int cuda__probe()
 {
 	u64 gpu_ts = bpf_get_globaltimer();
 	u32 key = 0;

--- a/example/gpu/mem_trace/mem_trace.bpf.c
+++ b/example/gpu/mem_trace/mem_trace.bpf.c
@@ -9,7 +9,7 @@
 #include <bpf/bpf_tracing.h>
 
 SEC("kprobe/__memcapture")
-int trace_cuda_kernel__cuda(struct pt_regs *ctx)
+int cuda__trace_cuda_kernel(struct pt_regs *ctx)
 {
 	bpf_printk("mem_trace called");
 	return 0;

--- a/example/gpu/threadhist/threadhist.bpf.c
+++ b/example/gpu/threadhist/threadhist.bpf.c
@@ -19,7 +19,7 @@ static const u64 (*bpf_get_block_dim)(u64 *x, u64 *y, u64 *z) = (void *)504;
 static const u64 (*bpf_get_thread_idx)(u64 *x, u64 *y, u64 *z) = (void *)505;
 
 SEC("kretprobe/_Z9vectorAddPKfS0_Pf")
-int retprobe__cuda()
+int cuda__retprobe()
 {
 	u32 key = 0;
 	u64 *cnt = bpf_map_lookup_elem(&call_count, &key);

--- a/runtime/include/bpftime_prog.hpp
+++ b/runtime/include/bpftime_prog.hpp
@@ -53,7 +53,7 @@ class bpftime_prog {
 #ifdef BPFTIME_ENABLE_CUDA_ATTACH
 	bool is_cuda() const
 	{
-		return name.ends_with("__cuda");
+		return name.starts_with("cuda__");
 	}
 	const void *get_cuda_elf_binary() const
 	{

--- a/runtime/src/attach/bpf_attach_ctx.cpp
+++ b/runtime/src/attach/bpf_attach_ctx.cpp
@@ -264,9 +264,15 @@ int bpf_attach_ctx::instantiate_bpf_link_handler_at(
 		return -ENOTSUP;
 	}
 	auto prog = instantiated_progs.at(handler.prog_id).get();
+	SPDLOG_DEBUG(
+		"Instantiating bpf link {}, bpftime_prog->prog_name() = {}", id,
+		prog->prog_name());
 	int attach_id;
 #ifdef BPFTIME_ENABLE_CUDA_ATTACH
 	if (prog->is_cuda()) {
+		SPDLOG_INFO(
+			"Instantiating bpf link {} and the corresponding program {} is cuda program",
+			id, prog->prog_name());
 		if (handle_nv_attach_impl) {
 			SPDLOG_INFO(
 				"Handling link to CUDA program: {}, recording it..",
@@ -296,6 +302,16 @@ int bpf_attach_ctx::instantiate_bpf_link_handler_at(
 	} else
 #endif
 	{
+#ifdef BPFTIME_ENABLE_CUDA_ATTACH
+		if (auto p = dynamic_cast<attach::nv_attach_private_data *>(
+			    priv_data.get());
+		    p) {
+			SPDLOG_ERROR(
+				"A CUDA attach must be used with a CUDA program (program with name startes with `cuda__`), not {}",
+				prog->prog_name());
+			return -1;
+		}
+#endif
 		auto cookie = handler.attach_cookie;
 		attach_id = attach_impl->create_attach_with_ebpf_callback(
 			[=](void *mem, size_t mem_size, uint64_t *ret) -> int {

--- a/runtime/src/attach/bpf_attach_ctx.cpp
+++ b/runtime/src/attach/bpf_attach_ctx.cpp
@@ -307,7 +307,7 @@ int bpf_attach_ctx::instantiate_bpf_link_handler_at(
 			    priv_data.get());
 		    p) {
 			SPDLOG_ERROR(
-				"A CUDA attach must be used with a CUDA program (program with name startes with `cuda__`), not {}",
+				"A CUDA attach must be used with a CUDA program (program with name starts with `cuda__`), not {}",
 				prog->prog_name());
 			return -1;
 		}


### PR DESCRIPTION
In ths original CUDA attach design, an eBPF program with name ending with `__cuda` marks it a CUDA program. But libbpf will ignore characters if that name was too long, so sometimes a name like `trace_cuda_kernel__cuda` will be regarded as `trace_cuda_kern` by bpftime. In this way, bpftime will pass an empty eBPF program for memtrace programs, with prepending memtrace-specific trampoline, an eBPF program without `exit` instructions will be generated, leading to a basicblock without exit instructions in LLVM IR, stuck the LLVM optimizer.

This PR fixed the issue by using prefix `cuda__` to mark an eBPF program a CUDA program