### PR TITLE
[+] Feat: Add cuda_memcpy_to_symbol for fixing constant sync issue 

### DIFF
--- a/attach/nv_attach_impl/nv_attach_impl.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl.cpp
@@ -238,6 +238,20 @@ nv_attach_impl::nv_attach_impl()
 			      cuda_malloc_managed_addr);
 	}
 	{
+		void *cuda_memcpy_to_symbol_addr =
+			GSIZE_TO_POINTER(gum_module_find_export_by_name(
+				nullptr, "cudaMemcpyToSymbol"));
+		register_hook(AttachedToFunction::CudaMemcpyToSymbol,
+			      cuda_memcpy_to_symbol_addr);
+	}
+	{
+		void *cuda_memcpy_to_symbol_async_addr =
+			GSIZE_TO_POINTER(gum_module_find_export_by_name(
+				nullptr, "cudaMemcpyToSymbolAsync"));
+		register_hook(AttachedToFunction::CudaMemcpyToSymbolAsync,
+			      cuda_memcpy_to_symbol_async_addr);
+	}
+	{
 		void *cuda_launch_kernel_addr =
 			GSIZE_TO_POINTER(gum_module_find_export_by_name(
 				nullptr, "cudaLaunchKernel"));
@@ -643,6 +657,72 @@ int nv_attach_impl::run_attach_entry_on_gpu(int attach_id, int run_count,
 		}
 	}
 	return 0;
+}
+
+void nv_attach_impl::mirror_cuda_memcpy_to_symbol(
+	const void *symbol, const void *src, size_t count, size_t offset,
+	cudaMemcpyKind kind, cudaStream_t stream, bool async)
+{
+	auto record_itr = symbol_address_to_fatbin.find((void *)symbol);
+	if (record_itr == symbol_address_to_fatbin.end())
+		return;
+	auto &record = *record_itr->second;
+	auto var_itr = record.variable_addr_to_symbol.find((void *)symbol);
+	if (var_itr == record.variable_addr_to_symbol.end()) {
+		SPDLOG_DEBUG(
+			"mirror_cuda_memcpy_to_symbol: no variable info for symbol pointer {:x}",
+			(uintptr_t)symbol);
+		return;
+	}
+	auto &var_info = var_itr->second;
+	if (offset >= var_info.size) {
+		SPDLOG_WARN(
+			"mirror_cuda_memcpy_to_symbol: offset {} exceeds size {} for symbol {}",
+			offset, var_info.size, var_info.symbol_name);
+		return;
+	}
+	size_t writable = var_info.size - offset;
+	size_t bytes_to_copy = std::min(count, writable);
+	if (bytes_to_copy == 0)
+		return;
+	if (bytes_to_copy != count) {
+		SPDLOG_WARN(
+			"mirror_cuda_memcpy_to_symbol: truncating copy for symbol {} (requested={}, allowed={})",
+			var_info.symbol_name, count, bytes_to_copy);
+	}
+	CUdeviceptr dst = var_info.ptr + offset;
+	CUstream cu_stream = reinterpret_cast<CUstream>(stream);
+	CUresult status = CUDA_SUCCESS;
+
+	auto copy_device_ptr = [](const void *ptr) -> CUdeviceptr {
+		return static_cast<CUdeviceptr>(
+			reinterpret_cast<uintptr_t>(ptr));
+	};
+
+	switch (kind) {
+	case cudaMemcpyHostToDevice:
+	case cudaMemcpyDefault:
+		status = async ? cuMemcpyHtoDAsync(dst, src, bytes_to_copy,
+						   cu_stream) :
+				 cuMemcpyHtoD(dst, src, bytes_to_copy);
+		break;
+	case cudaMemcpyDeviceToDevice:
+		status = async ? cuMemcpyDtoDAsync(dst, copy_device_ptr(src),
+						   bytes_to_copy, cu_stream) :
+				 cuMemcpyDtoD(dst, copy_device_ptr(src),
+					      bytes_to_copy);
+		break;
+	default:
+		SPDLOG_DEBUG(
+			"mirror_cuda_memcpy_to_symbol: unsupported memcpy kind {} for symbol {}",
+			(int)kind, var_info.symbol_name);
+		return;
+	}
+	if (status != CUDA_SUCCESS) {
+		SPDLOG_WARN(
+			"mirror_cuda_memcpy_to_symbol: failed to copy symbol {} (err={})",
+			var_info.symbol_name, (int)status);
+	}
 }
 
 } // namespace bpftime::attach

--- a/attach/nv_attach_impl/nv_attach_impl.hpp
+++ b/attach/nv_attach_impl/nv_attach_impl.hpp
@@ -56,7 +56,9 @@ enum class AttachedToFunction {
 	RegisterVariable,
 	RegisterFatbinEnd,
 	CudaMalloc,
-	CudaMallocManaged
+	CudaMallocManaged,
+	CudaMemcpyToSymbol,
+	CudaMemcpyToSymbolAsync
 };
 struct CUDARuntimeFunctionHookerContext {
 	class nv_attach_impl *impl;
@@ -129,6 +131,10 @@ class nv_attach_impl final : public base_attach_impl {
 		hack_fatbin(std::map<std::string, std::string>);
 	std::map<std::string, std::string>
 	extract_ptxs(std::vector<uint8_t> &&);
+	void mirror_cuda_memcpy_to_symbol(const void *symbol, const void *src,
+					  size_t count, size_t offset,
+					  cudaMemcpyKind kind,
+					  cudaStream_t stream, bool async);
 
 	int find_attach_entry_by_program_name(const char *name) const;
 	int run_attach_entry_on_gpu(int attach_id, int run_count = 1,


### PR DESCRIPTION
To fix issue of example/gpu/lanuchlate

before fix
```
C[1] = 0 (expected 3)
```

after fix

```
C[1] = 3 (expected 3)
```