### PR TITLE
Remove `#ifndef` around `__libc_start_main` 

### DIFF
--- a/runtime/agent/agent.cpp
+++ b/runtime/agent/agent.cpp
@@ -79,8 +79,6 @@ syscall_hooker_func_t orig_hooker;
 
 extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident);
 
-#ifndef BPFTIME_ENABLE_CUDA_ATTACH
-
 extern "C" int bpftime_hooked_main(int argc, char **argv, char **envp)
 {
 	int stay_resident = 0;
@@ -103,7 +101,6 @@ extern "C" int __libc_start_main(int (*main)(int, char **, char **), int argc,
 	return orig(bpftime_hooked_main, argc, argv, init, fini, rtld_fini,
 		    stack_end);
 }
-#endif
 static void sig_handler_sigusr1_detach(int sig)
 {
 	SPDLOG_INFO("Detaching..");


### PR DESCRIPTION
In the previous implementation of nv_attach_impl, if the hook starts from `__libc_start_main`, some functions in CUDA runtime API doesn't work since global variables haven't been initialized. Now we switched to CUDA driver API, and this problem doesn't exist, so nv attach impl can also start from `__libc_start_main`