### PR TITLE
[~]Fix: Change dynamic library loading to avoid glibc error

### DIFF
--- a/attach/nv_attach_impl/ptx_compiler/ptx_compiler.hpp
+++ b/attach/nv_attach_impl/ptx_compiler/ptx_compiler.hpp
@@ -38,7 +38,7 @@ struct nv_attach_impl_ptx_compiler_handler {
 static inline std::optional<nv_attach_impl_ptx_compiler_handler>
 load_nv_attach_impl_ptx_compiler(const char *path, void *&dl_handle)
 {
-	void *handle = dlmopen(LM_ID_NEWLM, path, RTLD_NOW | RTLD_LOCAL);
+	void *handle = dlopen(path, RTLD_NOW | RTLD_LOCAL);
 	if (!handle) {
 		std::cerr << "Unable to load dynamic library " << path << " = "
 			  << dlerror() << std::endl;


### PR DESCRIPTION
Issue found in example/gpu/kernelsnoop:

error log be like: https://pastebin.com/zgBZexnQ

The explanation of root cause:

We load libnv_attach_impl_ptx_compiler.so into a “brand-new” dynamic linking namespace via `dlmopen`(LM_ID_NEWLM, …). This namespace reinitializes `glibc` together with its global state (locale, TLS, alias tables, etc.). However, in this new `glibc` instance, the locale alias data has not been set up yet. When `setlocale()` tries to resolve the alias, it reads a null pointer, and then read_alias_file → _nl_expand_alias directly accesses address 0x8, which triggers a segmentation fault.

Right now we use `dlopen`, which shares the existing `glibc`, so this kind of error does not occur.
