### PR TITLE
support cudaMemcpyFromSymbol

### DIFF
--- a/attach/nv_attach_impl/nv_attach_impl.hpp
+++ b/attach/nv_attach_impl/nv_attach_impl.hpp
@@ -138,6 +138,10 @@ class nv_attach_impl final : public base_attach_impl {
 					  size_t count, size_t offset,
 					  cudaMemcpyKind kind,
 					  cudaStream_t stream, bool async);
+	void mirror_cuda_memcpy_from_symbol(void *dst, const void *symbol,
+					    size_t count, size_t offset,
+					    cudaMemcpyKind kind,
+					    cudaStream_t stream, bool async);
 
 	int find_attach_entry_by_program_name(const char *name) const;
 	int run_attach_entry_on_gpu(int attach_id, int run_count = 1,
@@ -177,6 +181,8 @@ class nv_attach_impl final : public base_attach_impl {
 	void *original_cu_graph_exec_kernel_node_set_params_v2 = nullptr;
 	void *original_cu_graph_kernel_node_set_params_v1 = nullptr;
 	void *original_cu_graph_kernel_node_set_params_v2 = nullptr;
+	void *original_cuda_memcpy_from_symbol = nullptr;
+	void *original_cuda_memcpy_from_symbol_async = nullptr;
 
     private:
 	void *frida_interceptor;

--- a/example/gpu/cuda-counter/vec_add.cu
+++ b/example/gpu/cuda-counter/vec_add.cu
@@ -18,9 +18,12 @@ g++ vectorAdd-new.cpp -Wall -L /usr/local/cuda-12.6/lib64 -lcudart -o vectorAdd
 
 __constant__ int d_N;
 
+__device__ int counter;
+
 __global__ void test_kernel_2()
 {
 	printf("qwq\n");
+	counter++;
 }
 
 // A simple vector addition kernel
@@ -36,7 +39,9 @@ int main()
 {
 	// Set vector size in constant memory
 	const int h_N = 1 << 20; // 1M elements
+	int i = 233;
 	cudaMemcpyToSymbol(d_N, &h_N, sizeof(h_N));
+	cudaMemcpyToSymbol(counter, &i, sizeof(i));
 
 	size_t bytes = h_N * sizeof(float);
 
@@ -67,6 +72,11 @@ int main()
 		// Zero output array
 		cudaMemset(d_C, 0, bytes);
 		test_kernel_2<<<1, 1>>>();
+		i++;
+		int h_counter = 0;
+		cudaMemcpyFromSymbol(&h_counter, counter, sizeof(h_counter));
+		std::cout << "counter = " << h_counter << " (expected " << i
+			  << ")\n";
 		// Launch kernel
 		vectorAdd<<<1, 10>>>(d_A, d_B, d_C);
 		cudaDeviceSynchronize();


### PR DESCRIPTION
## Description

The `cudaMemcpyFromSymbol` and `cudaMemcpyFromSymbolAsync` were not supported in the bpftime. The value in GPU symbols could not be retrieved to the host side.

Because we replaced the kernels, the original API calls in CUDA would read wrong device addresses. In this commit, I mimic the implementation for `cudaMemcpyToSymbol`, and replace the original CUDA API calls.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

By adding an additional counter to `example/gpu/cuda-counter/vec_add.cu`, it can be verified that both copying from and copying to the symbol works correctly now, which increases when the kernel function is called:

<img width="1252" height="800" alt="image" src="https://github.com/user-attachments/assets/ed32e6e6-a415-46fb-bac6-cb3835e5df82" />

Without this patch, the counter will always be a constant value.

**Test Configuration**:
- Hardware: L20
- Toolchain: clang 18.1
- SDK: CUDA 12.8

