### PR TITLE
cleanup: route diagnostics through spdlog

### DIFF
--- a/.github/workflows/build-gcc13.yml
+++ b/.github/workflows/build-gcc13.yml
@@ -67,6 +67,30 @@ jobs:
       - name: Build
         run: cmake --build build -j$(nproc)
 
+      - name: Configure daemon build and tests
+        env:
+          CC: gcc-13
+          CXX: g++-13
+        run: |
+          cmake -S . -B build-daemon \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=gcc-13 \
+            -DCMAKE_CXX_COMPILER=g++-13 \
+            -DBPFTIME_LLVM_JIT=OFF \
+            -DBPFTIME_BUILD_WITH_LIBBPF=ON \
+            -DBUILD_BPFTIME_DAEMON=ON \
+            -DBPFTIME_ENABLE_UNIT_TESTING=ON \
+            -DENABLE_EBPF_VERIFIER=OFF
+
+      - name: Build daemon targets
+        run: cmake --build build-daemon -j$(nproc) --target bpftime_daemon bpftime_daemon_tests
+
+      - name: Smoke test daemon CLI
+        run: ./build-daemon/daemon/bpftime_daemon --help >/dev/null
+
+      - name: Run daemon tests
+        run: ./build-daemon/daemon/test/bpftime_daemon_tests
+
       - name: List build outputs (first 200 lines)
         if: always()
         run: |

--- a/attach/nv_attach_impl/nv_attach_impl_patcher.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl_patcher.cpp
@@ -8,11 +8,10 @@
 #include <cstddef>
 #include <cstdint>
 #include <optional>
-#include <ostream>
 #include <regex>
 #include <set>
-#include <sstream>
 #include <string>
+#include <string_view>
 #include <vector>
 #include <fstream>
 using namespace bpftime;
@@ -21,32 +20,45 @@ using namespace attach;
 namespace bpftime::attach
 {
 
+namespace {
+template <typename Fn>
+void for_each_line(std::string_view input, Fn &&fn)
+{
+	size_t start = 0;
+	while (start < input.size()) {
+		const auto end = input.find('\n', start);
+		if (end == std::string_view::npos) {
+			fn(input.substr(start));
+			break;
+		}
+		fn(input.substr(start, end - start));
+		start = end + 1;
+	}
+}
+} // namespace
+
 std::string add_semicolon_for_variable_lines(std::string input)
 {
-	std::istringstream iss(input);
-	std::string line;
-	std::ostringstream oss;
-	while (std::getline(iss, line)) {
-		while (!line.empty() && line.ends_with("\n"))
-			line.pop_back();
-		oss << line;
+	std::string result;
+	result.reserve(input.size() + 8);
+	for_each_line(input, [&](std::string_view line) {
+		result.append(line);
 		if ((line.starts_with(".align") ||
 		     line.starts_with(".global")) &&
 		    !line.ends_with(";") && line.ends_with("}")) {
-			oss << ";";
+			result.push_back(';');
 			SPDLOG_DEBUG("Patching line: {}", line);
 		}
-		oss << std::endl;
-	}
-	return oss.str();
+		result.push_back('\n');
+	});
+	return result;
 }
 
 std::string filter_compiled_ptx_for_ebpf_program(std::string input,
 						 std::string new_func_name)
 {
-	std::istringstream iss(input);
-	std::ostringstream oss;
-	std::string line;
+	std::string filtered;
+	filtered.reserve(input.size());
 	static const std::string FILTERED_OUT_PREFIXES[] = {
 		".version", ".target", ".address_size", "//"
 	};
@@ -62,7 +74,7 @@ std::string filter_compiled_ptx_for_ebpf_program(std::string input,
 ))",
 		R"(.visible .func bpf_main())"
 	};
-	while (std::getline(iss, line)) {
+	for_each_line(input, [&](std::string_view line) {
 		// if(line.starts_with)
 		bool skip = false;
 		for (const auto &prefix : FILTERED_OUT_PREFIXES) {
@@ -72,9 +84,9 @@ std::string filter_compiled_ptx_for_ebpf_program(std::string input,
 			}
 		}
 		if (!skip)
-			oss << line << std::endl;
-	}
-	auto result = oss.str();
+			filtered.append(line).push_back('\n');
+	});
+	auto result = std::move(filtered);
 	for (const auto &sec : FILTERED_OUT_SECTION) {
 		if (auto pos = result.find(sec); pos != result.npos) {
 			result = result.replace(pos, sec.size(), "");

--- a/attach/nv_attach_impl/nv_attach_private_data.cpp
+++ b/attach/nv_attach_impl/nv_attach_private_data.cpp
@@ -1,44 +1,54 @@
 #include "nv_attach_private_data.hpp"
-#include <ios>
-#include <ostream>
-#include <sstream>
+#include <iterator>
+#include <spdlog/fmt/fmt.h>
 #include <string>
 
 using namespace bpftime;
 using namespace attach;
+namespace fmt_lib = spdlog::fmt_lib;
 
 std::string nv_attach_private_data::to_string() const
 {
-	std::ostringstream oss{};
-	oss << "nv_attach_private_data: ";
-	if (std::holds_alternative<uintptr_t>(code_addr_or_func_name))
-		oss << "code_addr=" << std::hex
-		    << std::get<uintptr_t>(code_addr_or_func_name) << " ";
-	else {
-		oss << "func_name=" << std::hex
-		    << std::get<std::string>(code_addr_or_func_name) << " ";
+	fmt_lib::memory_buffer buffer;
+	fmt_lib::format_to(std::back_inserter(buffer),
+			   "nv_attach_private_data: ");
+	if (std::holds_alternative<uintptr_t>(code_addr_or_func_name)) {
+		fmt_lib::format_to(std::back_inserter(buffer),
+				   "code_addr={:x} ",
+				   std::get<uintptr_t>(code_addr_or_func_name));
+	} else {
+		fmt_lib::format_to(std::back_inserter(buffer), "func_name={} ",
+				   std::get<std::string>(
+					   code_addr_or_func_name));
 	}
 	if (!func_names.empty()) {
-		oss << "func_names=";
+		fmt_lib::format_to(std::back_inserter(buffer), "func_names=");
 		for (size_t i = 0; i < func_names.size(); i++) {
 			if (i)
-				oss << ",";
-			oss << func_names[i];
+				fmt_lib::format_to(std::back_inserter(buffer),
+						   ",");
+			fmt_lib::format_to(std::back_inserter(buffer), "{}",
+					   func_names[i]);
 		}
-		oss << " ";
+		fmt_lib::format_to(std::back_inserter(buffer), " ");
 	}
-	oss << "comm_shared_mem=" << std::hex << comm_shared_mem << " ";
-	return oss.str();
+	fmt_lib::format_to(std::back_inserter(buffer), "comm_shared_mem={:x} ",
+			   comm_shared_mem);
+	return fmt_lib::to_string(buffer);
 };
 
 int nv_attach_private_data::initialize_from_string(const std::string_view &sv)
 {
 	std::string input{ sv };
-	std::stringstream ss(input);
-	std::string item;
-	while (std::getline(ss, item, ',')) {
+	size_t start = 0;
+	while (start < sv.size()) {
+		const size_t end = sv.find(',', start);
+		const auto item = sv.substr(start, end - start);
 		if (!item.empty())
-			func_names.push_back(item);
+			func_names.emplace_back(item);
+		if (end == std::string_view::npos)
+			break;
+		start = end + 1;
 	}
 	if (!func_names.empty())
 		code_addr_or_func_name = func_names.front();

--- a/attach/nv_attach_impl/nv_attach_utils.cpp
+++ b/attach/nv_attach_impl/nv_attach_utils.cpp
@@ -1,12 +1,13 @@
 #include "nv_attach_utils.hpp"
 #include "trampoline_ptx.h"
 #include <cstring>
-#include <iomanip>
+#include <iterator>
 #include <spdlog/spdlog.h>
+#include <spdlog/fmt/fmt.h>
 #include <openssl/sha.h>
-#include <sstream>
 #include <cstdlib>
 #include <cuda.h>
+namespace fmt_lib = spdlog::fmt_lib;
 namespace bpftime
 {
 namespace attach
@@ -82,12 +83,12 @@ std::string sha256(const void *data, size_t length)
 	unsigned char hash[SHA256_DIGEST_LENGTH];
 	SHA256((unsigned char *)data, length, hash);
 
-	std::stringstream ss;
+	fmt_lib::memory_buffer buffer;
 	for (int i = 0; i < SHA256_DIGEST_LENGTH; i++) {
-		ss << std::hex << std::setw(2) << std::setfill('0')
-		   << (int)hash[i];
+		fmt_lib::format_to(std::back_inserter(buffer), "{:02x}",
+				   hash[i]);
 	}
-	return ss.str();
+	return fmt_lib::to_string(buffer);
 }
 
 std::string get_gpu_sm_arch()

--- a/attach/nv_attach_impl/pass/ptxpass_core/src/core.cpp
+++ b/attach/nv_attach_impl/pass/ptxpass_core/src/core.cpp
@@ -4,11 +4,11 @@
 #include <cstdio>
 #include <cstdlib>
 #include <iostream>
-#include <ostream>
-#include <sstream>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <set>
+#include <string_view>
 #include <llvmbpf.hpp>
 #include <llvm_jit_context.hpp>
 
@@ -18,6 +18,21 @@ using nlohmann::json;
 
 namespace ptxpass
 {
+
+template <typename Fn>
+static void for_each_line(std::string_view input, Fn &&fn)
+{
+	size_t start = 0;
+	while (start < input.size()) {
+		const auto end = input.find('\n', start);
+		if (end == std::string_view::npos) {
+			fn(input.substr(start));
+			break;
+		}
+		fn(input.substr(start, end - start));
+		start = end + 1;
+	}
+}
 
 static std::vector<std::regex>
 compile_regex_list(const std::vector<std::string> &patterns)
@@ -57,12 +72,11 @@ bool AttachPointMatcher::matches(const std::string &attachPoint) const
 
 std::string read_all_from_stdin()
 {
-	std::ostringstream oss;
-	oss << std::cin.rdbuf();
+	std::string input(std::istreambuf_iterator<char>(std::cin), {});
 	if (!std::cin.good() && !std::cin.eof()) {
 		throw std::runtime_error("Failed to read from stdin");
 	}
-	return oss.str();
+	return input;
 }
 
 bool is_whitespace_only(const std::string &s)
@@ -121,27 +135,28 @@ bool validate_ptx_version(const std::string &input,
 			  const std::string &minVersion)
 {
 	// Expect line like: .version 7.0
-	std::istringstream iss(input);
-	std::string line;
 	double want = 0.0;
 	try {
 		want = std::stod(minVersion);
 	} catch (...) {
 		return true;
 	}
-	while (std::getline(iss, line)) {
+	std::optional<bool> version_ok;
+	for_each_line(input, [&](std::string_view line) {
+		if (version_ok.has_value())
+			return;
 		if (line.rfind(".version", 0) == 0) {
 			// parse number
-			std::string v = line.substr(8);
+			std::string v(line.substr(8));
 			try {
 				double have = std::stod(v);
-				return have >= want;
+				version_ok = have >= want;
 			} catch (...) {
-				return true;
+				version_ok = true;
 			}
 		}
-	}
-	return true;
+	});
+	return version_ok.value_or(true);
 }
 
 } // namespace ptxpass
@@ -154,11 +169,10 @@ std::string filter_out_version_headers_ptx(const std::string &input)
 		".version", ".target", ".address_size", "//"
 	};
 
-	std::istringstream iss(input);
-	std::ostringstream oss;
-	std::string line;
 	std::set<std::string> seen;
-	while (std::getline(iss, line)) {
+	std::string filtered;
+	filtered.reserve(input.size());
+	for_each_line(input, [&](std::string_view line) {
 		bool skip = false;
 		for (const auto &p : FILTERED_OUT_PREFIXES) {
 			if (line.rfind(p, 0) == 0) {
@@ -171,9 +185,9 @@ std::string filter_out_version_headers_ptx(const std::string &input)
 			}
 		}
 		if (!skip)
-			oss << line << '\n';
-	}
-	return oss.str();
+			filtered.append(line).push_back('\n');
+	});
+	return filtered;
 }
 static uint64_t test_func(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t)
 {
@@ -233,9 +247,6 @@ std::string compile_ebpf_to_ptx_from_words(
 }
 std::string filter_compiled_ptx_for_ebpf_program(std::string input)
 {
-	std::istringstream iss(input);
-	std::ostringstream oss;
-	std::string line;
 	static const std::string FILTERED_OUT_PREFIXES[] = {
 		".version", ".target", ".address_size", "//"
 	};
@@ -251,7 +262,9 @@ std::string filter_compiled_ptx_for_ebpf_program(std::string input)
 ))",
 		R"(.visible .func bpf_main())"
 	};
-	while (std::getline(iss, line)) {
+	std::string filtered;
+	filtered.reserve(input.size());
+	for_each_line(input, [&](std::string_view line) {
 		// if(line.starts_with)
 		bool skip = false;
 		for (const auto &prefix : FILTERED_OUT_PREFIXES) {
@@ -261,9 +274,9 @@ std::string filter_compiled_ptx_for_ebpf_program(std::string input)
 			}
 		}
 		if (!skip)
-			oss << line << std::endl;
-	}
-	auto result = oss.str();
+			filtered.append(line).push_back('\n');
+	});
+	auto result = std::move(filtered);
 	for (const auto &sec : FILTERED_OUT_SECTION) {
 		if (auto pos = result.find(sec); pos != result.npos) {
 			result = result.replace(pos, sec.size(), "");
@@ -309,7 +322,7 @@ std::pair<size_t, size_t> find_kernel_body(const std::string &ptx,
 void log_transform_stats(const char *pass_name, int matched, size_t bytes_in,
 			 size_t bytes_out)
 {
-	std::cerr << "[ptxpass] " << pass_name << ": matched=" << matched
-		  << ", in=" << bytes_in << ", out=" << bytes_out << "\n";
+	SPDLOG_INFO("[ptxpass] {}: matched={}, in={}, out={}", pass_name,
+		    matched, bytes_in, bytes_out);
 }
 } // namespace ptxpass

--- a/attach/nv_attach_impl/ptx_compiler/CMakeLists.txt
+++ b/attach/nv_attach_impl/ptx_compiler/CMakeLists.txt
@@ -4,9 +4,13 @@ add_library(nv_attach_impl_ptx_compiler SHARED ptx_compiler.cpp)
 include(../../../cmake/cuda.cmake)
 find_cuda()
 
-target_include_directories(nv_attach_impl_ptx_compiler PUBLIC ${CUDA_INCLUDE_PATH})
+target_include_directories(nv_attach_impl_ptx_compiler
+    PUBLIC
+    ${CUDA_INCLUDE_PATH}
+    ${SPDLOG_INCLUDE}
+)
 
 target_link_directories(nv_attach_impl_ptx_compiler PUBLIC ${CUDA_LIBRARY_PATH} )
 
-target_link_libraries(nv_attach_impl_ptx_compiler PUBLIC  ${CUDA_LIBS} )
+target_link_libraries(nv_attach_impl_ptx_compiler PUBLIC ${CUDA_LIBS} spdlog::spdlog)
 set_property(TARGET nv_attach_impl_ptx_compiler PROPERTY CXX_STANDARD 20)

--- a/attach/nv_attach_impl/ptx_compiler/ptx_compiler.cpp
+++ b/attach/nv_attach_impl/ptx_compiler/ptx_compiler.cpp
@@ -4,7 +4,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <clocale>
-#include <iostream>
+#include <spdlog/spdlog.h>
 #include <string>
 #include <vector>
 
@@ -50,8 +50,8 @@ int nv_attach_impl_compile(nv_attach_impl_ptx_compiler *ptr, const char *ptx,
 	const size_t len = strlen(ptx);
 	if (auto err = nvPTXCompilerCreate(&ptr->compiler, len, ptx);
 	    err != NVPTXCOMPILE_SUCCESS) {
-		std::cerr << "Unable to create compiler: " << (int)err
-			  << std::endl;
+		SPDLOG_ERROR("Unable to create compiler: {}",
+			     static_cast<int>(err));
 		size_t error_size = 0;
 		if (ptr->compiler &&
 		    nvPTXCompilerGetErrorLogSize(ptr->compiler, &error_size) ==
@@ -73,7 +73,7 @@ int nv_attach_impl_compile(nv_attach_impl_ptx_compiler *ptr, const char *ptx,
 
 	if (auto err = nvPTXCompilerCompile(ptr->compiler, arg_count, args);
 	    err != NVPTXCOMPILE_SUCCESS) {
-		std::cerr << "Unable to compile: " << (int)err << std::endl;
+		SPDLOG_ERROR("Unable to compile: {}", static_cast<int>(err));
 		size_t error_size = 0;
 		if (nvPTXCompilerGetErrorLogSize(ptr->compiler, &error_size) ==
 			    NVPTXCOMPILE_SUCCESS &&

--- a/attach/nv_attach_impl/ptx_compiler/ptx_compiler.hpp
+++ b/attach/nv_attach_impl/ptx_compiler/ptx_compiler.hpp
@@ -4,9 +4,8 @@
 #include <cstddef>
 #include <cstdint>
 #include <dlfcn.h>
-#include <iostream>
 #include <optional>
-#include <ostream>
+#include <spdlog/spdlog.h>
 struct nv_attach_impl_ptx_compiler;
 
 extern "C" {
@@ -40,8 +39,8 @@ load_nv_attach_impl_ptx_compiler(const char *path, void *&dl_handle)
 {
 	void *handle = dlopen(path, RTLD_NOW | RTLD_LOCAL);
 	if (!handle) {
-		std::cerr << "Unable to load dynamic library " << path << " = "
-			  << dlerror() << std::endl;
+		SPDLOG_ERROR("Unable to load dynamic library {} = {}", path,
+			     dlerror());
 		return {};
 	}
 	nv_attach_impl_ptx_compiler_handler result;

--- a/attach/nv_attach_impl/test/test_ptxpass.cpp
+++ b/attach/nv_attach_impl/test/test_ptxpass.cpp
@@ -1,7 +1,11 @@
 #include "catch2/catch_test_macros.hpp"
 #include "ptxpass/core.hpp"
+#include <memory>
 #include <fstream>
 #include <iostream>
+#include <spdlog/logger.h>
+#include <spdlog/sinks/ostream_sink.h>
+#include <spdlog/spdlog.h>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -289,14 +293,19 @@ TEST_CASE("compile_ebpf_to_ptx_from_words compiles eBPF to PTX",
 	REQUIRE(ptx.find("ret") != std::string::npos);
 }
 
-TEST_CASE("log_transform_stats outputs stats to stderr", "[ptxpass_core]")
+TEST_CASE("log_transform_stats emits stats through spdlog",
+	  "[ptxpass_core]")
 {
 	std::ostringstream oss;
-	std::streambuf *old_cerr = std::cerr.rdbuf(oss.rdbuf());
+	auto old_logger = spdlog::default_logger();
+	auto sink = std::make_shared<spdlog::sinks::ostream_sink_mt>(oss);
+	auto logger = std::make_shared<spdlog::logger>("ptxpass_test", sink);
+	logger->set_level(spdlog::level::info);
+	spdlog::set_default_logger(logger);
 
 	log_transform_stats("test_pass", 5, 1024, 2048);
-
-	std::cerr.rdbuf(old_cerr);
+	logger->flush();
+	spdlog::set_default_logger(old_logger);
 
 	std::string output = oss.str();
 	REQUIRE(output.find("test_pass") != std::string::npos);

--- a/bpftime-verifier/src/bpftime-verifier.cpp
+++ b/bpftime-verifier/src/bpftime-verifier.cpp
@@ -2,7 +2,6 @@
 #include "config.hpp"
 #include "helpers.hpp"
 #include <ebpf_base.h>
-#include <iostream>
 #include <linux/bpf.h>
 #include <linux/bpf_common.h>
 #include <linux/gpl/spec_type_descriptors.hpp>
@@ -14,7 +13,7 @@
 #include <bpftime-verifier.hpp>
 #include <crab_verifier.hpp>
 #include <asm_unmarshal.hpp>
-#include <sstream>
+#include <streambuf>
 #include <variant>
 #include <platform-impl.hpp>
 static ebpf_verifier_options_t verifier_options = {
@@ -34,6 +33,34 @@ namespace bpftime
 {
 namespace verifier
 {
+namespace {
+class string_capture_streambuf final : public std::streambuf {
+    public:
+	explicit string_capture_streambuf(std::string &output) :
+		output_(output)
+	{
+	}
+
+    protected:
+	std::streamsize xsputn(const char *s, std::streamsize count) override
+	{
+		output_.append(s, static_cast<size_t>(count));
+		return count;
+	}
+
+	int_type overflow(int_type ch) override
+	{
+		if (!traits_type::eq_int_type(ch, traits_type::eof())) {
+			output_.push_back(traits_type::to_char_type(ch));
+		}
+		return ch;
+	}
+
+    private:
+	std::string &output_;
+};
+} // namespace
+
 std::optional<std::string> verify_ebpf_program(const uint64_t *raw_inst,
 					       size_t num_inst,
 					       const std::string &section_name)
@@ -63,13 +90,15 @@ std::optional<std::string> verify_ebpf_program(const uint64_t *raw_inst,
 	ebpf_verifier_stats_t stats;
 	stats.max_instruction_count = stats.total_unreachable =
 		stats.total_warnings = 0;
-	std::ostringstream message;
-	auto result = ebpf_verify_program(message, inst_seq, prog.info,
+	std::string verifier_message;
+	string_capture_streambuf capture_buffer(verifier_message);
+	std::ostream message_stream(&capture_buffer);
+	auto result = ebpf_verify_program(message_stream, inst_seq, prog.info,
 					  &verifier_options, &stats);
 	if (result) {
 		return {};
 	} else {
-		return message.str();
+		return verifier_message;
 	}
 }
 

--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -64,7 +64,7 @@ endif()
 set_property(TARGET libbpftime_daemon PROPERTY CXX_STANDARD 20)
 
 add_dependencies(bpftime_daemon libbpftime_daemon)
-target_link_libraries(bpftime_daemon PRIVATE libbpftime_daemon)
+target_link_libraries(bpftime_daemon PRIVATE libbpftime_daemon spdlog::spdlog)
 
 install(TARGETS bpftime_daemon CONFIGURATIONS Release Debug RelWithDebInfo DESTINATION ~/.bpftime)
 

--- a/daemon/user/bpf_tracer.cpp
+++ b/daemon/user/bpf_tracer.cpp
@@ -6,6 +6,7 @@
 #include "spdlog/common.h"
 #include <argp.h>
 #include <cstddef>
+#include <cstdarg>
 #include <filesystem>
 #include <fstream>
 #include <signal.h>
@@ -36,15 +37,53 @@ using namespace bpftime;
 static volatile sig_atomic_t exiting = 0;
 static bool verbose = false;
 
+static std::string format_variadic_message(const char *format, va_list args)
+{
+	va_list args_copy;
+	va_copy(args_copy, args);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+	const int size = vsnprintf(nullptr, 0, format, args_copy);
+#pragma GCC diagnostic pop
+	va_end(args_copy);
+	if (size <= 0)
+		return {};
+	std::string message(static_cast<size_t>(size) + 1, '\0');
+	va_copy(args_copy, args);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
+	vsnprintf(message.data(), message.size(), format, args_copy);
+#pragma GCC diagnostic pop
+	va_end(args_copy);
+	message.resize(static_cast<size_t>(size));
+	while (!message.empty() &&
+	       (message.back() == '\n' || message.back() == '\r')) {
+		message.pop_back();
+	}
+	return message;
+}
+
 static int libbpf_print_fn(enum libbpf_print_level level, const char *format,
 			   va_list args)
 {
 	if (level == LIBBPF_DEBUG && !verbose)
 		return 0;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-	return vfprintf(stderr, format, args);
-#pragma GCC diagnostic pop
+	auto message = format_variadic_message(format, args);
+	switch (level) {
+	case LIBBPF_WARN:
+		SPDLOG_WARN("{}", message);
+		break;
+	case LIBBPF_INFO:
+		SPDLOG_INFO("{}", message);
+		break;
+	case LIBBPF_DEBUG:
+		SPDLOG_DEBUG("{}", message);
+		break;
+	default:
+		SPDLOG_ERROR("{}", message);
+		break;
+	}
+	return static_cast<int>(message.size());
 }
 
 static void sig_int(int signo)
@@ -138,8 +177,7 @@ int bpftime::start_daemon(struct daemon_config env)
 	libbpf_set_print(libbpf_print_fn);
 
 	if (signal(SIGINT, sig_int) == SIG_ERR) {
-		fprintf(stderr, "can't set signal handler: %s\n",
-			strerror(errno));
+		SPDLOG_ERROR("can't set signal handler: {}", strerror(errno));
 		err = 1;
 		return err;
 	}
@@ -147,7 +185,7 @@ int bpftime::start_daemon(struct daemon_config env)
 	obj = bpf_tracer_bpf__open();
 	if (!obj) {
 		err = -1;
-		fprintf(stderr, "failed to open BPF object\n");
+		SPDLOG_ERROR("failed to open BPF object");
 		return err;
 	}
 
@@ -207,7 +245,7 @@ int bpftime::start_daemon(struct daemon_config env)
 
 	err = bpf_tracer_bpf__load(obj);
 	if (err) {
-		fprintf(stderr, "failed to load BPF object: %d\n", err);
+		SPDLOG_ERROR("failed to load BPF object: {}", err);
 		goto cleanup;
 	}
 	if (env.whitelist_enabled()) {
@@ -228,7 +266,7 @@ int bpftime::start_daemon(struct daemon_config env)
 	}
 	err = bpf_tracer_bpf__attach(obj);
 	if (err) {
-		fprintf(stderr, "failed to attach BPF programs\n");
+		SPDLOG_ERROR("failed to attach BPF programs");
 		goto cleanup;
 	}
 
@@ -237,7 +275,7 @@ int bpftime::start_daemon(struct daemon_config env)
 			      &handler, NULL);
 	if (!rb) {
 		err = -1;
-		fprintf(stderr, "Failed to create ring buffer\n");
+		SPDLOG_ERROR("Failed to create ring buffer");
 		goto cleanup;
 	}
 

--- a/daemon/user/handle_bpf_event.cpp
+++ b/daemon/user/handle_bpf_event.cpp
@@ -7,6 +7,7 @@
 #include <bpf/bpf.h>
 #include <linux/bpf.h>
 #include <cstdio>
+#include <cstring>
 #include <errno.h>
 #include <sys/time.h>
 #include <time.h>
@@ -33,8 +34,10 @@ static int parse_uint_from_file(const char *file, const char *fmt)
 
 	f = fopen(file, "re");
 	if (!f) {
-		err = -errno;
-		fprintf(stderr, "failed to open '%s\n", file);
+		const int saved_errno = errno;
+		err = -saved_errno;
+		SPDLOG_ERROR("failed to open '{}': {}", file,
+			     std::strerror(saved_errno));
 		exit(1);
 	}
 #pragma GCC diagnostic push
@@ -42,9 +45,18 @@ static int parse_uint_from_file(const char *file, const char *fmt)
 	err = fscanf(f, fmt, &ret);
 #pragma GCC diagnostic pop
 	if (err != 1) {
+		const int saved_errno = errno;
 		err = err == EOF ? -EIO : -errno;
-		fprintf(stderr, "failed to parse '%s'\n", file);
 		fclose(f);
+		if (err == -EIO) {
+			SPDLOG_ERROR("failed to parse '{}': unexpected EOF",
+				     file);
+		} else if (saved_errno != 0) {
+			SPDLOG_ERROR("failed to parse '{}': {}", file,
+				     std::strerror(saved_errno));
+		} else {
+			SPDLOG_ERROR("failed to parse '{}'", file);
+		}
 		exit(1);
 	}
 	fclose(f);

--- a/daemon/user/main.cpp
+++ b/daemon/user/main.cpp
@@ -6,11 +6,12 @@
 #include <argp.h>
 #include <cstdint>
 #include <cstdlib>
-#include <iostream>
-#include <ostream>
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <spdlog/cfg/env.h>
+#include <spdlog/spdlog.h>
 #include "daemon.hpp"
 using namespace bpftime;
 
@@ -46,7 +47,7 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 		errno = 0;
 		pid = strtol(arg, NULL, 10);
 		if (errno || pid <= 0) {
-			fprintf(stderr, "Invalid PID: %s\n", arg);
+			SPDLOG_ERROR("Invalid PID: {}", arg);
 			argp_usage(state);
 		}
 		env.pid = pid;
@@ -55,7 +56,7 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 		errno = 0;
 		uid = strtol(arg, NULL, 10);
 		if (errno || uid < 0 || uid >= -1) {
-			fprintf(stderr, "Invalid UID %s\n", arg);
+			SPDLOG_ERROR("Invalid UID: {}", arg);
 			argp_usage(state);
 		}
 		env.uid = uid;
@@ -64,16 +65,15 @@ static error_t parse_arg(int key, char *arg, struct argp_state *state)
 		errno = 0;
 		addr = strtoul(arg, nullptr, 0);
 		if (errno) {
-			std::cerr << "Invalid function address: " << arg
-				  << std::endl;
+			SPDLOG_ERROR("Invalid function address: {}", arg);
 			argp_usage(state);
 		}
 		env.whitelist_uprobes.insert(addr);
 		break;
 	case ARGP_KEY_ARG:
 		if (pos_args++) {
-			fprintf(stderr,
-				"Unrecognized positional argument: %s\n", arg);
+			SPDLOG_ERROR("Unrecognized positional argument: {}",
+				     arg);
 			argp_usage(state);
 		}
 		errno = 0;
@@ -94,6 +94,7 @@ int main(int argc, char **argv)
 	int err;
 	// use current path as default path
 	strncpy(env.new_uprobe_path, argv[0], PATH_LENTH);
+	spdlog::cfg::load_env_levels();
 	err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
 	if (err)
 		return err;

--- a/daemon/user/main.cpp
+++ b/daemon/user/main.cpp
@@ -98,5 +98,8 @@ int main(int argc, char **argv)
 	err = argp_parse(&argp, argc, argv, 0, NULL, NULL);
 	if (err)
 		return err;
+	if (env.verbose && spdlog::get_level() > spdlog::level::debug) {
+		spdlog::set_level(spdlog::level::debug);
+	}
 	return start_daemon(env);
 }

--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -5,11 +5,15 @@
  */
 #include "bpftime_logger.hpp"
 #include "bpftime_shm.hpp"
+#ifdef ENABLE_BPFTIME_VERIFIER
+#include <bpftime-verifier.hpp>
+#endif
 #include <cstdint>
 #ifdef BPFTIME_ENABLE_CUDA_ATTACH
 #include "cuda.h"
 #endif
 #include "spdlog/cfg/env.h"
+#include "spdlog/fmt/fmt.h"
 #include <cstdio>
 #include <ebpf-vm.h>
 #include "syscall_context.hpp"
@@ -29,6 +33,7 @@
 #include "spdlog/spdlog.h"
 #include <cerrno>
 #include <cstdlib>
+#include <iterator>
 #include "syscall_server_utils.hpp"
 #include <optional>
 #include <sys/mman.h>
@@ -58,6 +63,27 @@ using namespace bpftime;
 #if __APPLE__
 using namespace bpftime_epoll;
 #endif
+
+namespace fmt_lib = spdlog::fmt_lib;
+
+namespace {
+std::string format_verifier_program_dump(const uint64_t *instructions,
+					 size_t instruction_count)
+{
+	fmt_lib::memory_buffer buffer;
+	for (size_t i = 0; i < instruction_count; i++) {
+		uint64_t inst = instructions[i];
+		fmt_lib::format_to(std::back_inserter(buffer), "{:03}: ", i);
+		for (int j = 0; j < 8; j++) {
+			fmt_lib::format_to(std::back_inserter(buffer), "{:02X} ",
+					   inst & 0xff);
+			inst >>= 8;
+		}
+		fmt_lib::format_to(std::back_inserter(buffer), "\n");
+	}
+	return fmt_lib::to_string(buffer);
+}
+} // namespace
 
 void syscall_context::load_config_from_env()
 {
@@ -505,29 +531,13 @@ long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 					(size_t)attr->insn_cnt,
 					simple_section_name.value());
 				if (result.has_value()) {
-					std::ostringstream message;
-					message << *result;
-					// Print the program by bytes
-					for (size_t i = 0; i < attr->insn_cnt;
-					     i++) {
-						uint64_t inst =
-							((uint64_t *)(uintptr_t)
-								 attr->insns)[i];
-						message << std::setw(3)
-							<< std::setfill('0')
-							<< i << ": ";
-						for (int j = 0; j < 8; j++) {
-							message << std::hex
-								<< std::uppercase
-								<< std::setw(2)
-								<< std::setfill(
-									   '0')
-								<< (inst & 0xff)
-								<< " ";
-							inst >>= 8;
-						}
-						message << std::endl;
-					}
+					auto message = fmt_lib::format(
+						"{}{}",
+						*result,
+						format_verifier_program_dump(
+							(uint64_t *)(uintptr_t)
+								attr->insns,
+							(size_t)attr->insn_cnt));
 					if (verifier_mode ==
 					    BPFTIME_VERIFIER_STRICT) {
 						SPDLOG_ERROR(
@@ -536,7 +546,7 @@ long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 							"or BPFTIME_VERIFIER_LEVEL=NO_VERIFY to disable verification. "
 							"Alternatively, set BPFTIME_RUN_WITH_KERNEL=1 to use the kernel verifier.",
 							attr->prog_name,
-							message.str());
+							message);
 						errno = EINVAL;
 						return -1;
 					} else {
@@ -548,7 +558,7 @@ long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 							"or BPFTIME_VERIFIER_LEVEL=NO_VERIFY to disable verification. "
 							"Alternatively, set BPFTIME_RUN_WITH_KERNEL=1 to use the kernel verifier.",
 							attr->prog_name,
-							message.str());
+							message);
 					}
 				}
 			}

--- a/runtime/syscall-server/syscall_server_utils.cpp
+++ b/runtime/syscall-server/syscall_server_utils.cpp
@@ -4,6 +4,7 @@
  * All rights reserved.
  */
 #include "bpftime_config.hpp"
+#include "bpftime_helper_group.hpp"
 #include "bpftime_shm_internal.hpp"
 #if defined(BPFTIME_ENABLE_CUDA_ATTACH)
 #include "cuda.h"


### PR DESCRIPTION
## Summary
- route first-party daemon and PTX/NV attach diagnostics through `SPDLOG_*`
- replace local stringstream-based formatting in nv attach, verifier, and syscall verifier diagnostics with `spdlog/fmt`-style formatting
- fix feature-on build fallout by linking `bpftime_daemon` against `spdlog` directly and including the verifier/helper declarations required by `bpftime-syscall-server`

## Verification
- `cmake -S . -B build`
- `cmake --build build -j4 --target runtime bpftime-syscall-server bpftime_daemon`
- `cmake -S . -B build-feature-lib -DBPFTIME_ENABLE_CUDA_ATTACH=ON -DENABLE_EBPF_VERIFIER=ON -DBPFTIME_CUDA_ROOT=/usr/local/cuda-12.9`
- `cmake --build build-feature-lib -j4 --target ptxpass_core nv_attach_impl_ptx_compiler bpftime_nv_attach_impl bpftime-verifier runtime bpftime-syscall-server bpftime_daemon`

## Notes
- `cmake -S . -B build-feature -DBPFTIME_ENABLE_CUDA_ATTACH=ON -DENABLE_EBPF_VERIFIER=ON -DBPFTIME_ENABLE_UNIT_TESTING=ON -DBPFTIME_CUDA_ROOT=/usr/local/cuda-12.9` fails in the vendored Catch2 build on this machine before it reaches bpftime targets. The compile-only verification above avoids that unrelated local issue.
