### PR TITLE
fix: remove unreachable return in add_software_perf_event

### DIFF
--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -284,7 +284,6 @@ int bpftime_shm::add_software_perf_event(int fd, int cpu, int32_t sample_type,
 				    bpftime::bpf_perf_event_handler(
 					    cpu, sample_type, config, segment),
 				    segment);
-	return fd;
 }
 
 int bpftime_shm::attach_perf_to_bpf(int perf_fd, int bpf_fd,


### PR DESCRIPTION
## Description

Remove redundant `return fd;` statement at the end of
`add_software_perf_event` in `bpftime_shm_internal.cpp`.

This fixes an unreachable return warning reported by the compiler.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Local build passed

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings