### PR TITLE
fix: initialize bpf_link attach_cookie and validate perf target_fd (#569)

### DIFF
--- a/runtime/include/bpftime_shm.hpp
+++ b/runtime/include/bpftime_shm.hpp
@@ -240,6 +240,12 @@ int bpftime_export_global_shm_to_json(const char *filename);
 // import a hander to global shared memory from json string
 int bpftime_import_shm_handler_from_json(int fd, const char *json_string);
 
+// Mirrors the kernel's `enum bpf_attach_type` value for BPF_PERF_EVENT.
+// Defined here (rather than pulling in <linux/bpf.h>) so the value has a single
+// source usable from the cross-platform shm/handler code, which also builds on
+// non-Linux targets.
+constexpr __u32 BPFTIME_BPF_PERF_EVENT_ATTACH_TYPE = 41;
+
 /* struct used by BPF_LINK_CREATE command */
 struct bpf_link_create_args {
 	union {

--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -573,11 +573,28 @@ int bpftime_shm::add_bpf_prog(int fd, const ebpf_inst *insn, size_t insn_cnt,
 // add a bpf link fd
 int bpftime_shm::add_bpf_link(int fd, struct bpf_link_create_args *args)
 {
+	if (!args) {
+		errno = EINVAL;
+		return -1;
+	}
 	if (fd < 0) {
 		// if fd is negative, we need to create a new fd for allocating
 		fd = open_fake_fd();
 	}
-	if (!is_prog_fd(args->prog_fd) || !args) {
+	if (!is_prog_fd(args->prog_fd)) {
+		errno = EBADF;
+		return -1;
+	}
+	// For perf-event links (uprobe/kprobe/tracepoint, attach type
+	// BPF_PERF_EVENT == 41) the target must be a valid perf-event handler
+	// fd, matching the kernel's BPF_LINK_CREATE validation. Without this a
+	// stale/non-perf target_fd would be silently accepted.
+	constexpr __u32 ATTACH_TYPE_BPF_PERF_EVENT = 41;
+	if (args->attach_type == ATTACH_TYPE_BPF_PERF_EVENT &&
+	    !is_perf_event_handler_fd(args->target_fd)) {
+		SPDLOG_ERROR(
+			"add_bpf_link: target_fd {} is not a perf-event handler for BPF_PERF_EVENT link",
+			args->target_fd);
 		errno = EBADF;
 		return -1;
 	}

--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -577,26 +577,27 @@ int bpftime_shm::add_bpf_link(int fd, struct bpf_link_create_args *args)
 		errno = EINVAL;
 		return -1;
 	}
-	if (fd < 0) {
-		// if fd is negative, we need to create a new fd for allocating
-		fd = open_fake_fd();
-	}
+	// Validate before allocating an fd so error paths don't leak the fd that
+	// open_fake_fd() would otherwise create.
 	if (!is_prog_fd(args->prog_fd)) {
 		errno = EBADF;
 		return -1;
 	}
-	// For perf-event links (uprobe/kprobe/tracepoint, attach type
-	// BPF_PERF_EVENT == 41) the target must be a valid perf-event handler
-	// fd, matching the kernel's BPF_LINK_CREATE validation. Without this a
-	// stale/non-perf target_fd would be silently accepted.
-	constexpr __u32 ATTACH_TYPE_BPF_PERF_EVENT = 41;
-	if (args->attach_type == ATTACH_TYPE_BPF_PERF_EVENT &&
+	// For perf-event links (uprobe/kprobe/tracepoint) the target must be a
+	// valid perf-event handler fd, matching the kernel's BPF_LINK_CREATE
+	// validation. Without this a stale/non-perf target_fd would be silently
+	// accepted.
+	if (args->attach_type == BPFTIME_BPF_PERF_EVENT_ATTACH_TYPE &&
 	    !is_perf_event_handler_fd(args->target_fd)) {
 		SPDLOG_ERROR(
 			"add_bpf_link: target_fd {} is not a perf-event handler for BPF_PERF_EVENT link",
 			args->target_fd);
 		errno = EBADF;
 		return -1;
+	}
+	if (fd < 0) {
+		// if fd is negative, we need to create a new fd for allocating
+		fd = open_fake_fd();
 	}
 	return manager->set_handler(fd, bpftime::bpf_link_handler(*args),
 				    segment);

--- a/runtime/src/handler/link_handler.hpp
+++ b/runtime/src/handler/link_handler.hpp
@@ -20,9 +20,15 @@ struct bpf_link_handler {
 	std::optional<uint64_t> attach_cookie;
 	bpf_link_handler(struct bpf_link_create_args args)
 		: args(args), prog_id(args.prog_fd),
-		  attach_target_id(args.target_fd),
-		  attach_cookie(args.perf_event.bpf_cookie)
+		  attach_target_id(args.target_fd)
 	{
+		// Only perf-event links store the cookie in perf_event.bpf_cookie.
+		// Other attach types keep it in a different union member
+		// (tracing.cookie, kprobe_multi.cookies, ...), so leave
+		// attach_cookie disengaged for them instead of reading the wrong
+		// field.
+		if (args.attach_type == BPFTIME_BPF_PERF_EVENT_ATTACH_TYPE)
+			attach_cookie = args.perf_event.bpf_cookie;
 	}
 	bpf_link_handler(int prog_id, int attach_target_id)
 		: prog_id(prog_id), attach_target_id(attach_target_id)

--- a/runtime/src/handler/link_handler.hpp
+++ b/runtime/src/handler/link_handler.hpp
@@ -20,7 +20,8 @@ struct bpf_link_handler {
 	std::optional<uint64_t> attach_cookie;
 	bpf_link_handler(struct bpf_link_create_args args)
 		: args(args), prog_id(args.prog_fd),
-		  attach_target_id(args.target_fd)
+		  attach_target_id(args.target_fd),
+		  attach_cookie(args.perf_event.bpf_cookie)
 	{
 	}
 	bpf_link_handler(int prog_id, int attach_target_id)


### PR DESCRIPTION
## Summary

Fixes #569 and #564 — both trace back to the `BPF_LINK_CREATE` / `add_bpf_link()` code path.

### 1. `attach_cookie` never initialized → `bpf_get_attach_cookie()` returns 0

`bpf_link_handler(struct bpf_link_create_args)` did not initialize its `std::optional<uint64_t> attach_cookie` from `args.perf_event.bpf_cookie`, so it stayed disengaged. The cookie is later read in `instantiate_bpf_link_handler_at()` and propagated to `current_thread_bpf_cookie`, so `bpf_get_attach_cookie()` always returned 0 for programs attached via this path (e.g. a uprobe attached with a non-zero `.cookie` via `bpf_program__attach_uprobe_opts()`).

### 2. `add_bpf_link()` did not validate `target_fd` → FEAT_PERF_LINK probe fails → USDT broken (#564)

For a `BPF_PERF_EVENT` link (attach type 41) the target must be a valid perf-event handler fd, matching the kernel's `BPF_LINK_CREATE` validation. `add_bpf_link()` now rejects such a link when `target_fd` is not a perf-event handler, and the null-`args` check is moved ahead of the first `args` dereference.

This also fixes #564: libbpf probes `FEAT_PERF_LINK` via `bpf_link_create(prog_fd, target_fd=-1, BPF_PERF_EVENT, NULL)` and only treats the feature as supported if the call returns `EBADF`. Previously `add_bpf_link()` accepted that probe (returned a link, not `EBADF`), so libbpf concluded perf-link/cookie support was unavailable and refused USDT attach with `user context value is not supported` / `-EOPNOTSUPP (95)`. Returning `EBADF` for an invalid perf `target_fd` makes the probe pass.

## Verification (rootless docker, non-root user, ubpf backend, no CUDA)

Built `usdt_minimal` + `victim` and ran `bpftime load ./usdt_minimal` as an unprivileged user. Same container/build, only difference is this PR's change:

| build | result |
| --- | --- |
| master (this fix reverted) | ❌ `user context value is not supported` → `-EOPNOTSUPP` → `Failed to attach BPF program: 95` |
| this PR | ✅ no `EOPNOTSUPP`/`95`; USDT maps created and probe attaches |

Confirms #564 needs no root and is resolved by this change.

## Notes

- The cookie is read from `perf_event.bpf_cookie`, the correct union member for perf-event/uprobe links.
- No GPU paths are touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
