### PR TITLE
refactor(shm): dedup bpf_map_* fd validation via try_get_map_handler

### DIFF
--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -107,99 +107,73 @@ void bpftime_shm::set_syscall_trace_setup(int pid, bool whether)
 	}
 }
 
-uint32_t bpftime_shm::bpf_map_value_size(int fd) const
-{
-	if (!is_map_fd(fd)) {
-		errno = ENOENT;
-		return 0;
-	}
-	auto &handler =
-		std::get<bpftime::bpf_map_handler>(manager->get_handler(fd));
-	return handler.get_userspace_value_size();
-}
-
-const void *bpftime_shm::bpf_map_lookup_elem(int fd, const void *key,
-					     bool from_syscall) const
+const bpf_map_handler *bpftime_shm::try_get_map_handler(int fd) const
 {
 	if (!is_map_fd(fd)) {
 		errno = ENOENT;
 		return nullptr;
 	}
-	auto &handler =
-		std::get<bpftime::bpf_map_handler>(manager->get_handler(fd));
-	return handler.map_lookup_elem(key, from_syscall);
+	return &std::get<bpftime::bpf_map_handler>(manager->get_handler(fd));
+}
+
+uint32_t bpftime_shm::bpf_map_value_size(int fd) const
+{
+	auto *handler = try_get_map_handler(fd);
+	return handler ? handler->get_userspace_value_size() : 0;
+}
+
+const void *bpftime_shm::bpf_map_lookup_elem(int fd, const void *key,
+					     bool from_syscall) const
+{
+	auto *handler = try_get_map_handler(fd);
+	return handler ? handler->map_lookup_elem(key, from_syscall) : nullptr;
 }
 
 long bpftime_shm::bpf_map_update_elem(int fd, const void *key,
 				      const void *value, uint64_t flags,
 				      bool from_syscall) const
 {
-	if (!is_map_fd(fd)) {
-		errno = ENOENT;
-		return -1;
-	}
-	auto &handler =
-		std::get<bpftime::bpf_map_handler>(manager->get_handler(fd));
-	return handler.map_update_elem(key, value, flags, from_syscall);
+	auto *handler = try_get_map_handler(fd);
+	return handler ? handler->map_update_elem(key, value, flags,
+						  from_syscall) :
+			 -1;
 }
 
 long bpftime_shm::bpf_delete_elem(int fd, const void *key,
 				  bool from_syscall) const
 {
-	if (!is_map_fd(fd)) {
-		errno = ENOENT;
-		return -1;
-	}
-	auto &handler =
-		std::get<bpftime::bpf_map_handler>(manager->get_handler(fd));
-	return handler.map_delete_elem(key, from_syscall);
+	auto *handler = try_get_map_handler(fd);
+	return handler ? handler->map_delete_elem(key, from_syscall) : -1;
 }
 
 long bpftime_shm::bpf_map_push_elem(int fd, const void *value, uint64_t flags,
 				    bool from_syscall) const
 {
-	if (!is_map_fd(fd)) {
-		errno = ENOENT;
-		return -1;
-	}
-	auto &handler =
-		std::get<bpftime::bpf_map_handler>(manager->get_handler(fd));
-	return handler.map_push_elem(value, flags, from_syscall);
+	auto *handler = try_get_map_handler(fd);
+	return handler ? handler->map_push_elem(value, flags, from_syscall) : -1;
 }
 
 long bpftime_shm::bpf_map_pop_elem(int fd, void *value, bool from_syscall) const
 {
-	if (!is_map_fd(fd)) {
-		errno = ENOENT;
-		return -1;
-	}
-	auto &handler =
-		std::get<bpftime::bpf_map_handler>(manager->get_handler(fd));
-	return handler.map_pop_elem(value, from_syscall);
+	auto *handler = try_get_map_handler(fd);
+	return handler ? handler->map_pop_elem(value, from_syscall) : -1;
 }
 
 long bpftime_shm::bpf_map_peek_elem(int fd, void *value,
 				    bool from_syscall) const
 {
-	if (!is_map_fd(fd)) {
-		errno = ENOENT;
-		return -1;
-	}
-	auto &handler =
-		std::get<bpftime::bpf_map_handler>(manager->get_handler(fd));
-	return handler.map_peek_elem(value, from_syscall);
+	auto *handler = try_get_map_handler(fd);
+	return handler ? handler->map_peek_elem(value, from_syscall) : -1;
 }
 
 int bpftime_shm::bpf_map_get_next_key(int fd, const void *key, void *next_key,
 				      bool from_syscall) const
 {
-	if (!is_map_fd(fd)) {
-		errno = ENOENT;
-		return -1;
-	}
-	auto &handler =
-		std::get<bpftime::bpf_map_handler>(manager->get_handler(fd));
-	return handler.bpf_map_get_next_key(key, next_key, from_syscall);
+	auto *handler = try_get_map_handler(fd);
+	return handler ?
+		       handler->bpf_map_get_next_key(key, next_key,
+						     from_syscall) :
+		       -1;
 }
 
 int bpftime_shm::add_kprobe(std::optional<int> fd, const char *func_name,

--- a/runtime/src/bpftime_shm_internal.hpp
+++ b/runtime/src/bpftime_shm_internal.hpp
@@ -139,9 +139,13 @@ class bpftime_shm {
 	bool is_epoll_fd(int fd) const;
 
 	bool is_map_fd(int fd) const;
+
+private:
 	// Returns the map handler for `fd`, or nullptr (with errno=ENOENT) if
 	// `fd` is not a map fd. Shared by the bpf_map_* accessors below.
 	const bpf_map_handler *try_get_map_handler(int fd) const;
+
+public:
 	bool is_ringbuf_map_fd(int fd) const;
 	bool is_array_map_fd(int fd) const;
 

--- a/runtime/src/bpftime_shm_internal.hpp
+++ b/runtime/src/bpftime_shm_internal.hpp
@@ -139,6 +139,9 @@ class bpftime_shm {
 	bool is_epoll_fd(int fd) const;
 
 	bool is_map_fd(int fd) const;
+	// Returns the map handler for `fd`, or nullptr (with errno=ENOENT) if
+	// `fd` is not a map fd. Shared by the bpf_map_* accessors below.
+	const bpf_map_handler *try_get_map_handler(int fd) const;
 	bool is_ringbuf_map_fd(int fd) const;
 	bool is_array_map_fd(int fd) const;
 


### PR DESCRIPTION
## Summary

Pure, behavior-preserving cleanup of `runtime/src/bpftime_shm_internal.cpp`.

The eight `bpf_map_*` accessors (`bpf_map_value_size`, `bpf_map_lookup_elem`, `bpf_map_update_elem`, `bpf_delete_elem`, `bpf_map_push_elem`, `bpf_map_pop_elem`, `bpf_map_peek_elem`, `bpf_map_get_next_key`) each repeated:

```cpp
if (!is_map_fd(fd)) { errno = ENOENT; return <err>; }
auto &handler = std::get<bpftime::bpf_map_handler>(manager->get_handler(fd));
return handler.<op>(...);
```

This extracts a single private helper:

```cpp
const bpf_map_handler *bpftime_shm::try_get_map_handler(int fd) const;
```

which performs the `is_map_fd` check (setting `errno = ENOENT` and returning `nullptr` on failure), and reduces each accessor to a one-line ternary.

## Behavior

Unchanged — identical `ENOENT`/`errno` semantics and identical per-method error return values (`0` / `nullptr` / `-1`). Net **-23 lines** and a single validation path, so the eight checks can no longer drift apart.

Exercised by the existing map unit tests (`runtime/unit-test/maps`) and the `build-runtime` / `build-and-test` CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)