### PR TITLE
fix(syscall-server): four isolated correctness bugs in shm/syscall handlers

### DIFF
--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -50,6 +50,10 @@ extern "C" void bpftime_destroy_global_shm()
 	if (global_shm_initialized) {
 		// SPDLOG_INFO("Global shm destructed");
 		shm_holder.global_shared_memory.~bpftime_shm();
+		// Make this idempotent: clear the flag so a later explicit call
+		// or the __destruct_shm static destructor does not destroy the
+		// already-destroyed object a second time.
+		global_shm_initialized = false;
 		// Why not spdlog? because global variables that spdlog used
 		// were already destroyed..
 #ifdef DEBUG

--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -70,6 +70,14 @@ extern "C" void bpftime_remove_global_shm()
 
 static __attribute__((destructor(65535))) void __destruct_shm()
 {
+	// If the global shm was never successfully initialized (e.g. a process
+	// that links the runtime but never created/opened shm, or whose
+	// bpftime_shm constructor threw on the expected "shm not ready yet"
+	// path), the object is uninitialized — touching it (get_open_type /
+	// remove_pid_from_alive_agent_set) would read garbage and can crash on
+	// exit. Bail out before any access.
+	if (!global_shm_initialized)
+		return;
 	// This usually indicates that the living shared memory object is used
 	// by an agent instance
 	if (bpftime::shm_holder.global_shared_memory.get_open_type() ==
@@ -402,7 +410,7 @@ int bpftime_shm::add_ringbuf_to_epoll(int ringbuf_fd, int epoll_fd,
 		std::get<bpf_map_handler>(manager->get_handler(ringbuf_fd));
 
 	auto ringbuf_map_impl = map_inst.try_get_ringbuf_map_impl();
-	if (ringbuf_map_impl.has_value(); auto val = ringbuf_map_impl.value()) {
+	if (auto val = ringbuf_map_impl.value_or(nullptr)) {
 		epoll_inst.files.emplace_back(val->create_impl_weak_ptr(),
 					      extra_data);
 		SPDLOG_DEBUG("Ringbuf {} added to epoll {}", ringbuf_fd,

--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -624,7 +624,8 @@ long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 						       &map_attr, &map_name,
 						       &map_type);
 			if (res < 0) {
-				errno = res;
+				// bpftime_map_get_info already set errno (ENOENT);
+				// don't overwrite it with the -1 return value.
 				return -1;
 			}
 			auto ptr = (bpf_map_info *)((uintptr_t)attr->info.info);
@@ -965,7 +966,7 @@ int syscall_context::handle_epoll_wait(int epfd, epoll_event *evt,
 {
 	if (!enable_mock || run_with_kernel || initializing_cuda ||
 	    !enable_mock_after_initialized)
-		orig_epoll_wait_fn(epfd, evt, maxevents, timeout);
+		return orig_epoll_wait_fn(epfd, evt, maxevents, timeout);
 	try_startup();
 	if (bpftime_is_epoll_handler(epfd)) {
 		return bpftime_epoll_wait(epfd, evt, maxevents, timeout);
@@ -977,7 +978,7 @@ int syscall_context::handle_munmap(void *addr, size_t size)
 {
 	if (!enable_mock || run_with_kernel || initializing_cuda ||
 	    !enable_mock_after_initialized)
-		orig_munmap_fn(addr, size);
+		return orig_munmap_fn(addr, size);
 	try_startup();
 	if (auto itr = mocked_mmap_values.find((uintptr_t)addr);
 	    itr != mocked_mmap_values.end()) {


### PR DESCRIPTION
## Summary

Four small, isolated correctness bugs found during a design review of the syscall-server / shm layer. Each is independent and behavior-preserving on the normal success path — only the broken/edge paths change.

### 1. `handle_epoll_wait` / `handle_munmap`: missing `return` → double syscall
`runtime/syscall-server/syscall_context.cpp`

On the mock-disabled fast path:
```cpp
if (!enable_mock || run_with_kernel || ...)
    orig_epoll_wait_fn(epfd, evt, maxevents, timeout);   // result dropped, no return
try_startup();
... mock logic ...
return orig_epoll_wait_fn(...);                           // called AGAIN
```
The real `epoll_wait`/`munmap` was invoked, its result discarded, then the mock logic ran and a second `orig_*` call was made. Every other guarded handler `return`s the orig call; these two didn't. Fixed by returning the orig result.

### 2. `BPF_OBJ_GET_INFO_BY_FD`: `errno = res` clobbers errno with `-1`
`bpftime_map_get_info()` returns `-1` on failure and already sets `errno = ENOENT`. The caller did `errno = res;` (i.e. `errno = -1`), so libbpf saw a nonsense errno. Dropped the assignment (errno is already set by the callee).

### 3. `add_ringbuf_to_epoll`: malformed `if` → `std::bad_optional_access`
```cpp
if (ringbuf_map_impl.has_value(); auto val = ringbuf_map_impl.value()) { ... }
```
The `has_value()` is a discarded init-statement; the condition is `auto val = .value()`. A disengaged optional therefore throws `std::bad_optional_access` instead of taking the `errno = EINVAL` error branch. Replaced with `if (auto val = ringbuf_map_impl.value_or(nullptr))`, which preserves the original intent (succeed only with a non-null impl) without throwing.

### 4. `__destruct_shm`: reads uninitialized global shm → crash on exit
The `destructor(65535)` static destructor called `get_open_type()` / `remove_pid_from_alive_agent_set()` unconditionally. A process that links the runtime but never successfully initialized the global shm (e.g. an agent whose `bpftime_shm` constructor threw on the expected "shm not ready yet" retry path, or a tool that exits early) would read an uninitialized object and can crash at exit. Guarded with the existing `global_shm_initialized` flag.

## Testing
Behavior-preserving on success paths; exercised by the existing runtime/syscall-server CI (`build-runtime`, `build-and-test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
