### PR TITLE
fix: enable bpf_cookie support by fixing three  bugs

### DIFF
--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -594,8 +594,7 @@ long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 			SPDLOG_DEBUG(
 				"Attaching perf event {} to prog {}, with bpf cookie {:x}",
 				target_fd, prog_fd, cookie);
-			bpftime_attach_perf_to_bpf_with_cookie(target_fd,
-							       prog_fd, cookie);
+				id = bpftime_attach_perf_to_bpf_with_cookie(target_fd, prog_fd, cookie);
 		}
 		return id;
 	}


### PR DESCRIPTION
Fixes #569

## Remaining Fix

The fallback path in `syscall_context.cpp` discards the return value of `bpftime_attach_perf_to_bpf_with_cookie()`, assigning it to neither the local variable `id` nor any other storage. This causes link fd loss and state inconsistency when the fallback path is triggered.

## Already Fixed Upstream

The other two bugs from the original PR have already been fixed upstream:
1. **FEAT_PERF_LINK detection** — `add_bpf_link()` now validates `target_fd` for `BPF_PERF_EVENT` (fixed in #xxx)
2. **attach_cookie initialization** — `bpf_link_handler` constructor now initializes `attach_cookie` from `args.perf_event.bpf_cookie` (fixed in #xxx)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)