### PR TITLE
runtime: shard software perf event producers by thread

### DIFF
--- a/runtime/src/handler/perf_event_handler.cpp
+++ b/runtime/src/handler/perf_event_handler.cpp
@@ -17,7 +17,13 @@
 #include <boost/interprocess/allocators/allocator.hpp>
 #include <unistd.h>
 #include <spdlog/fmt/bin_to_hex.h>
+#include <unordered_map>
 #include <variant>
+#if __linux__
+#include <sys/syscall.h>
+#elif __APPLE__
+#include <pthread.h>
+#endif
 
 #pragma GCC diagnostic ignored "-Wstrict-aliasing"
 
@@ -56,6 +62,40 @@
 
 namespace bpftime
 {
+namespace
+{
+struct spin_lock_guard {
+	pthread_spinlock_t &lock;
+	explicit spin_lock_guard(pthread_spinlock_t &lock) : lock(lock)
+	{
+		pthread_spin_lock(&lock);
+	}
+	~spin_lock_guard()
+	{
+		pthread_spin_unlock(&lock);
+	}
+	spin_lock_guard(const spin_lock_guard &) = delete;
+	spin_lock_guard &operator=(const spin_lock_guard &) = delete;
+};
+
+int64_t current_thread_id()
+{
+#if __linux__
+	return (int64_t)syscall(SYS_gettid);
+#elif __APPLE__
+	uint64_t tid = 0;
+	pthread_threadid_np(nullptr, &tid);
+	return (int64_t)tid;
+#else
+	return 0;
+#endif
+}
+
+thread_local std::unordered_map<const software_perf_event_data *,
+				software_perf_event_shard *>
+	software_perf_event_shard_cache;
+} // namespace
+
 bpf_perf_event_handler::bpf_perf_event_handler(
 	int type, const char *attach_arg,
 	boost::interprocess::managed_shared_memory &mem)
@@ -145,89 +185,6 @@ bpf_perf_event_handler::bpf_perf_event_handler(
 {
 }
 
-bool software_perf_event_data::has_data() const
-{
-	auto &ref = get_header_ref_const();
-	return ref.data_tail != ref.data_head;
-}
-
-const perf_event_mmap_page &
-software_perf_event_data::get_header_ref_const() const
-{
-	return *(perf_event_mmap_page *)(uintptr_t)(mmap_buffer.data());
-}
-
-int software_perf_event_data::output_data(const void *buf, size_t size)
-{
-	SPDLOG_DEBUG("Handling perf event output data with size {}", size);
-	auto &header = get_header_ref();
-	perf_sample_raw head;
-	head.header.type = PERF_RECORD_SAMPLE;
-	head.header.size = sizeof(head) + size;
-	head.header.misc = 0;
-	head.size = size;
-	int64_t data_head = smp_load_acquire_u64(&header.data_head);
-	int64_t data_tail = header.data_tail;
-	uint8_t *base_addr = (uint8_t *)mmap_buffer.data() + pagesize;
-	int64_t available_size = mmap_size() - (data_head - data_tail);
-	SPDLOG_DEBUG("Data tail={}", data_tail);
-	if (available_size == 0) {
-		SPDLOG_DEBUG("Upgraded available size to {}", mmap_size());
-		available_size = mmap_size();
-	}
-	// If available_size is less or equal than head.header.size, just drop
-	// the data. In this way, we'll never make data_head equals to
-	// data_tail, at situation other than an empty buffer
-	if (available_size <= head.header.size) {
-		SPDLOG_DEBUG(
-			"Dropping data with size {}, available_size {}, required size {}",
-			size, available_size, head.header.size);
-		return 0;
-	}
-	auto &copy_size = head.header.size;
-	if (copy_buffer.size() != copy_size)
-		copy_buffer.resize(copy_size);
-
-	memcpy(copy_buffer.data(), &head, sizeof(head));
-	memcpy((uint8_t *)(copy_buffer.data()) + sizeof(head), buf, size);
-	uint8_t *copy_start_1 = base_addr + (data_head & (mmap_size() - 1));
-	if (copy_size + copy_start_1 <= base_addr + mmap_size()) {
-		memcpy(copy_start_1, copy_buffer.data(), copy_size);
-	} else {
-		size_t len_first = base_addr + mmap_size() - copy_start_1;
-		size_t len_second = copy_size - len_first;
-		memcpy(copy_start_1, copy_buffer.data(), len_first);
-		memcpy(base_addr, copy_buffer.data() + len_first, len_second);
-	}
-	uint64_t new_head = (data_head + copy_size);
-	smp_store_release_u64(&header.data_head, new_head);
-	SPDLOG_DEBUG(
-		"Data of size {}, total size {} outputed at head {}; new_head={} addr={:x}; available_size={}",
-		size, copy_size, data_head, new_head,
-		(uintptr_t)(base_addr + data_head), available_size);
-
-	return 0;
-}
-
-perf_event_mmap_page &software_perf_event_data::get_header_ref()
-{
-	return *(perf_event_mmap_page *)(uintptr_t)(mmap_buffer.data());
-}
-
-software_perf_event_data::software_perf_event_data(
-	int cpu, int64_t config, int32_t sample_type,
-	boost::interprocess::managed_shared_memory &memory)
-	: cpu(cpu), config(config), sample_type(sample_type),
-	  pagesize(getpagesize()),
-	  mmap_buffer(pagesize, memory.get_segment_manager()),
-	  copy_buffer(pagesize, memory.get_segment_manager())
-{
-	perf_event_mmap_page &perf_header = get_header_ref();
-	perf_header.data_offset = pagesize;
-	perf_header.data_head = perf_header.data_tail = 0;
-	perf_header.data_size = 0;
-}
-
 [[maybe_unused]] static inline int popcnt(uint64_t x)
 {
 	int ret = 0;
@@ -238,7 +195,36 @@ software_perf_event_data::software_perf_event_data(
 	return ret;
 }
 
-void *software_perf_event_data::ensure_mmap_buffer(size_t buffer_size)
+software_perf_event_buffer::software_perf_event_buffer(int pagesize,
+						       segment_manager *manager)
+	: pagesize(pagesize), mmap_buffer(pagesize, manager),
+	  copy_buffer(pagesize, manager)
+{
+	perf_event_mmap_page &perf_header = get_header_ref();
+	perf_header.data_offset = pagesize;
+	perf_header.data_head = perf_header.data_tail = 0;
+	perf_header.data_size = 0;
+}
+
+const perf_event_mmap_page &
+software_perf_event_buffer::get_header_ref_const() const
+{
+	return *(perf_event_mmap_page *)(uintptr_t)(mmap_buffer.data());
+}
+
+perf_event_mmap_page &software_perf_event_buffer::get_header_ref()
+{
+	return *(perf_event_mmap_page *)(uintptr_t)(mmap_buffer.data());
+}
+
+bool software_perf_event_buffer::has_data() const
+{
+	auto &ref = get_header_ref_const();
+	return smp_load_acquire_u64(&ref.data_tail) !=
+	       smp_load_acquire_u64(&ref.data_head);
+}
+
+void *software_perf_event_buffer::ensure_mmap_buffer(size_t buffer_size)
 {
 	if (buffer_size > mmap_buffer.size()) {
 		SPDLOG_DEBUG("Expanding mmap buffer size to {}", buffer_size);
@@ -254,9 +240,230 @@ void *software_perf_event_data::ensure_mmap_buffer(size_t buffer_size)
 	return mmap_buffer.data();
 }
 
-size_t software_perf_event_data::mmap_size() const
+size_t software_perf_event_buffer::mmap_size() const
 {
 	return mmap_buffer.size() - pagesize;
+}
+
+bool software_perf_event_buffer::append_record(const void *record,
+					       size_t record_size)
+{
+	if (mmap_size() == 0 || record_size > mmap_size()) {
+		return false;
+	}
+	auto &header = get_header_ref();
+	uint64_t data_head = smp_load_acquire_u64(&header.data_head);
+	uint64_t data_tail = smp_load_acquire_u64(&header.data_tail);
+	uint8_t *base_addr = (uint8_t *)mmap_buffer.data() + pagesize;
+	int64_t available_size =
+		(int64_t)mmap_size() - (int64_t)(data_head - data_tail);
+	if (available_size == 0) {
+		available_size = mmap_size();
+	}
+	// Keep one byte empty so head == tail only represents an empty buffer.
+	if (available_size <= (int64_t)record_size) {
+		SPDLOG_DEBUG(
+			"Dropping perf record with size {}, available_size {}",
+			record_size, available_size);
+		return false;
+	}
+
+	uint8_t *copy_start_1 = base_addr + (data_head & (mmap_size() - 1));
+	if (record_size + copy_start_1 <= base_addr + mmap_size()) {
+		memcpy(copy_start_1, record, record_size);
+	} else {
+		size_t len_first = base_addr + mmap_size() - copy_start_1;
+		size_t len_second = record_size - len_first;
+		memcpy(copy_start_1, record, len_first);
+		memcpy(base_addr, (const uint8_t *)record + len_first,
+		       len_second);
+	}
+	uint64_t new_head = data_head + record_size;
+	smp_store_release_u64(&header.data_head, new_head);
+	SPDLOG_DEBUG(
+		"Perf record of size {} outputed at head {}; new_head={} addr={:x}; available_size={}",
+		record_size, data_head, new_head,
+		(uintptr_t)(base_addr + data_head), available_size);
+	return true;
+}
+
+int software_perf_event_buffer::output_data(const void *buf, size_t size)
+{
+	SPDLOG_DEBUG("Handling perf event output data with size {}", size);
+	perf_sample_raw head;
+	head.header.type = PERF_RECORD_SAMPLE;
+	head.header.size = sizeof(head) + size;
+	head.header.misc = 0;
+	head.size = size;
+
+	auto copy_size = head.header.size;
+	if (copy_buffer.size() != copy_size)
+		copy_buffer.resize(copy_size);
+	memcpy(copy_buffer.data(), &head, sizeof(head));
+	memcpy((uint8_t *)(copy_buffer.data()) + sizeof(head), buf, size);
+	append_record(copy_buffer.data(), copy_size);
+	return 0;
+}
+
+void software_perf_event_buffer::copy_from_ring(uint64_t offset, void *dst,
+						size_t size) const
+{
+	uint8_t *base_addr = (uint8_t *)mmap_buffer.data() + pagesize;
+	uint8_t *copy_start_1 = base_addr + (offset & (mmap_size() - 1));
+	if (size + copy_start_1 <= base_addr + mmap_size()) {
+		memcpy(dst, copy_start_1, size);
+	} else {
+		size_t len_first = base_addr + mmap_size() - copy_start_1;
+		size_t len_second = size - len_first;
+		memcpy(dst, copy_start_1, len_first);
+		memcpy((uint8_t *)dst + len_first, base_addr, len_second);
+	}
+}
+
+bool software_perf_event_buffer::copy_next_record_to(
+	software_perf_event_buffer &dst)
+{
+	if (mmap_size() == 0) {
+		return false;
+	}
+	auto &header = get_header_ref();
+	uint64_t data_tail = smp_load_acquire_u64(&header.data_tail);
+	uint64_t data_head = smp_load_acquire_u64(&header.data_head);
+	if (data_tail == data_head) {
+		return false;
+	}
+	if (data_head < data_tail) {
+		SPDLOG_ERROR("Invalid perf buffer state: head {} < tail {}",
+			     data_head, data_tail);
+		smp_store_release_u64(&header.data_tail, data_head);
+		return false;
+	}
+
+	perf_event_header record_header;
+	copy_from_ring(data_tail, &record_header, sizeof(record_header));
+	if (record_header.size < sizeof(record_header) ||
+	    record_header.size > mmap_size()) {
+		SPDLOG_ERROR("Invalid perf record size {}, dropping shard data",
+			     record_header.size);
+		smp_store_release_u64(&header.data_tail, data_head);
+		return false;
+	}
+	if (record_header.size > data_head - data_tail) {
+		return false;
+	}
+
+	if (copy_buffer.size() != record_header.size)
+		copy_buffer.resize(record_header.size);
+	copy_from_ring(data_tail, copy_buffer.data(), record_header.size);
+	if (!dst.append_record(copy_buffer.data(), record_header.size)) {
+		return false;
+	}
+	smp_store_release_u64(&header.data_tail,
+			      data_tail + record_header.size);
+	return true;
+}
+
+software_perf_event_shard::software_perf_event_shard(
+	int pid, int64_t tid, uint64_t generation, int pagesize,
+	software_perf_event_buffer::segment_manager *manager,
+	size_t buffer_size)
+	: pid(pid), tid(tid), generation(generation), buffer(pagesize, manager)
+{
+	buffer.ensure_mmap_buffer(buffer_size);
+}
+
+software_perf_event_data::software_perf_event_data(
+	int cpu, int64_t config, int32_t sample_type,
+	boost::interprocess::managed_shared_memory &memory)
+	: cpu(cpu), config(config), sample_type(sample_type),
+	  pagesize(getpagesize()),
+	  consumer_buffer(pagesize, memory.get_segment_manager()),
+	  producer_shards(memory.get_segment_manager())
+{
+	pthread_spin_init(&shard_lock, PTHREAD_PROCESS_SHARED);
+}
+
+software_perf_event_data::~software_perf_event_data()
+{
+	pthread_spin_destroy(&shard_lock);
+}
+
+software_perf_event_shard &software_perf_event_data::get_current_thread_shard()
+{
+	const int pid = getpid();
+	const int64_t tid = current_thread_id();
+	if (auto itr = software_perf_event_shard_cache.find(this);
+	    itr != software_perf_event_shard_cache.end() &&
+	    itr->second->pid == pid && itr->second->tid == tid) {
+		return *itr->second;
+	}
+
+	spin_lock_guard guard(shard_lock);
+	for (auto &shard : producer_shards) {
+		if (shard.pid == pid && shard.tid == tid) {
+			software_perf_event_shard_cache[this] = &shard;
+			return shard;
+		}
+	}
+
+	auto *manager = producer_shards.get_allocator().get_segment_manager();
+	producer_shards.emplace_back(pid, tid, next_generation++, pagesize,
+				     manager,
+				     consumer_buffer.mmap_buffer.size());
+	auto &shard = producer_shards.back();
+	software_perf_event_shard_cache[this] = &shard;
+	return shard;
+}
+
+void software_perf_event_data::drain_producer_shards()
+{
+	spin_lock_guard guard(shard_lock);
+	for (auto &shard : producer_shards) {
+		while (shard.buffer.copy_next_record_to(consumer_buffer)) {
+		}
+	}
+}
+
+bool software_perf_event_data::has_data()
+{
+	drain_producer_shards();
+	return consumer_buffer.has_data();
+}
+
+const perf_event_mmap_page &
+software_perf_event_data::get_header_ref_const() const
+{
+	return consumer_buffer.get_header_ref_const();
+}
+
+int software_perf_event_data::output_data(const void *buf, size_t size)
+{
+	return get_current_thread_shard().buffer.output_data(buf, size);
+}
+
+perf_event_mmap_page &software_perf_event_data::get_header_ref()
+{
+	return consumer_buffer.get_header_ref();
+}
+
+void *software_perf_event_data::ensure_mmap_buffer(size_t buffer_size)
+{
+	void *result = consumer_buffer.ensure_mmap_buffer(buffer_size);
+	if (result == nullptr) {
+		return nullptr;
+	}
+	spin_lock_guard guard(shard_lock);
+	for (auto &shard : producer_shards) {
+		if (shard.buffer.ensure_mmap_buffer(buffer_size) == nullptr) {
+			return nullptr;
+		}
+	}
+	return result;
+}
+
+size_t software_perf_event_data::mmap_size() const
+{
+	return consumer_buffer.mmap_size();
 }
 
 std::optional<software_perf_event_weak_ptr>

--- a/runtime/src/handler/perf_event_handler.cpp
+++ b/runtime/src/handler/perf_event_handler.cpp
@@ -17,6 +17,8 @@
 #include <boost/interprocess/allocators/allocator.hpp>
 #include <unistd.h>
 #include <spdlog/fmt/bin_to_hex.h>
+#include <atomic>
+#include <cerrno>
 #include <unordered_map>
 #include <variant>
 #if __linux__
@@ -91,8 +93,39 @@ int64_t current_thread_id()
 #endif
 }
 
+uint64_t next_software_perf_event_generation()
+{
+	static std::atomic<uint64_t> next_generation{ 1 };
+	uint64_t generation =
+		next_generation.fetch_add(1, std::memory_order_relaxed);
+	return ((uint64_t)(uint32_t)getpid() << 32) ^ generation;
+}
+
+bool is_thread_alive(int pid, int64_t tid)
+{
+#if __linux__
+	if (syscall(SYS_tgkill, pid, (pid_t)tid, 0) == 0) {
+		return true;
+	}
+	return errno == EPERM;
+#else
+	(void)pid;
+	(void)tid;
+	return true;
+#endif
+}
+
+struct software_perf_event_shard_cache_entry {
+	uint64_t event_generation;
+	uint64_t buffer_generation;
+	uint64_t shard_generation;
+	software_perf_event_shard *shard;
+};
+
+constexpr size_t max_software_perf_event_shard_cache_entries = 64;
+
 thread_local std::unordered_map<const software_perf_event_data *,
-				software_perf_event_shard *>
+				software_perf_event_shard_cache_entry>
 	software_perf_event_shard_cache;
 } // namespace
 
@@ -255,13 +288,16 @@ bool software_perf_event_buffer::append_record(const void *record,
 	uint64_t data_head = smp_load_acquire_u64(&header.data_head);
 	uint64_t data_tail = smp_load_acquire_u64(&header.data_tail);
 	uint8_t *base_addr = (uint8_t *)mmap_buffer.data() + pagesize;
-	int64_t available_size =
-		(int64_t)mmap_size() - (int64_t)(data_head - data_tail);
-	if (available_size == 0) {
-		available_size = mmap_size();
+	const uint64_t used_size = data_head - data_tail;
+	if (data_head < data_tail || used_size >= mmap_size()) {
+		SPDLOG_DEBUG(
+			"Dropping perf record with invalid ring state: head {}, tail {}, ring size {}",
+			data_head, data_tail, mmap_size());
+		return false;
 	}
+	const size_t available_size = mmap_size() - used_size;
 	// Keep one byte empty so head == tail only represents an empty buffer.
-	if (available_size <= (int64_t)record_size) {
+	if (available_size <= record_size) {
 		SPDLOG_DEBUG(
 			"Dropping perf record with size {}, available_size {}",
 			record_size, available_size);
@@ -364,10 +400,11 @@ bool software_perf_event_buffer::copy_next_record_to(
 }
 
 software_perf_event_shard::software_perf_event_shard(
-	int pid, int64_t tid, uint64_t generation, int pagesize,
-	software_perf_event_buffer::segment_manager *manager,
+	int pid, int64_t tid, uint64_t generation, uint64_t buffer_generation,
+	int pagesize, software_perf_event_buffer::segment_manager *manager,
 	size_t buffer_size)
-	: pid(pid), tid(tid), generation(generation), buffer(pagesize, manager)
+	: pid(pid), tid(tid), generation(generation),
+	  buffer_generation(buffer_generation), buffer(pagesize, manager)
 {
 	buffer.ensure_mmap_buffer(buffer_size);
 }
@@ -377,6 +414,7 @@ software_perf_event_data::software_perf_event_data(
 	boost::interprocess::managed_shared_memory &memory)
 	: cpu(cpu), config(config), sample_type(sample_type),
 	  pagesize(getpagesize()),
+	  event_generation(next_software_perf_event_generation()),
 	  consumer_buffer(pagesize, memory.get_segment_manager()),
 	  producer_shards(memory.get_segment_manager())
 {
@@ -392,26 +430,55 @@ software_perf_event_shard &software_perf_event_data::get_current_thread_shard()
 {
 	const int pid = getpid();
 	const int64_t tid = current_thread_id();
+	uint64_t current_buffer_generation =
+		READ_ONCE_U64(producer_buffer_generation);
 	if (auto itr = software_perf_event_shard_cache.find(this);
-	    itr != software_perf_event_shard_cache.end() &&
-	    itr->second->pid == pid && itr->second->tid == tid) {
-		return *itr->second;
+	    itr != software_perf_event_shard_cache.end()) {
+		auto &entry = itr->second;
+		if (entry.event_generation != event_generation ||
+		    entry.buffer_generation != current_buffer_generation) {
+			software_perf_event_shard_cache.erase(itr);
+		} else if (entry.shard->pid == pid && entry.shard->tid == tid &&
+			   entry.shard->generation == entry.shard_generation &&
+			   entry.shard->buffer_generation ==
+				   current_buffer_generation) {
+			return *entry.shard;
+		} else {
+			software_perf_event_shard_cache.erase(itr);
+		}
 	}
 
 	spin_lock_guard guard(shard_lock);
+	current_buffer_generation = READ_ONCE_U64(producer_buffer_generation);
+	reclaim_inactive_producer_shards_locked();
 	for (auto &shard : producer_shards) {
-		if (shard.pid == pid && shard.tid == tid) {
-			software_perf_event_shard_cache[this] = &shard;
+		if (shard.pid == pid && shard.tid == tid &&
+		    shard.buffer_generation == current_buffer_generation) {
+			if (software_perf_event_shard_cache.size() >=
+			    max_software_perf_event_shard_cache_entries) {
+				software_perf_event_shard_cache.clear();
+			}
+			software_perf_event_shard_cache[this] = {
+				event_generation, current_buffer_generation,
+				shard.generation, &shard
+			};
 			return shard;
 		}
 	}
 
 	auto *manager = producer_shards.get_allocator().get_segment_manager();
-	producer_shards.emplace_back(pid, tid, next_generation++, pagesize,
+	producer_shards.emplace_back(pid, tid, next_shard_generation++,
+				     current_buffer_generation, pagesize,
 				     manager,
 				     consumer_buffer.mmap_buffer.size());
 	auto &shard = producer_shards.back();
-	software_perf_event_shard_cache[this] = &shard;
+	if (software_perf_event_shard_cache.size() >=
+	    max_software_perf_event_shard_cache_entries) {
+		software_perf_event_shard_cache.clear();
+	}
+	software_perf_event_shard_cache[this] = { event_generation,
+						  current_buffer_generation,
+						  shard.generation, &shard };
 	return shard;
 }
 
@@ -420,6 +487,21 @@ void software_perf_event_data::drain_producer_shards()
 	spin_lock_guard guard(shard_lock);
 	for (auto &shard : producer_shards) {
 		while (shard.buffer.copy_next_record_to(consumer_buffer)) {
+		}
+	}
+	reclaim_inactive_producer_shards_locked();
+}
+
+void software_perf_event_data::reclaim_inactive_producer_shards_locked()
+{
+	for (auto itr = producer_shards.begin();
+	     itr != producer_shards.end();) {
+		auto &shard = *itr;
+		if (!shard.buffer.has_data() &&
+		    !is_thread_alive(shard.pid, shard.tid)) {
+			itr = producer_shards.erase(itr);
+		} else {
+			++itr;
 		}
 	}
 }
@@ -448,15 +530,15 @@ perf_event_mmap_page &software_perf_event_data::get_header_ref()
 
 void *software_perf_event_data::ensure_mmap_buffer(size_t buffer_size)
 {
+	spin_lock_guard guard(shard_lock);
+	const size_t old_buffer_size = consumer_buffer.mmap_buffer.size();
 	void *result = consumer_buffer.ensure_mmap_buffer(buffer_size);
 	if (result == nullptr) {
 		return nullptr;
 	}
-	spin_lock_guard guard(shard_lock);
-	for (auto &shard : producer_shards) {
-		if (shard.buffer.ensure_mmap_buffer(buffer_size) == nullptr) {
-			return nullptr;
-		}
+	if (consumer_buffer.mmap_buffer.size() != old_buffer_size) {
+		WRITE_ONCE_U64(producer_buffer_generation,
+			       producer_buffer_generation + 1);
 	}
 	return result;
 }

--- a/runtime/src/handler/perf_event_handler.cpp
+++ b/runtime/src/handler/perf_event_handler.cpp
@@ -19,6 +19,7 @@
 #include <spdlog/fmt/bin_to_hex.h>
 #include <atomic>
 #include <cerrno>
+#include <limits>
 #include <unordered_map>
 #include <variant>
 #if __linux__
@@ -123,6 +124,8 @@ struct software_perf_event_shard_cache_entry {
 };
 
 constexpr size_t max_software_perf_event_shard_cache_entries = 64;
+constexpr uint64_t software_perf_event_reclaim_drain_interval = 64;
+constexpr size_t software_perf_event_reclaim_shard_threshold = 64;
 
 thread_local std::unordered_map<const software_perf_event_data *,
 				software_perf_event_shard_cache_entry>
@@ -231,7 +234,7 @@ bpf_perf_event_handler::bpf_perf_event_handler(
 software_perf_event_buffer::software_perf_event_buffer(int pagesize,
 						       segment_manager *manager)
 	: pagesize(pagesize), mmap_buffer(pagesize, manager),
-	  copy_buffer(pagesize, manager)
+	  copy_buffer(manager)
 {
 	perf_event_mmap_page &perf_header = get_header_ref();
 	perf_header.data_offset = pagesize;
@@ -281,13 +284,24 @@ size_t software_perf_event_buffer::mmap_size() const
 bool software_perf_event_buffer::append_record(const void *record,
 					       size_t record_size)
 {
+	return append_record_parts(record, record_size, nullptr, 0);
+}
+
+bool software_perf_event_buffer::append_record_parts(const void *first,
+						     size_t first_size,
+						     const void *second,
+						     size_t second_size)
+{
+	if (second_size > std::numeric_limits<size_t>::max() - first_size) {
+		return false;
+	}
+	const size_t record_size = first_size + second_size;
 	if (mmap_size() == 0 || record_size > mmap_size()) {
 		return false;
 	}
 	auto &header = get_header_ref();
 	uint64_t data_head = smp_load_acquire_u64(&header.data_head);
 	uint64_t data_tail = smp_load_acquire_u64(&header.data_tail);
-	uint8_t *base_addr = (uint8_t *)mmap_buffer.data() + pagesize;
 	const uint64_t used_size = data_head - data_tail;
 	if (data_head < data_tail || used_size >= mmap_size()) {
 		SPDLOG_DEBUG(
@@ -304,54 +318,69 @@ bool software_perf_event_buffer::append_record(const void *record,
 		return false;
 	}
 
-	uint8_t *copy_start_1 = base_addr + (data_head & (mmap_size() - 1));
-	if (record_size + copy_start_1 <= base_addr + mmap_size()) {
-		memcpy(copy_start_1, record, record_size);
-	} else {
-		size_t len_first = base_addr + mmap_size() - copy_start_1;
-		size_t len_second = record_size - len_first;
-		memcpy(copy_start_1, record, len_first);
-		memcpy(base_addr, (const uint8_t *)record + len_first,
-		       len_second);
+	write_wrapped(data_head, first, first_size);
+	if (second_size > 0) {
+		write_wrapped(data_head + first_size, second, second_size);
 	}
 	uint64_t new_head = data_head + record_size;
 	smp_store_release_u64(&header.data_head, new_head);
 	SPDLOG_DEBUG(
 		"Perf record of size {} outputed at head {}; new_head={} addr={:x}; available_size={}",
 		record_size, data_head, new_head,
-		(uintptr_t)(base_addr + data_head), available_size);
+		(uintptr_t)((uint8_t *)mmap_buffer.data() + pagesize +
+			    (data_head & (mmap_size() - 1))),
+		available_size);
 	return true;
+}
+
+bool software_perf_event_buffer::append_sample(const perf_sample_raw &header,
+					       const void *payload,
+					       size_t payload_size)
+{
+	return append_record_parts(&header, sizeof(header), payload,
+				   payload_size);
 }
 
 int software_perf_event_buffer::output_data(const void *buf, size_t size)
 {
 	SPDLOG_DEBUG("Handling perf event output data with size {}", size);
-	perf_sample_raw head;
-	head.header.type = PERF_RECORD_SAMPLE;
-	head.header.size = sizeof(head) + size;
-	head.header.misc = 0;
-	head.size = size;
+	perf_sample_raw header;
+	header.header.type = PERF_RECORD_SAMPLE;
+	header.header.size = sizeof(header) + size;
+	header.header.misc = 0;
+	header.size = size;
 
-	auto copy_size = head.header.size;
-	if (copy_buffer.size() != copy_size)
-		copy_buffer.resize(copy_size);
-	memcpy(copy_buffer.data(), &head, sizeof(head));
-	memcpy((uint8_t *)(copy_buffer.data()) + sizeof(head), buf, size);
-	append_record(copy_buffer.data(), copy_size);
+	append_sample(header, buf, size);
 	return 0;
 }
 
-void software_perf_event_buffer::copy_from_ring(uint64_t offset, void *dst,
-						size_t size) const
+void software_perf_event_buffer::write_wrapped(uint64_t offset, const void *src,
+					       size_t size)
 {
 	uint8_t *base_addr = (uint8_t *)mmap_buffer.data() + pagesize;
-	uint8_t *copy_start_1 = base_addr + (offset & (mmap_size() - 1));
-	if (size + copy_start_1 <= base_addr + mmap_size()) {
-		memcpy(dst, copy_start_1, size);
+	uint8_t *copy_start = base_addr + (offset & (mmap_size() - 1));
+	if (size + copy_start <= base_addr + mmap_size()) {
+		memcpy(copy_start, src, size);
 	} else {
-		size_t len_first = base_addr + mmap_size() - copy_start_1;
+		size_t len_first = base_addr + mmap_size() - copy_start;
 		size_t len_second = size - len_first;
-		memcpy(dst, copy_start_1, len_first);
+		memcpy(copy_start, src, len_first);
+		memcpy(base_addr, (const uint8_t *)src + len_first, len_second);
+	}
+}
+
+void software_perf_event_buffer::read_wrapped(uint64_t offset, void *dst,
+					      size_t size) const
+{
+	const uint8_t *base_addr =
+		(const uint8_t *)mmap_buffer.data() + pagesize;
+	const uint8_t *copy_start = base_addr + (offset & (mmap_size() - 1));
+	if (size + copy_start <= base_addr + mmap_size()) {
+		memcpy(dst, copy_start, size);
+	} else {
+		size_t len_first = base_addr + mmap_size() - copy_start;
+		size_t len_second = size - len_first;
+		memcpy(dst, copy_start, len_first);
 		memcpy((uint8_t *)dst + len_first, base_addr, len_second);
 	}
 }
@@ -376,7 +405,7 @@ bool software_perf_event_buffer::copy_next_record_to(
 	}
 
 	perf_event_header record_header;
-	copy_from_ring(data_tail, &record_header, sizeof(record_header));
+	read_wrapped(data_tail, &record_header, sizeof(record_header));
 	if (record_header.size < sizeof(record_header) ||
 	    record_header.size > mmap_size()) {
 		SPDLOG_ERROR("Invalid perf record size {}, dropping shard data",
@@ -390,7 +419,7 @@ bool software_perf_event_buffer::copy_next_record_to(
 
 	if (copy_buffer.size() != record_header.size)
 		copy_buffer.resize(record_header.size);
-	copy_from_ring(data_tail, copy_buffer.data(), record_header.size);
+	read_wrapped(data_tail, copy_buffer.data(), record_header.size);
 	if (!dst.append_record(copy_buffer.data(), record_header.size)) {
 		return false;
 	}
@@ -450,7 +479,10 @@ software_perf_event_shard &software_perf_event_data::get_current_thread_shard()
 
 	spin_lock_guard guard(shard_lock);
 	current_buffer_generation = READ_ONCE_U64(producer_buffer_generation);
-	reclaim_inactive_producer_shards_locked();
+	if (producer_shards.size() >=
+	    software_perf_event_reclaim_shard_threshold) {
+		reclaim_inactive_producer_shards_locked();
+	}
 	for (auto &shard : producer_shards) {
 		if (shard.pid == pid && shard.tid == tid &&
 		    shard.buffer_generation == current_buffer_generation) {
@@ -489,7 +521,22 @@ void software_perf_event_data::drain_producer_shards()
 		while (shard.buffer.copy_next_record_to(consumer_buffer)) {
 		}
 	}
-	reclaim_inactive_producer_shards_locked();
+	maybe_reclaim_inactive_producer_shards_locked();
+}
+
+void software_perf_event_data::maybe_reclaim_inactive_producer_shards_locked()
+{
+	if (producer_shards.empty()) {
+		drains_since_reclaim = 0;
+		return;
+	}
+	if (++drains_since_reclaim >=
+		    software_perf_event_reclaim_drain_interval ||
+	    producer_shards.size() >=
+		    software_perf_event_reclaim_shard_threshold) {
+		drains_since_reclaim = 0;
+		reclaim_inactive_producer_shards_locked();
+	}
 }
 
 void software_perf_event_data::reclaim_inactive_producer_shards_locked()

--- a/runtime/src/handler/perf_event_handler.hpp
+++ b/runtime/src/handler/perf_event_handler.hpp
@@ -91,7 +91,12 @@ struct software_perf_event_buffer {
 
     private:
 	bool append_record(const void *record, size_t record_size);
-	void copy_from_ring(uint64_t offset, void *dst, size_t size) const;
+	bool append_record_parts(const void *first, size_t first_size,
+				 const void *second, size_t second_size);
+	bool append_sample(const perf_sample_raw &header, const void *payload,
+			   size_t payload_size);
+	void write_wrapped(uint64_t offset, const void *src, size_t size);
+	void read_wrapped(uint64_t offset, void *dst, size_t size) const;
 };
 
 struct software_perf_event_shard {
@@ -127,6 +132,7 @@ struct software_perf_event_data {
 	software_perf_event_buffer consumer_buffer;
 	mutable pthread_spinlock_t shard_lock;
 	uint64_t next_shard_generation = 1;
+	uint64_t drains_since_reclaim = 0;
 	software_perf_event_shard_list producer_shards;
 	software_perf_event_data(
 		int cpu, int64_t config, int32_t sample_type,
@@ -142,6 +148,7 @@ struct software_perf_event_data {
     private:
 	software_perf_event_shard &get_current_thread_shard();
 	void drain_producer_shards();
+	void maybe_reclaim_inactive_producer_shards_locked();
 	void reclaim_inactive_producer_shards_locked();
 };
 

--- a/runtime/src/handler/perf_event_handler.hpp
+++ b/runtime/src/handler/perf_event_handler.hpp
@@ -98,10 +98,12 @@ struct software_perf_event_shard {
 	int pid;
 	int64_t tid;
 	uint64_t generation;
+	uint64_t buffer_generation;
 	software_perf_event_buffer buffer;
 
 	software_perf_event_shard(
-		int pid, int64_t tid, uint64_t generation, int pagesize,
+		int pid, int64_t tid, uint64_t generation,
+		uint64_t buffer_generation, int pagesize,
 		software_perf_event_buffer::segment_manager *manager,
 		size_t buffer_size);
 };
@@ -120,9 +122,11 @@ struct software_perf_event_data {
 	// Field `sample_type` of perf_event_attr
 	int32_t sample_type;
 	int pagesize;
+	uint64_t event_generation;
+	uint64_t producer_buffer_generation = 1;
 	software_perf_event_buffer consumer_buffer;
 	mutable pthread_spinlock_t shard_lock;
-	uint64_t next_generation = 1;
+	uint64_t next_shard_generation = 1;
 	software_perf_event_shard_list producer_shards;
 	software_perf_event_data(
 		int cpu, int64_t config, int32_t sample_type,
@@ -138,6 +142,7 @@ struct software_perf_event_data {
     private:
 	software_perf_event_shard &get_current_thread_shard();
 	void drain_producer_shards();
+	void reclaim_inactive_producer_shards_locked();
 };
 
 using software_perf_event_shared_ptr = boost::interprocess::managed_shared_ptr<

--- a/runtime/src/handler/perf_event_handler.hpp
+++ b/runtime/src/handler/perf_event_handler.hpp
@@ -7,6 +7,7 @@
 #define _PERF_EVENT_HANDLER
 #include "spdlog/spdlog.h"
 #include <boost/interprocess/managed_shared_memory.hpp>
+#include <boost/interprocess/containers/list.hpp>
 #include <boost/interprocess/containers/string.hpp>
 #include <boost/interprocess/containers/vector.hpp>
 #include <cstddef>
@@ -19,6 +20,7 @@
 #include "linux/perf_event.h"
 #endif
 #include "bpftime_shm.hpp"
+#include <pthread.h>
 #include <variant>
 
 namespace bpftime
@@ -66,29 +68,76 @@ at the head, if the remaining buffer space at the tail is not enough
 - Add data_head with the corresponding size. modular with buf_len
 */
 
-struct software_perf_event_data {
+struct software_perf_event_buffer {
+	using segment_manager =
+		boost::interprocess::managed_shared_memory::segment_manager;
 	using bytes_vec_allocator = boost::interprocess::allocator<
 		uint8_t,
 		boost::interprocess::managed_shared_memory::segment_manager>;
 	using bytes_vec =
 		boost::interprocess::vector<uint8_t, bytes_vec_allocator>;
-	int cpu;
-	// Field `config` of perf_event_attr
-	int64_t config;
-	// Field `sample_type` of perf_event_attr
-	int32_t sample_type;
 	int pagesize;
 	bytes_vec mmap_buffer;
 	bytes_vec copy_buffer;
-	software_perf_event_data(
-		int cpu, int64_t config, int32_t sample_type,
-		boost::interprocess::managed_shared_memory &memory);
+
+	software_perf_event_buffer(int pagesize, segment_manager *manager);
 	void *ensure_mmap_buffer(size_t buffer_size);
 	perf_event_mmap_page &get_header_ref();
 	const perf_event_mmap_page &get_header_ref_const() const;
 	int output_data(const void *buf, size_t size);
 	size_t mmap_size() const;
 	bool has_data() const;
+	bool copy_next_record_to(software_perf_event_buffer &dst);
+
+    private:
+	bool append_record(const void *record, size_t record_size);
+	void copy_from_ring(uint64_t offset, void *dst, size_t size) const;
+};
+
+struct software_perf_event_shard {
+	int pid;
+	int64_t tid;
+	uint64_t generation;
+	software_perf_event_buffer buffer;
+
+	software_perf_event_shard(
+		int pid, int64_t tid, uint64_t generation, int pagesize,
+		software_perf_event_buffer::segment_manager *manager,
+		size_t buffer_size);
+};
+
+using software_perf_event_shard_allocator = boost::interprocess::allocator<
+	software_perf_event_shard,
+	boost::interprocess::managed_shared_memory::segment_manager>;
+using software_perf_event_shard_list =
+	boost::interprocess::list<software_perf_event_shard,
+				  software_perf_event_shard_allocator>;
+
+struct software_perf_event_data {
+	int cpu;
+	// Field `config` of perf_event_attr
+	int64_t config;
+	// Field `sample_type` of perf_event_attr
+	int32_t sample_type;
+	int pagesize;
+	software_perf_event_buffer consumer_buffer;
+	mutable pthread_spinlock_t shard_lock;
+	uint64_t next_generation = 1;
+	software_perf_event_shard_list producer_shards;
+	software_perf_event_data(
+		int cpu, int64_t config, int32_t sample_type,
+		boost::interprocess::managed_shared_memory &memory);
+	~software_perf_event_data();
+	void *ensure_mmap_buffer(size_t buffer_size);
+	perf_event_mmap_page &get_header_ref();
+	const perf_event_mmap_page &get_header_ref_const() const;
+	int output_data(const void *buf, size_t size);
+	size_t mmap_size() const;
+	bool has_data();
+
+    private:
+	software_perf_event_shard &get_current_thread_shard();
+	void drain_producer_shards();
 };
 
 using software_perf_event_shared_ptr = boost::interprocess::managed_shared_ptr<

--- a/runtime/unit-test/CMakeLists.txt
+++ b/runtime/unit-test/CMakeLists.txt
@@ -32,6 +32,7 @@ set(TEST_SOURCES
     test_bpftime_shm_json.cpp
     test_probe.cpp
     test_config.cpp
+    test_software_perf_event.cpp
 
     attach_with_ebpf/test_attach_filter_with_ebpf.cpp
     attach_with_ebpf/test_attach_uprobe_with_ebpf.cpp

--- a/runtime/unit-test/test_software_perf_event.cpp
+++ b/runtime/unit-test/test_software_perf_event.cpp
@@ -1,0 +1,125 @@
+#include "catch2/catch_test_macros.hpp"
+
+#include "handler/perf_event_handler.hpp"
+#include "common_def.hpp"
+#include <atomic>
+#include <boost/interprocess/managed_shared_memory.hpp>
+#include <cstring>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+namespace
+{
+struct event_payload {
+	int producer;
+	int sequence;
+};
+
+void copy_from_perf_ring(uint8_t *base, size_t ring_size, uint64_t offset,
+			 void *dst, size_t size)
+{
+	uint8_t *copy_start_1 = base + (offset & (ring_size - 1));
+	if (size + copy_start_1 <= base + ring_size) {
+		memcpy(dst, copy_start_1, size);
+	} else {
+		size_t len_first = base + ring_size - copy_start_1;
+		size_t len_second = size - len_first;
+		memcpy(dst, copy_start_1, len_first);
+		memcpy((uint8_t *)dst + len_first, base, len_second);
+	}
+}
+} // namespace
+
+TEST_CASE("Software perf event buffers shard concurrent producers by thread",
+	  "[perf_event][software_perf_event]")
+{
+	const char *shared_memory_name = "SoftwarePerfEventShardTestShm";
+	const size_t shared_memory_size = 16 * 1024 * 1024;
+	shm_remove remover((std::string(shared_memory_name)));
+
+	boost::interprocess::managed_shared_memory shm(
+		boost::interprocess::create_only, shared_memory_name,
+		shared_memory_size);
+
+	auto *perf = shm.construct<bpftime::software_perf_event_data>(
+		"perf")(0, 0, 0, shm);
+	REQUIRE(perf != nullptr);
+
+	const size_t ring_size = 1024 * 1024;
+	void *raw_buffer = perf->ensure_mmap_buffer(getpagesize() + ring_size);
+	REQUIRE(raw_buffer != nullptr);
+
+	constexpr int producer_count = 4;
+	constexpr int events_per_producer = 256;
+	std::atomic<bool> start{ false };
+	std::atomic<bool> output_failed{ false };
+	std::vector<std::thread> producers;
+	producers.reserve(producer_count);
+	for (int producer = 0; producer < producer_count; producer++) {
+		producers.emplace_back([&, producer]() {
+			while (!start.load(std::memory_order_acquire)) {
+				std::this_thread::yield();
+			}
+			for (int sequence = 0; sequence < events_per_producer;
+			     sequence++) {
+				event_payload payload{ producer, sequence };
+				if (perf->output_data(&payload,
+						      sizeof(payload)) != 0) {
+					output_failed.store(
+						true,
+						std::memory_order_release);
+				}
+			}
+		});
+	}
+
+	start.store(true, std::memory_order_release);
+	for (auto &producer : producers) {
+		producer.join();
+	}
+	REQUIRE_FALSE(output_failed.load(std::memory_order_acquire));
+
+	REQUIRE(perf->has_data());
+
+	auto *header = (perf_event_mmap_page *)raw_buffer;
+	auto *base = (uint8_t *)raw_buffer + getpagesize();
+	uint64_t tail = header->data_tail;
+	uint64_t head = header->data_head;
+	REQUIRE(head > tail);
+
+	std::vector<int> seen(producer_count * events_per_producer, 0);
+	int record_count = 0;
+	while (tail < head) {
+		perf_event_header record_header;
+		copy_from_perf_ring(base, ring_size, tail, &record_header,
+				    sizeof(record_header));
+		REQUIRE(record_header.type == PERF_RECORD_SAMPLE);
+		REQUIRE(record_header.size == sizeof(bpftime::perf_sample_raw) +
+						      sizeof(event_payload));
+
+		std::vector<uint8_t> record(record_header.size);
+		copy_from_perf_ring(base, ring_size, tail, record.data(),
+				    record.size());
+		auto *sample = (const bpftime::perf_sample_raw *)record.data();
+		REQUIRE(sample->size == sizeof(event_payload));
+
+		event_payload payload;
+		memcpy(&payload,
+		       record.data() + sizeof(bpftime::perf_sample_raw),
+		       sizeof(payload));
+		REQUIRE(payload.producer >= 0);
+		REQUIRE(payload.producer < producer_count);
+		REQUIRE(payload.sequence >= 0);
+		REQUIRE(payload.sequence < events_per_producer);
+		seen[payload.producer * events_per_producer +
+		     payload.sequence]++;
+		record_count++;
+		tail += record_header.size;
+	}
+
+	REQUIRE(record_count == producer_count * events_per_producer);
+	for (int count : seen) {
+		REQUIRE(count == 1);
+	}
+}

--- a/runtime/unit-test/test_software_perf_event.cpp
+++ b/runtime/unit-test/test_software_perf_event.cpp
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <boost/interprocess/managed_shared_memory.hpp>
 #include <cstring>
+#include <string>
 #include <thread>
 #include <unistd.h>
 #include <vector>
@@ -34,12 +35,13 @@ void copy_from_perf_ring(uint8_t *base, size_t ring_size, uint64_t offset,
 TEST_CASE("Software perf event buffers shard concurrent producers by thread",
 	  "[perf_event][software_perf_event]")
 {
-	const char *shared_memory_name = "SoftwarePerfEventShardTestShm";
+	const std::string shared_memory_name =
+		"SoftwarePerfEventShardTestShm-" + std::to_string(getpid());
 	const size_t shared_memory_size = 16 * 1024 * 1024;
-	shm_remove remover((std::string(shared_memory_name)));
+	shm_remove remover{ std::string(shared_memory_name) };
 
 	boost::interprocess::managed_shared_memory shm(
-		boost::interprocess::create_only, shared_memory_name,
+		boost::interprocess::create_only, shared_memory_name.c_str(),
 		shared_memory_size);
 
 	auto *perf = shm.construct<bpftime::software_perf_event_data>(
@@ -81,6 +83,7 @@ TEST_CASE("Software perf event buffers shard concurrent producers by thread",
 	REQUIRE_FALSE(output_failed.load(std::memory_order_acquire));
 
 	REQUIRE(perf->has_data());
+	REQUIRE(perf->producer_shards.empty());
 
 	auto *header = (perf_event_mmap_page *)raw_buffer;
 	auto *base = (uint8_t *)raw_buffer + getpagesize();
@@ -122,4 +125,60 @@ TEST_CASE("Software perf event buffers shard concurrent producers by thread",
 	for (int count : seen) {
 		REQUIRE(count == 1);
 	}
+}
+
+TEST_CASE("Software perf event producer shards rotate after mmap resize",
+	  "[perf_event][software_perf_event]")
+{
+	const std::string shared_memory_name =
+		"SoftwarePerfEventResizeTestShm-" + std::to_string(getpid());
+	const size_t shared_memory_size = 16 * 1024 * 1024;
+	shm_remove remover{ std::string(shared_memory_name) };
+
+	boost::interprocess::managed_shared_memory shm(
+		boost::interprocess::create_only, shared_memory_name.c_str(),
+		shared_memory_size);
+
+	auto *perf = shm.construct<bpftime::software_perf_event_data>(
+		"perf")(0, 0, 0, shm);
+	REQUIRE(perf != nullptr);
+
+	event_payload dropped_before_mmap{ 0, 0 };
+	REQUIRE(perf->output_data(&dropped_before_mmap,
+				  sizeof(dropped_before_mmap)) == 0);
+	REQUIRE_FALSE(perf->has_data());
+
+	const size_t ring_size = 64 * 1024;
+	void *raw_buffer = perf->ensure_mmap_buffer(getpagesize() + ring_size);
+	REQUIRE(raw_buffer != nullptr);
+
+	event_payload payload{ 1, 7 };
+	REQUIRE(perf->output_data(&payload, sizeof(payload)) == 0);
+	REQUIRE(perf->has_data());
+
+	auto *header = (perf_event_mmap_page *)raw_buffer;
+	auto *base = (uint8_t *)raw_buffer + getpagesize();
+	uint64_t tail = header->data_tail;
+	uint64_t head = header->data_head;
+	REQUIRE(head > tail);
+
+	perf_event_header record_header;
+	copy_from_perf_ring(base, ring_size, tail, &record_header,
+			    sizeof(record_header));
+	REQUIRE(record_header.type == PERF_RECORD_SAMPLE);
+	REQUIRE(record_header.size ==
+		sizeof(bpftime::perf_sample_raw) + sizeof(event_payload));
+
+	std::vector<uint8_t> record(record_header.size);
+	copy_from_perf_ring(base, ring_size, tail, record.data(),
+			    record.size());
+	auto *sample = (const bpftime::perf_sample_raw *)record.data();
+	REQUIRE(sample->size == sizeof(event_payload));
+
+	event_payload actual;
+	memcpy(&actual, record.data() + sizeof(bpftime::perf_sample_raw),
+	       sizeof(actual));
+	REQUIRE(actual.producer == payload.producer);
+	REQUIRE(actual.sequence == payload.sequence);
+	REQUIRE(tail + record_header.size == head);
 }

--- a/runtime/unit-test/test_software_perf_event.cpp
+++ b/runtime/unit-test/test_software_perf_event.cpp
@@ -83,6 +83,9 @@ TEST_CASE("Software perf event buffers shard concurrent producers by thread",
 	REQUIRE_FALSE(output_failed.load(std::memory_order_acquire));
 
 	REQUIRE(perf->has_data());
+	for (int i = 0; i < 64; i++) {
+		REQUIRE(perf->has_data());
+	}
 	REQUIRE(perf->producer_shards.empty());
 
 	auto *header = (perf_event_mmap_page *)raw_buffer;


### PR DESCRIPTION
## Summary

Move userspace software perf event output away from a single per-CPU producer buffer and into per-thread producer shards stored in shared memory. Each producer thread writes only its own SPSC shard, while the existing consumer-facing mmap buffer remains the public read surface and is populated from shards during readiness checks.

This keeps the hot producer path lock-free after first-thread shard registration and avoids the current race where multiple userspace threads pinned to the same CPU can observe the same `data_head` and overwrite each other.

## Details

- Adds `software_perf_event_buffer` as the reusable perf ring implementation.
- Adds shared-memory per-thread `software_perf_event_shard` storage under each software perf event.
- Keeps `bpftime_get_software_perf_event_raw_buffer()` compatible by returning the existing logical consumer mmap buffer.
- Drains producer shards into the consumer buffer from `has_data()`, which is already used by the mocked epoll readiness path.
- Adds a concurrency unit test with multiple threads writing the same logical software perf event and verifies each record appears exactly once.

## Validation

- `cmake --build build --target runtime -j$(nproc)`
- `cmake -S . -B build-perf-test -DBPFTIME_ENABLE_UNIT_TESTING=ON -DBPFTIME_ENABLE_CUDA_ATTACH=OFF -DCMAKE_BUILD_TYPE=RelWithDebInfo`
- `cmake --build build-perf-test --target bpftime_runtime_tests -j$(nproc)`
- `./build-perf-test/runtime/unit-test/bpftime_runtime_tests "[perf_event][software_perf_event]"`
- `./build-perf-test/runtime/unit-test/bpftime_runtime_tests '~Test tail calling from userspace to kernel' '~Test shm progs attach'`

Full `bpftime_runtime_tests` still has two environment-sensitive failures in this checkout: `Test shm progs attach` fails on a file-equivalence check with an empty path, and `Test tail calling from userspace to kernel` fails because map creation returns `-1` with errno `1`. The remaining 69 runtime test cases pass.
