### PR TITLE
[codex] support userspace bpf tail calls

### DIFF
--- a/runtime/src/bpf_helper.cpp
+++ b/runtime/src/bpf_helper.cpp
@@ -555,7 +555,6 @@ uint64_t bpf_perf_event_output(uint64_t ctx, uint64_t map, uint64_t flags,
 
 uint64_t bpftime_tail_call(uint64_t ctx, uint64_t prog_array, uint64_t index)
 {
-#ifdef BPFTIME_BUILD_WITH_LIBBPF
 	int fd = (int)prog_array;
 	if (!bpftime_is_prog_array(fd)) {
 		SPDLOG_ERROR("Expected fd {} to be a prog array fd", fd);
@@ -571,6 +570,78 @@ uint64_t bpftime_tail_call(uint64_t ctx, uint64_t prog_array, uint64_t index)
 	}
 	int to_call_fd = *to_call_id_ptr;
 	SPDLOG_DEBUG("tail call helper: calling prog fd {}", to_call_fd);
+
+	if (bpftime_is_prog_fd(to_call_fd)) {
+		constexpr uint32_t MAX_TAIL_CALL_CNT = 32;
+		static thread_local uint32_t tail_call_depth = 0;
+		if (tail_call_depth >= MAX_TAIL_CALL_CNT) {
+			SPDLOG_ERROR("tail call depth limit exceeded");
+			return -1;
+		}
+		struct tail_call_depth_guard {
+			uint32_t &depth;
+			explicit tail_call_depth_guard(uint32_t &depth)
+				: depth(depth)
+			{
+				depth++;
+			}
+			~tail_call_depth_guard()
+			{
+				depth--;
+			}
+		} guard(tail_call_depth);
+
+		const auto &handler = std::get<bpftime::bpf_prog_handler>(
+			bpftime::shm_holder.global_shared_memory.get_handler(
+				to_call_fd));
+		bpftime::agent_config config =
+			bpftime::bpftime_get_agent_config();
+		bpftime::bpftime_prog prog(handler.insns.data(),
+					   handler.insns.size(),
+					   handler.name.c_str());
+
+		if (config.enable_kernel_helper_group &&
+		    bpftime::bpftime_helper_group::get_kernel_utils_helper_group()
+				    .add_helper_group_to_prog(&prog) < 0) {
+			return -1;
+		}
+		if (config.enable_ufunc_helper_group &&
+		    bpftime::bpftime_helper_group::get_ufunc_helper_group()
+				    .add_helper_group_to_prog(&prog) < 0) {
+			return -1;
+		}
+		if (config.enable_shm_maps_helper_group &&
+		    bpftime::bpftime_helper_group::get_shm_maps_helper_group()
+				    .add_helper_group_to_prog(&prog) < 0) {
+			return -1;
+		}
+		if (prog.bpftime_prog_load(false) < 0) {
+			SPDLOG_ERROR(
+				"Failed to load userspace tail call target fd {}",
+				to_call_fd);
+			return -1;
+		}
+
+		char context[64];
+		if (ctx) {
+			memcpy(context, (const void *)(uintptr_t)ctx,
+			       sizeof(context));
+		} else {
+			memset(context, 0, sizeof(context));
+		}
+		uint64_t retval = 0;
+		int err = prog.bpftime_prog_exec(context, sizeof(context),
+						 &retval);
+		if (err < 0) {
+			SPDLOG_ERROR(
+				"Failed to execute userspace tail call target fd {}",
+				to_call_fd);
+			return -1;
+		}
+		return retval;
+	}
+
+#if __linux__ && defined(BPFTIME_BUILD_WITH_LIBBPF)
 	char context[64];
 	if (ctx) {
 		memcpy(context, (const void *)(uintptr_t)ctx, 64);
@@ -591,7 +662,9 @@ uint64_t bpftime_tail_call(uint64_t ctx, uint64_t prog_array, uint64_t index)
 	close(to_call_fd);
 	return run_opts.retval;
 #else
-	SPDLOG_ERROR("tail_call is not supported in this build");
+	SPDLOG_ERROR(
+		"tail_call to kernel program fd {} requires libbpf support",
+		to_call_fd);
 	return -ENOTSUP;
 #endif
 }

--- a/runtime/src/bpf_map/userspace/prog_array.cpp
+++ b/runtime/src/bpf_map/userspace/prog_array.cpp
@@ -13,7 +13,7 @@
 #elif __APPLE__
 #include "bpftime_epoll.h"
 #endif
-#include "spdlog/spdlog.h"
+#include "bpftime_shm.hpp"
 #include <bpf_map/userspace/prog_array.hpp>
 #include <cerrno>
 #include <spdlog/spdlog.h>
@@ -24,7 +24,6 @@
 #define offsetofend(TYPE, FIELD)                                               \
 	(offsetof(TYPE, FIELD) + sizeof(((TYPE *)0)->FIELD))
 #endif
-
 
 #if __linux__
 
@@ -80,13 +79,32 @@ int my_bpf_prog_get_fd_by_id(__u32 id)
 
 namespace bpftime
 {
-static thread_local uint32_t current_thread_lookup_val = 0;
+namespace
+{
+constexpr int32_t INVALID_ENTRY = -1;
+
+constexpr bool is_userspace_prog_fd_entry(int32_t value)
+{
+	return value < INVALID_ENTRY;
+}
+
+constexpr int32_t encode_userspace_prog_fd(int fd)
+{
+	return -fd - 2;
+}
+
+constexpr int decode_userspace_prog_fd(int32_t value)
+{
+	return -value - 2;
+}
+} // namespace
+
+static thread_local int32_t current_thread_lookup_val = 0;
 
 prog_array_map_impl::prog_array_map_impl(
 	boost::interprocess::managed_shared_memory &memory, uint32_t key_size,
 	uint32_t value_size, uint32_t max_entries)
-	// Default value of fd map is -1
-	: data(max_entries, -1, memory.get_segment_manager())
+	: data(max_entries, INVALID_ENTRY, memory.get_segment_manager())
 {
 	if (key_size != 4 || value_size != 4) {
 		throw std::runtime_error(
@@ -103,11 +121,27 @@ void *prog_array_map_impl::elem_lookup(const void *key)
 		errno = EINVAL;
 		return nullptr;
 	}
-	int fd = my_bpf_prog_get_fd_by_id(data[k]);
-	if (fd < 0) {
-		SPDLOG_ERROR("Unable to retrive prog fd of id {}", data[k]);
+	int32_t value = data[k];
+	if (value == INVALID_ENTRY) {
+		errno = ENOENT;
+		return nullptr;
 	}
-	SPDLOG_DEBUG("prog array: fd of prog id {} is {}", data[k], fd);
+	if (is_userspace_prog_fd_entry(value)) {
+		int fd = decode_userspace_prog_fd(value);
+		if (!bpftime_is_prog_fd(fd)) {
+			errno = ENOENT;
+			return nullptr;
+		}
+		current_thread_lookup_val = fd;
+		return &current_thread_lookup_val;
+	}
+	int fd = my_bpf_prog_get_fd_by_id(value);
+	if (fd < 0) {
+		SPDLOG_ERROR("Unable to retrieve prog fd of id {}", value);
+		errno = ENOENT;
+		return nullptr;
+	}
+	SPDLOG_DEBUG("prog array: fd of prog id {} is {}", value, fd);
 	current_thread_lookup_val = fd;
 	return &current_thread_lookup_val;
 }
@@ -121,6 +155,12 @@ long prog_array_map_impl::elem_update(const void *key, const void *value,
 		return -1;
 	}
 	int32_t v = *(int32_t *)value;
+	if (bpftime_is_prog_fd(v)) {
+		data[k] = encode_userspace_prog_fd(v);
+		SPDLOG_DEBUG("prog array: update slot {} to bpftime prog fd {}",
+			     k, v);
+		return 0;
+	}
 	struct bpf_prog_info info = {};
 	uint32_t len = sizeof(info);
 	int err = my_bpf_obj_get_info_by_fd(v, &info, &len);
@@ -145,7 +185,7 @@ long prog_array_map_impl::elem_delete(const void *key)
 		errno = EINVAL;
 		return -1;
 	}
-	data[k] = -1;
+	data[k] = INVALID_ENTRY;
 	return 0;
 }
 

--- a/runtime/src/bpf_map/userspace/prog_array.hpp
+++ b/runtime/src/bpf_map/userspace/prog_array.hpp
@@ -17,9 +17,8 @@ using i32_vec_allocator = boost::interprocess::allocator<
 using i32_vec = boost::interprocess::vector<int32_t, i32_vec_allocator>;
 class prog_array_map_impl {
     private:
-	// accept fd, but store id
-	// maps might be shared among processes, fd are process independent, but
-	// ids are shared
+	// Kernel programs are stored by id; bpftime programs use encoded fake
+	// fds because their handlers live in bpftime shared memory.
 	i32_vec data;
 
     public:

--- a/runtime/unit-test/CMakeLists.txt
+++ b/runtime/unit-test/CMakeLists.txt
@@ -42,6 +42,7 @@ set(TEST_SOURCES
     attach_with_ebpf/test_attach_replace.cpp
 
     tailcall/test_user_to_kernel_tailcall.cpp
+    tailcall/test_user_to_user_tailcall.cpp
 
 )
 if(${BPFTIME_ENABLE_CUDA_ATTACH})

--- a/runtime/unit-test/tailcall/test_user_to_user_tailcall.cpp
+++ b/runtime/unit-test/tailcall/test_user_to_user_tailcall.cpp
@@ -1,0 +1,78 @@
+#include "bpftime_helper_group.hpp"
+#include "bpftime_prog.hpp"
+#include "bpftime_shm.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <linux/filter.h>
+#include <unit-test/common_def.hpp>
+
+using namespace bpftime;
+
+static const char *SHM_NAME = "BPFTIME_USER_TO_USER_TAIL_CALL_TEST_SHM";
+static const int PROG_ARRAY_MAP_FD = 1001;
+static const int TAIL_CALL_TARGET_FD = 1002;
+
+TEST_CASE("Test tail calling from userspace to userspace")
+{
+	shm_remove remover(SHM_NAME);
+	bpftime_initialize_global_shm(
+		bpftime::shm_open_type::SHM_REMOVE_AND_CREATE);
+
+	REQUIRE(bpftime_maps_create(PROG_ARRAY_MAP_FD, "prog_array",
+				    bpftime::bpf_map_attr{
+					    .type = (int)bpftime::bpf_map_type::
+						    BPF_MAP_TYPE_PROG_ARRAY,
+					    .key_size = 4,
+					    .value_size = 4,
+					    .max_ents = 4 }) >= 0);
+
+	struct bpf_insn target_insn[] = {
+		BPF_MOV64_IMM(0, 0x1234),
+		BPF_EXIT_INSN(),
+	};
+	REQUIRE(bpftime_progs_create(TAIL_CALL_TARGET_FD,
+				     (const ebpf_inst *)target_insn,
+				     sizeof(target_insn) /
+					     sizeof(target_insn[0]),
+				     "tail_call_target",
+				     (int)bpftime::bpf_prog_type::
+					     BPF_PROG_TYPE_SOCKET_FILTER) >= 0);
+
+	{
+		int key = 0;
+		int value = TAIL_CALL_TARGET_FD;
+		REQUIRE(bpftime_map_update_elem(PROG_ARRAY_MAP_FD, &key, &value,
+						0) >= 0);
+	}
+
+	struct bpf_insn caller_insn[] = {
+		BPF_LD_IMM64_RAW_FULL(2, 0, 0, 0, PROG_ARRAY_MAP_FD, 0),
+		BPF_MOV64_IMM(3, 0),
+		BPF_EMIT_CALL(0x0c),
+		BPF_MOV64_IMM(0, 0xdead),
+		BPF_EXIT_INSN(),
+	};
+
+	bpftime::agent_config config;
+	config.set_vm_name("llvm");
+	bpftime_prog prog((const ebpf_inst *)caller_insn,
+			  sizeof(caller_insn) / sizeof(caller_insn[0]),
+			  "tail_call_caller",
+			  std::move(config));
+	REQUIRE(bpftime_helper_group::get_kernel_utils_helper_group()
+			.add_helper_group_to_prog(&prog) == 0);
+	REQUIRE(prog.bpftime_prog_load(false) == 0);
+
+	uint64_t ret = 0;
+	int ctx = 0;
+	REQUIRE(prog.bpftime_prog_exec(&ctx, sizeof(ctx), &ret) >= 0);
+	REQUIRE(ret == 0x1234);
+
+	{
+		int key = 0;
+		bpftime_close(TAIL_CALL_TARGET_FD);
+		REQUIRE(bpftime_map_lookup_elem(PROG_ARRAY_MAP_FD, &key) ==
+			nullptr);
+	}
+
+	bpftime_destroy_global_shm();
+}


### PR DESCRIPTION
## Summary
- Allow `BPF_MAP_TYPE_PROG_ARRAY` entries to store bpftime userspace program fds as well as kernel program ids, including stale userspace-fd validation on lookup.
- Teach `bpf_tail_call` to execute bpftime userspace tail-call targets while preserving the existing kernel `bpf_prog_test_run_opts` path.
- Add a userspace tail-call depth guard, copy the 64-byte context consistently with the kernel path, and cover the userspace-to-userspace path with a unit test.

## Testing
- `git diff --check`
- `cmake --build build --target bpftime_runtime_tests -j$(nproc)`
- `./build/runtime/unit-test/bpftime_runtime_tests "Test tail calling from userspace to userspace"`

Additional check attempted:
- `./build/runtime/unit-test/bpftime_runtime_tests "Test tail calling from userspace to kernel"` fails in this environment while creating the kernel BPF map with `errno=1` (`EPERM`).
