### PR TITLE
[codex] fix gpu example attach races

### DIFF
--- a/runtime/include/bpf_attach_ctx.hpp
+++ b/runtime/include/bpf_attach_ctx.hpp
@@ -207,6 +207,7 @@ private:
 #ifdef BPFTIME_ENABLE_CUDA_ATTACH
 	// Start host thread for handling map requests from CUDA
 	void start_cuda_watcher_thread();
+	void stop_cuda_watcher_thread();
 	std::unique_ptr<cuda::CUDAContext> cuda_ctx;
 	std::thread cuda_watcher_thread;
 #endif

--- a/runtime/src/attach/bpf_attach_ctx.cpp
+++ b/runtime/src/attach/bpf_attach_ctx.cpp
@@ -163,9 +163,7 @@ bpf_attach_ctx::~bpf_attach_ctx()
 	SPDLOG_INFO("Destructor: bpf_attach_ctx");
 #ifdef BPFTIME_ENABLE_CUDA_ATTACH
 	if (cuda_ctx) {
-		cuda_ctx->cuda_watcher_should_stop->store(true);
-		if (cuda_watcher_thread.joinable())
-			cuda_watcher_thread.join();
+		stop_cuda_watcher_thread();
 	}
 #endif
 }

--- a/runtime/src/attach/bpf_attach_ctx_cuda.cpp
+++ b/runtime/src/attach/bpf_attach_ctx_cuda.cpp
@@ -7,6 +7,7 @@
 #include <optional>
 #include <cstdlib>
 #include <mutex>
+#include <system_error>
 #include <thread>
 #include <spdlog/spdlog.h>
 #include "cuda.h"
@@ -279,6 +280,38 @@ void bpf_attach_ctx::start_cuda_watcher_thread()
 		std::lock_guard<std::mutex> guard(g_cuda_watcher_mutex);
 		g_cuda_watcher_thread = &cuda_watcher_thread;
 		g_cuda_watcher_stop_flag = flag;
+	}
+}
+
+void bpf_attach_ctx::stop_cuda_watcher_thread()
+{
+	if (!cuda_ctx)
+		return;
+	auto flag = cuda_ctx->cuda_watcher_should_stop;
+	if (flag)
+		flag->store(true, std::memory_order_release);
+	{
+		std::lock_guard<std::mutex> guard(g_cuda_watcher_mutex);
+		if (g_cuda_watcher_thread == &cuda_watcher_thread) {
+			g_cuda_watcher_thread = nullptr;
+			g_cuda_watcher_stop_flag.reset();
+		}
+	}
+	if (cuda_watcher_thread.joinable()) {
+		try {
+			cuda_watcher_thread.join();
+		} catch (const std::system_error &ex) {
+			SPDLOG_WARN("Failed to join CUDA watcher thread: {}",
+				    ex.what());
+			try {
+				if (cuda_watcher_thread.joinable())
+					cuda_watcher_thread.detach();
+			} catch (const std::system_error &detach_ex) {
+				SPDLOG_WARN(
+					"Failed to detach CUDA watcher thread after join failure: {}",
+					detach_ex.what());
+			}
+		}
 	}
 }
 std::vector<attach::MapBasicInfo>

--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -745,6 +745,11 @@ bpftime_shm::bpftime_shm(const char *shm_name, shm_open_type type)
 	if (open_type == shm_open_type::SHM_OPEN_ONLY) {
 		auto pair = segment.find<cuda::CommSharedMem>(
 			"cuda_comm_shared_mem");
+		for (int i = 0; pair.first == nullptr && i < 100; i++) {
+			usleep(10000);
+			pair = segment.find<cuda::CommSharedMem>(
+				"cuda_comm_shared_mem");
+		}
 		if (pair.first == nullptr) {
 			SPDLOG_ERROR(
 				"CommSharedMem not found in shared memory; did syscall-server initialize CUDA support?");
@@ -755,7 +760,8 @@ bpftime_shm::bpftime_shm(const char *shm_name, shm_open_type type)
 		// Register the shared communication memory for CUDA device
 		// mapping. This must happen after we have located the
 		// CommSharedMem in the shared segment.
-		register_cuda_host_memory();
+		if (cuda_comm_shared_mem != nullptr)
+			register_cuda_host_memory();
 	} else {
 		auto pair = segment.find<cuda::CommSharedMem>(
 			"cuda_comm_shared_mem");

--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -115,9 +115,20 @@ syscall_context::syscall_context()
 	SPDLOG_INFO("The log will be written to: {}",
 		    runtime_config.get_logger_output_path());
 	spdlog::cfg::load_env_levels();
+}
+
 #ifdef BPFTIME_ENABLE_CUDA_ATTACH
+void syscall_context::initialize_cuda()
+{
 	SPDLOG_INFO("Initializing CUDA at syscall-server side");
-	initializing_cuda = true;
+	initializing_cuda.store(true, std::memory_order_release);
+	struct cuda_init_guard {
+		std::atomic<bool> &flag;
+		~cuda_init_guard()
+		{
+			flag.store(false, std::memory_order_release);
+		}
+	} guard{ initializing_cuda };
 	if (auto err = cuInit(0); err != CUDA_SUCCESS) {
 		SPDLOG_ERROR(
 			"Unable to initialize CUDA from syscall server side: {}",
@@ -126,9 +137,8 @@ syscall_context::syscall_context()
 			"Unable to initialize CUDA from syscall server side");
 	}
 	SPDLOG_INFO("CUDA initialized at syscall server side");
-	initializing_cuda = false;
-#endif
 }
+#endif
 
 void syscall_context::try_startup()
 {
@@ -139,7 +149,9 @@ void syscall_context::try_startup()
 
 int syscall_context::handle_close(int fd)
 {
-	if (!enable_mock || initializing_cuda || !enable_mock_after_initialized)
+	if (!enable_mock ||
+	    initializing_cuda.load(std::memory_order_acquire) ||
+	    !enable_mock_after_initialized)
 		return orig_close_fn(fd);
 	SPDLOG_DEBUG("Calling mocked close");
 	try_startup();
@@ -159,7 +171,9 @@ int syscall_context::handle_close(int fd)
 int syscall_context::handle_openat(int fd, const char *file, int oflag,
 				   unsigned short mode)
 {
-	if (!enable_mock || initializing_cuda || !enable_mock_after_initialized)
+	if (!enable_mock ||
+	    initializing_cuda.load(std::memory_order_acquire) ||
+	    !enable_mock_after_initialized)
 		return orig_openat_fn(fd, file, oflag, mode);
 	try_startup();
 	auto path = resolve_filename_and_fd_to_full_path(fd, file);
@@ -186,7 +200,9 @@ int syscall_context::handle_openat(int fd, const char *file, int oflag,
 int syscall_context::handle_open(const char *file, int oflag,
 				 unsigned short mode)
 {
-	if (!enable_mock || initializing_cuda || !enable_mock_after_initialized)
+	if (!enable_mock ||
+	    initializing_cuda.load(std::memory_order_acquire) ||
+	    !enable_mock_after_initialized)
 		return orig_open_fn(file, oflag, mode);
 	SPDLOG_DEBUG("Calling mocked open");
 	try_startup();
@@ -207,7 +223,9 @@ int syscall_context::handle_open(const char *file, int oflag,
 
 ssize_t syscall_context::handle_read(int fd, void *buf, size_t count)
 {
-	if (!enable_mock || initializing_cuda || !enable_mock_after_initialized)
+	if (!enable_mock ||
+	    initializing_cuda.load(std::memory_order_acquire) ||
+	    !enable_mock_after_initialized)
 		return orig_read_fn(fd, buf, count);
 	SPDLOG_DEBUG("Calling mocked read");
 	try_startup();
@@ -354,7 +372,9 @@ int syscall_context::create_kernel_bpf_prog_in_userspace(int cmd,
 
 long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 {
-	if (!enable_mock || initializing_cuda || !enable_mock_after_initialized)
+	if (!enable_mock ||
+	    initializing_cuda.load(std::memory_order_acquire) ||
+	    !enable_mock_after_initialized)
 		return orig_syscall_fn(__NR_bpf, (long)cmd,
 				       (long)(uintptr_t)attr, (long)size);
 	try_startup();
@@ -674,7 +694,9 @@ long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 int syscall_context::handle_perfevent(perf_event_attr *attr, pid_t pid, int cpu,
 				      int group_fd, unsigned long flags)
 {
-	if (!enable_mock || initializing_cuda || !enable_mock_after_initialized)
+	if (!enable_mock ||
+	    initializing_cuda.load(std::memory_order_acquire) ||
+	    !enable_mock_after_initialized)
 		return orig_syscall_fn(__NR_perf_event_open,
 				       (uint64_t)(uintptr_t)attr, (uint64_t)pid,
 				       (uint64_t)cpu, (uint64_t)group_fd,
@@ -803,7 +825,8 @@ int syscall_context::handle_perfevent(perf_event_attr *attr, pid_t pid, int cpu,
 void *syscall_context::handle_mmap(void *addr, size_t length, int prot,
 				   int flags, int fd, off64_t offset)
 {
-	if (!enable_mock || run_with_kernel || initializing_cuda ||
+	if (!enable_mock || run_with_kernel ||
+	    initializing_cuda.load(std::memory_order_acquire) ||
 	    !enable_mock_after_initialized)
 		return orig_mmap_fn(addr, length, prot, flags, fd, offset);
 	try_startup();
@@ -814,7 +837,8 @@ void *syscall_context::handle_mmap(void *addr, size_t length, int prot,
 void *syscall_context::handle_mmap64(void *addr, size_t length, int prot,
 				     int flags, int fd, off64_t offset)
 {
-	if (!enable_mock || run_with_kernel || initializing_cuda)
+	if (!enable_mock || run_with_kernel ||
+	    initializing_cuda.load(std::memory_order_acquire))
 		return orig_mmap64_fn(addr, length, prot, flags, fd, offset);
 	try_startup();
 	SPDLOG_DEBUG("Calling mocked mmap64");
@@ -867,11 +891,12 @@ void *syscall_context::handle_mmap64(void *addr, size_t length, int prot,
 
 int syscall_context::handle_ioctl(int fd, unsigned long req, unsigned long data)
 {
-	if (!enable_mock || initializing_cuda ||
-	    !enable_mock_after_initialized) {
+	bool cuda_initializing =
+		initializing_cuda.load(std::memory_order_acquire);
+	if (!enable_mock || cuda_initializing || !enable_mock_after_initialized) {
 		SPDLOG_DEBUG(
 			"Calling original ioctl, enable_lock={}, initializing_cuda={}",
-			enable_mock, initializing_cuda);
+			enable_mock, cuda_initializing);
 		return orig_ioctl_fn(fd, req, data);
 	}
 	SPDLOG_DEBUG("Calling mocked ioctl..");
@@ -924,7 +949,8 @@ int syscall_context::handle_ioctl(int fd, unsigned long req, unsigned long data)
 
 int syscall_context::handle_epoll_create1(int flags)
 {
-	if (!enable_mock || run_with_kernel || initializing_cuda ||
+	if (!enable_mock || run_with_kernel ||
+	    initializing_cuda.load(std::memory_order_acquire) ||
 	    !enable_mock_after_initialized)
 		return orig_epoll_create1_fn(flags);
 	try_startup();
@@ -963,7 +989,8 @@ int syscall_context::handle_epoll_ctl(int epfd, int op, int fd,
 int syscall_context::handle_epoll_wait(int epfd, epoll_event *evt,
 				       int maxevents, int timeout)
 {
-	if (!enable_mock || run_with_kernel || initializing_cuda ||
+	if (!enable_mock || run_with_kernel ||
+	    initializing_cuda.load(std::memory_order_acquire) ||
 	    !enable_mock_after_initialized)
 		return orig_epoll_wait_fn(epfd, evt, maxevents, timeout);
 	try_startup();
@@ -975,7 +1002,8 @@ int syscall_context::handle_epoll_wait(int epfd, epoll_event *evt,
 
 int syscall_context::handle_munmap(void *addr, size_t size)
 {
-	if (!enable_mock || run_with_kernel || initializing_cuda ||
+	if (!enable_mock || run_with_kernel ||
+	    initializing_cuda.load(std::memory_order_acquire) ||
 	    !enable_mock_after_initialized)
 		return orig_munmap_fn(addr, size);
 	try_startup();
@@ -992,7 +1020,9 @@ int syscall_context::handle_munmap(void *addr, size_t size)
 
 FILE *syscall_context::handle_fopen(const char *pathname, const char *flags)
 {
-	if (!enable_mock || initializing_cuda || !enable_mock_after_initialized)
+	if (!enable_mock ||
+	    initializing_cuda.load(std::memory_order_acquire) ||
+	    !enable_mock_after_initialized)
 		return orig_fopen_fn(pathname, flags);
 	SPDLOG_DEBUG("Calling mocked fopen");
 	try_startup();
@@ -1024,7 +1054,8 @@ FILE *syscall_context::handle_fopen(const char *pathname, const char *flags)
 int syscall_context::handle_dup3(int oldfd, int newfd, int flags)
 {
 	SPDLOG_DEBUG("Calling mocked dup3 {}, {}", oldfd, newfd);
-	if (!enable_mock || run_with_kernel || initializing_cuda ||
+	if (!enable_mock || run_with_kernel ||
+	    initializing_cuda.load(std::memory_order_acquire) ||
 	    !enable_mock_after_initialized)
 		return orig_syscall_fn(__NR_dup3, (long)oldfd, (long)newfd,
 				       (long)flags);
@@ -1039,7 +1070,8 @@ int syscall_context::handle_dup3(int oldfd, int newfd, int flags)
 int syscall_context::handle_memfd_create(const char *name, int flags)
 {
 	SPDLOG_DEBUG("Calling mocked memfd_create {}, {}", name, flags);
-	if (!enable_mock || initializing_cuda ||
+	if (!enable_mock ||
+	    initializing_cuda.load(std::memory_order_acquire) ||
 	    !enable_mock_after_initialized) {
 		SPDLOG_DEBUG("Calling original dup3");
 		return orig_syscall_fn(__NR_dup3, (long)name, (long)flags);

--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -142,16 +142,16 @@ void syscall_context::initialize_cuda()
 
 void syscall_context::try_startup()
 {
-	enable_mock = false;
+	enable_mock.store(false, std::memory_order_relaxed);
 	start_up(*this);
-	enable_mock = true;
+	enable_mock.store(true, std::memory_order_relaxed);
 }
 
 int syscall_context::handle_close(int fd)
 {
-	if (!enable_mock ||
+	if (!enable_mock.load(std::memory_order_relaxed) ||
 	    initializing_cuda.load(std::memory_order_acquire) ||
-	    !enable_mock_after_initialized)
+	    !enable_mock_after_initialized.load(std::memory_order_relaxed))
 		return orig_close_fn(fd);
 	SPDLOG_DEBUG("Calling mocked close");
 	try_startup();
@@ -171,9 +171,9 @@ int syscall_context::handle_close(int fd)
 int syscall_context::handle_openat(int fd, const char *file, int oflag,
 				   unsigned short mode)
 {
-	if (!enable_mock ||
+	if (!enable_mock.load(std::memory_order_relaxed) ||
 	    initializing_cuda.load(std::memory_order_acquire) ||
-	    !enable_mock_after_initialized)
+	    !enable_mock_after_initialized.load(std::memory_order_relaxed))
 		return orig_openat_fn(fd, file, oflag, mode);
 	try_startup();
 	auto path = resolve_filename_and_fd_to_full_path(fd, file);
@@ -200,9 +200,9 @@ int syscall_context::handle_openat(int fd, const char *file, int oflag,
 int syscall_context::handle_open(const char *file, int oflag,
 				 unsigned short mode)
 {
-	if (!enable_mock ||
+	if (!enable_mock.load(std::memory_order_relaxed) ||
 	    initializing_cuda.load(std::memory_order_acquire) ||
-	    !enable_mock_after_initialized)
+	    !enable_mock_after_initialized.load(std::memory_order_relaxed))
 		return orig_open_fn(file, oflag, mode);
 	SPDLOG_DEBUG("Calling mocked open");
 	try_startup();
@@ -223,9 +223,9 @@ int syscall_context::handle_open(const char *file, int oflag,
 
 ssize_t syscall_context::handle_read(int fd, void *buf, size_t count)
 {
-	if (!enable_mock ||
+	if (!enable_mock.load(std::memory_order_relaxed) ||
 	    initializing_cuda.load(std::memory_order_acquire) ||
-	    !enable_mock_after_initialized)
+	    !enable_mock_after_initialized.load(std::memory_order_relaxed))
 		return orig_read_fn(fd, buf, count);
 	SPDLOG_DEBUG("Calling mocked read");
 	try_startup();
@@ -372,9 +372,9 @@ int syscall_context::create_kernel_bpf_prog_in_userspace(int cmd,
 
 long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 {
-	if (!enable_mock ||
+	if (!enable_mock.load(std::memory_order_relaxed) ||
 	    initializing_cuda.load(std::memory_order_acquire) ||
-	    !enable_mock_after_initialized)
+	    !enable_mock_after_initialized.load(std::memory_order_relaxed))
 		return orig_syscall_fn(__NR_bpf, (long)cmd,
 				       (long)(uintptr_t)attr, (long)size);
 	try_startup();
@@ -694,9 +694,9 @@ long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 int syscall_context::handle_perfevent(perf_event_attr *attr, pid_t pid, int cpu,
 				      int group_fd, unsigned long flags)
 {
-	if (!enable_mock ||
+	if (!enable_mock.load(std::memory_order_relaxed) ||
 	    initializing_cuda.load(std::memory_order_acquire) ||
-	    !enable_mock_after_initialized)
+	    !enable_mock_after_initialized.load(std::memory_order_relaxed))
 		return orig_syscall_fn(__NR_perf_event_open,
 				       (uint64_t)(uintptr_t)attr, (uint64_t)pid,
 				       (uint64_t)cpu, (uint64_t)group_fd,
@@ -825,9 +825,9 @@ int syscall_context::handle_perfevent(perf_event_attr *attr, pid_t pid, int cpu,
 void *syscall_context::handle_mmap(void *addr, size_t length, int prot,
 				   int flags, int fd, off64_t offset)
 {
-	if (!enable_mock || run_with_kernel ||
+	if (!enable_mock.load(std::memory_order_relaxed) || run_with_kernel ||
 	    initializing_cuda.load(std::memory_order_acquire) ||
-	    !enable_mock_after_initialized)
+	    !enable_mock_after_initialized.load(std::memory_order_relaxed))
 		return orig_mmap_fn(addr, length, prot, flags, fd, offset);
 	try_startup();
 	SPDLOG_DEBUG("Called normal mmap");
@@ -837,7 +837,7 @@ void *syscall_context::handle_mmap(void *addr, size_t length, int prot,
 void *syscall_context::handle_mmap64(void *addr, size_t length, int prot,
 				     int flags, int fd, off64_t offset)
 {
-	if (!enable_mock || run_with_kernel ||
+	if (!enable_mock.load(std::memory_order_relaxed) || run_with_kernel ||
 	    initializing_cuda.load(std::memory_order_acquire))
 		return orig_mmap64_fn(addr, length, prot, flags, fd, offset);
 	try_startup();
@@ -893,10 +893,12 @@ int syscall_context::handle_ioctl(int fd, unsigned long req, unsigned long data)
 {
 	bool cuda_initializing =
 		initializing_cuda.load(std::memory_order_acquire);
-	if (!enable_mock || cuda_initializing || !enable_mock_after_initialized) {
+	bool mock_enabled = enable_mock.load(std::memory_order_relaxed);
+	if (!mock_enabled || cuda_initializing ||
+	    !enable_mock_after_initialized.load(std::memory_order_relaxed)) {
 		SPDLOG_DEBUG(
 			"Calling original ioctl, enable_lock={}, initializing_cuda={}",
-			enable_mock, cuda_initializing);
+			mock_enabled, cuda_initializing);
 		return orig_ioctl_fn(fd, req, data);
 	}
 	SPDLOG_DEBUG("Calling mocked ioctl..");
@@ -949,9 +951,9 @@ int syscall_context::handle_ioctl(int fd, unsigned long req, unsigned long data)
 
 int syscall_context::handle_epoll_create1(int flags)
 {
-	if (!enable_mock || run_with_kernel ||
+	if (!enable_mock.load(std::memory_order_relaxed) || run_with_kernel ||
 	    initializing_cuda.load(std::memory_order_acquire) ||
-	    !enable_mock_after_initialized)
+	    !enable_mock_after_initialized.load(std::memory_order_relaxed))
 		return orig_epoll_create1_fn(flags);
 	try_startup();
 	return bpftime_epoll_create();
@@ -960,7 +962,8 @@ int syscall_context::handle_epoll_create1(int flags)
 int syscall_context::handle_epoll_ctl(int epfd, int op, int fd,
 				      epoll_event *evt)
 {
-	if (!enable_mock || run_with_kernel || !enable_mock_after_initialized)
+	if (!enable_mock.load(std::memory_order_relaxed) || run_with_kernel ||
+	    !enable_mock_after_initialized.load(std::memory_order_relaxed))
 		return orig_epoll_ctl_fn(epfd, op, fd, evt);
 	try_startup();
 	if (op == EPOLL_CTL_ADD) {
@@ -989,9 +992,9 @@ int syscall_context::handle_epoll_ctl(int epfd, int op, int fd,
 int syscall_context::handle_epoll_wait(int epfd, epoll_event *evt,
 				       int maxevents, int timeout)
 {
-	if (!enable_mock || run_with_kernel ||
+	if (!enable_mock.load(std::memory_order_relaxed) || run_with_kernel ||
 	    initializing_cuda.load(std::memory_order_acquire) ||
-	    !enable_mock_after_initialized)
+	    !enable_mock_after_initialized.load(std::memory_order_relaxed))
 		return orig_epoll_wait_fn(epfd, evt, maxevents, timeout);
 	try_startup();
 	if (bpftime_is_epoll_handler(epfd)) {
@@ -1002,9 +1005,9 @@ int syscall_context::handle_epoll_wait(int epfd, epoll_event *evt,
 
 int syscall_context::handle_munmap(void *addr, size_t size)
 {
-	if (!enable_mock || run_with_kernel ||
+	if (!enable_mock.load(std::memory_order_relaxed) || run_with_kernel ||
 	    initializing_cuda.load(std::memory_order_acquire) ||
-	    !enable_mock_after_initialized)
+	    !enable_mock_after_initialized.load(std::memory_order_relaxed))
 		return orig_munmap_fn(addr, size);
 	try_startup();
 	if (auto itr = mocked_mmap_values.find((uintptr_t)addr);
@@ -1020,9 +1023,9 @@ int syscall_context::handle_munmap(void *addr, size_t size)
 
 FILE *syscall_context::handle_fopen(const char *pathname, const char *flags)
 {
-	if (!enable_mock ||
+	if (!enable_mock.load(std::memory_order_relaxed) ||
 	    initializing_cuda.load(std::memory_order_acquire) ||
-	    !enable_mock_after_initialized)
+	    !enable_mock_after_initialized.load(std::memory_order_relaxed))
 		return orig_fopen_fn(pathname, flags);
 	SPDLOG_DEBUG("Calling mocked fopen");
 	try_startup();
@@ -1054,9 +1057,9 @@ FILE *syscall_context::handle_fopen(const char *pathname, const char *flags)
 int syscall_context::handle_dup3(int oldfd, int newfd, int flags)
 {
 	SPDLOG_DEBUG("Calling mocked dup3 {}, {}", oldfd, newfd);
-	if (!enable_mock || run_with_kernel ||
+	if (!enable_mock.load(std::memory_order_relaxed) || run_with_kernel ||
 	    initializing_cuda.load(std::memory_order_acquire) ||
-	    !enable_mock_after_initialized)
+	    !enable_mock_after_initialized.load(std::memory_order_relaxed))
 		return orig_syscall_fn(__NR_dup3, (long)oldfd, (long)newfd,
 				       (long)flags);
 	try_startup();
@@ -1070,9 +1073,9 @@ int syscall_context::handle_dup3(int oldfd, int newfd, int flags)
 int syscall_context::handle_memfd_create(const char *name, int flags)
 {
 	SPDLOG_DEBUG("Calling mocked memfd_create {}, {}", name, flags);
-	if (!enable_mock ||
+	if (!enable_mock.load(std::memory_order_relaxed) ||
 	    initializing_cuda.load(std::memory_order_acquire) ||
-	    !enable_mock_after_initialized) {
+	    !enable_mock_after_initialized.load(std::memory_order_relaxed)) {
 		SPDLOG_DEBUG("Calling original dup3");
 		return orig_syscall_fn(__NR_dup3, (long)name, (long)flags);
 	}

--- a/runtime/syscall-server/syscall_context.hpp
+++ b/runtime/syscall-server/syscall_context.hpp
@@ -20,6 +20,7 @@
 #include <spdlog/spdlog.h>
 #include <unordered_set>
 #include <pthread.h>
+#include <atomic>
 #include <future>
 #include <thread>
 // #include "pos/include/common.h"
@@ -156,7 +157,7 @@ class syscall_context {
 	// enable mock the syscall behavior in userspace
 	bool enable_mock = true;
 	// Initializing CUDA
-	bool initializing_cuda = false;
+	std::atomic<bool> initializing_cuda{ false };
 	// Whether enable mock after syscall server has been initialized
 	bool enable_mock_after_initialized = true;
 	syscall_context();
@@ -191,6 +192,7 @@ class syscall_context {
 	int handle_memfd_create(const char *name, int flags);
 
 #if defined(BPFTIME_ENABLE_CUDA_ATTACH)
+	void initialize_cuda();
 	int poll_gpu_ringbuf_map(int mapfd, void *ctx,
 
 				 void (*)(const void *, uint64_t, void *));

--- a/runtime/syscall-server/syscall_context.hpp
+++ b/runtime/syscall-server/syscall_context.hpp
@@ -155,11 +155,11 @@ class syscall_context {
 
     public:
 	// enable mock the syscall behavior in userspace
-	bool enable_mock = true;
+	std::atomic<bool> enable_mock{ true };
 	// Initializing CUDA
 	std::atomic<bool> initializing_cuda{ false };
 	// Whether enable mock after syscall server has been initialized
-	bool enable_mock_after_initialized = true;
+	std::atomic<bool> enable_mock_after_initialized{ true };
 	syscall_context();
 	virtual ~syscall_context()
 	{

--- a/runtime/syscall-server/syscall_server_utils.cpp
+++ b/runtime/syscall-server/syscall_server_utils.cpp
@@ -50,6 +50,9 @@ void start_up(syscall_context &ctx)
 
 		bpftime_initialize_global_shm(
 			shm_open_type::SHM_CREATE_OR_OPEN);
+#if defined(BPFTIME_ENABLE_CUDA_ATTACH)
+		ctx.initialize_cuda();
+#endif
 		shm_holder.global_shared_memory.begin_new_session();
 		shm_holder.global_shared_memory.set_mock_setter([&](bool flg) {
 			ctx.enable_mock_after_initialized = flg;

--- a/runtime/syscall-server/syscall_server_utils.cpp
+++ b/runtime/syscall-server/syscall_server_utils.cpp
@@ -55,10 +55,11 @@ void start_up(syscall_context &ctx)
 #endif
 		shm_holder.global_shared_memory.begin_new_session();
 		shm_holder.global_shared_memory.set_mock_setter([&](bool flg) {
-			ctx.enable_mock_after_initialized = flg;
+			ctx.enable_mock_after_initialized.store(
+				flg, std::memory_order_relaxed);
 			SPDLOG_INFO(
 				"syscall server: Set enable_mock_after_initialized to {}",
-				ctx.enable_mock_after_initialized);
+				flg);
 		});
 #ifdef ENABLE_BPFTIME_VERIFIER
 		std::vector<int32_t> helper_ids;


### PR DESCRIPTION
## Summary

Fix GPU example startup/teardown races in the existing runtime and syscall-server path. This PR keeps the change scoped to runtime/shared-memory coordination; it does **not** add the PTX pass subprocess runner from #583.

What changed:

- Move syscall-server CUDA initialization out of `syscall_context` construction and run it after global shared memory is created.
- Guard CUDA initialization with an atomic `initializing_cuda` flag so intercepted syscalls fall back to the real libc/syscall path during CUDA startup.
- Retry `cuda_comm_shared_mem` lookup for `SHM_OPEN_ONLY` clients before registering CUDA host memory, covering the window where the shared segment exists but the CUDA communication object is not visible yet.
- Stop and clear the CUDA watcher thread state before `bpf_attach_ctx` teardown, including the global atexit pointer/stop flag, to avoid stale watcher-thread state at process exit.

## Why

Several GPU examples exposed races around startup and process teardown:

- The syscall server could initialize CUDA before shared memory/CUDA communication memory was ready.
- Clients could attach to the shared memory segment before `cuda_comm_shared_mem` had been constructed.
- CUDA initialization itself could trigger intercepted syscalls and recurse into bpftime startup/mocking.
- Direct-run style examples could leave stale CUDA watcher-thread globals during teardown.

Together these showed up as flaky GPU example startup, dynamic attach failures, or exit-time aborts.

## Scope

This PR changes only runtime/syscall-server/shared-memory code:

- `runtime/syscall-server/*`
- `runtime/src/bpftime_shm_internal.cpp`
- `runtime/src/attach/bpf_attach_ctx*.cpp`
- `runtime/include/bpf_attach_ctx.hpp`

The PTX pass isolation runner is intentionally split out into #583 and is not required for this PR to work.

## Validation

- CI is green for #582, including runtime, attach, tools, integrated examples, PTX pass executable checks, and GPU example workflow.
- GPU examples passed in CI, including `atomizer`, `kernel_trace`, `gpu_shared_map`, `threadscheduling`, `threadscheduling_dynamic_hook`, `cudagraph`, `threadhist-gpu-kernel-shared-map`, `directly_run_on_gpu`, `kernelretsnoop`, `threadhist`, `cuda-counter`, `launchlate`, `launchlate-kernel-gpu-shared-map`, `mem_trace`, `host_map_test`, and `cutlass`.
- Non-GPU integrated examples also pass in CI. Local no-GPU smoke covered `malloc`, `minimal`, `queue_demo`, `stack_demo`, `bloom_filter_demo`, `get_stack_id_example`, and `lpm_trie_demo`.