### PR TITLE
refactor: isolate PTX pass execution in runner

### DIFF
--- a/attach/nv_attach_impl/CMakeLists.txt
+++ b/attach/nv_attach_impl/CMakeLists.txt
@@ -6,6 +6,10 @@ add_subdirectory(pass/ptxpass_kprobe_entry)
 add_subdirectory(pass/ptxpass_kretprobe)
 add_subdirectory(pass/ptxpass_kprobe_memcapture)
 
+add_executable(bpftime_ptxpass_runner pass/ptxpass_runner.cpp)
+target_link_libraries(bpftime_ptxpass_runner PRIVATE ${CMAKE_DL_LIBS})
+set_property(TARGET bpftime_ptxpass_runner PROPERTY CXX_STANDARD 20)
+
 list(APPEND PTX_PASS_EXECUTABLE $<TARGET_FILE:ptxpass_kprobe_entry>)
 list(APPEND PTX_PASS_EXECUTABLE $<TARGET_FILE:ptxpass_kretprobe>)
 list(APPEND PTX_PASS_EXECUTABLE $<TARGET_FILE:ptxpass_kprobe_memcapture>)
@@ -42,6 +46,7 @@ add_dependencies(
     ptxpass_kprobe_entry
     ptxpass_kretprobe
     ptxpass_kprobe_memcapture
+    bpftime_ptxpass_runner
     nv_attach_impl_ptx_compiler
 )
 set(NV_ATTACH_IMPL_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR} )
@@ -69,7 +74,7 @@ endif()
 # Create a build-time header file with the PTX pass paths
 # This avoids shell escaping issues with colons and quotes
 file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/ptx_pass_config.h"
-     CONTENT "#pragma once\nstatic constexpr const char *DEFAULT_PTX_PASS_EXECUTABLE = \"$<JOIN:${PTX_PASS_EXECUTABLE},:>\";static constexpr const char* DEFAULT_PTX_COMPILER_SHARED_LIB=\"$<JOIN:${PTX_COMPILER_SHARED_LIB},:>\";\n")
+     CONTENT "#pragma once\nstatic constexpr const char *DEFAULT_PTX_PASS_EXECUTABLE = \"$<JOIN:${PTX_PASS_EXECUTABLE},:>\";static constexpr const char *DEFAULT_PTX_PASS_RUNNER_EXECUTABLE = \"$<TARGET_FILE:bpftime_ptxpass_runner>\";static constexpr const char* DEFAULT_PTX_COMPILER_SHARED_LIB=\"$<JOIN:${PTX_COMPILER_SHARED_LIB},:>\";\n")
 
 
 target_link_options(bpftime_nv_attach_impl PUBLIC "-Wl,--whole-archive" "$<TARGET_FILE:bpftime_nv_attach_impl>" "-Wl,--no-whole-archive")

--- a/attach/nv_attach_impl/nv_attach_impl.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl.cpp
@@ -12,7 +12,6 @@
 // #include "spdlog/common.h"
 #include "spdlog/spdlog.h"
 #include <asm/unistd.h> // For architecture-specific syscall numbers
-#include <boost/asio/io_context.hpp>
 #include <boost/asio/post.hpp>
 #include <boost/asio/thread_pool.hpp>
 #include <boost/process.hpp>
@@ -55,6 +54,7 @@
 #include <variant>
 #include <vector>
 #include <atomic>
+#include <cerrno>
 #include <optional>
 #include <thread>
 #include "ptxpass/core.hpp"
@@ -78,6 +78,238 @@ struct nv_attach_hook_state_holder {
 };
 
 static nv_attach_hook_state_holder g_nv_attach_hook_state_holder{};
+constexpr size_t kPtxPassConfigOutputBytes = 10U << 20;
+constexpr size_t kInitialPtxPassProcessOutputBytes = 1U << 20;
+constexpr size_t kMaxPtxPassProcessOutputBytes = 64U << 20;
+
+static std::optional<std::string>
+run_ptxpass_runner(const std::string &mode,
+		   const std::filesystem::path &pass_library,
+		   const std::string *stdin_payload,
+		   std::optional<size_t> output_bytes = std::nullopt)
+{
+	const char *configured_runner = getenv("BPFTIME_PTXPASS_RUNNER");
+	const bool using_configured_runner =
+		configured_runner && configured_runner[0] != '\0';
+	std::filesystem::path runner_path =
+		using_configured_runner ? configured_runner
+			: DEFAULT_PTX_PASS_RUNNER_EXECUTABLE;
+	char tmp_dir_template[] = "/tmp/bpftime-ptxpass-runner.XXXXXX";
+	char *tmp_dir_c = mkdtemp(tmp_dir_template);
+	if (tmp_dir_c == nullptr) {
+		SPDLOG_ERROR("mkdtemp failed for PTX pass runner: {}",
+			     strerror(errno));
+		return std::nullopt;
+	}
+	struct tmp_dir_guard {
+		std::filesystem::path path;
+		~tmp_dir_guard()
+		{
+			std::error_code ec;
+			std::filesystem::remove_all(path, ec);
+		}
+	} guard{ std::filesystem::path(tmp_dir_c) };
+
+	auto stdin_path = guard.path / "stdin.json";
+	auto stdout_path = guard.path / "stdout.json";
+	auto stderr_path = guard.path / "stderr.log";
+	{
+		std::ofstream ofs(stdin_path);
+		if (!ofs.is_open()) {
+			SPDLOG_ERROR("Unable to create PTX pass runner input {}",
+				     stdin_path.c_str());
+			return std::nullopt;
+		}
+		if (stdin_payload != nullptr)
+			ofs << *stdin_payload;
+		ofs.flush();
+		if (!ofs.good()) {
+			SPDLOG_ERROR("Unable to write PTX pass runner input {}",
+				     stdin_path.c_str());
+			return std::nullopt;
+		}
+	}
+
+	if (!using_configured_runner &&
+	    access(runner_path.c_str(), X_OK) != 0 && errno == EACCES) {
+		std::error_code ec;
+		std::filesystem::permissions(
+			runner_path, std::filesystem::perms::owner_exec,
+			std::filesystem::perm_options::add, ec);
+		if (ec) {
+			SPDLOG_WARN(
+				"Unable to add execute permission to PTX pass runner {}: {}",
+				runner_path.c_str(), ec.message());
+		}
+	}
+#if __linux__
+	posix_spawn_file_actions_t file_actions;
+	int spawn_rc = posix_spawn_file_actions_init(&file_actions);
+	if (spawn_rc != 0) {
+		SPDLOG_ERROR(
+			"posix_spawn_file_actions_init failed for PTX pass runner: {}",
+			strerror(spawn_rc));
+		return std::nullopt;
+	}
+	struct file_actions_guard {
+		posix_spawn_file_actions_t *actions;
+		~file_actions_guard()
+		{
+			posix_spawn_file_actions_destroy(actions);
+		}
+	} file_actions_cleanup{ &file_actions };
+	auto add_open = [&](int fd, const std::filesystem::path &path,
+			    int flags, mode_t mode) -> bool {
+		int rc = posix_spawn_file_actions_addopen(
+			&file_actions, fd, path.c_str(), flags, mode);
+		if (rc != 0) {
+			SPDLOG_ERROR(
+				"Unable to prepare PTX pass runner fd {} redirection to {}: {}",
+				fd, path.c_str(), strerror(rc));
+			return false;
+		}
+		return true;
+	};
+	if (!add_open(STDIN_FILENO, stdin_path, O_RDONLY, 0) ||
+	    !add_open(STDOUT_FILENO, stdout_path,
+		      O_WRONLY | O_CREAT | O_TRUNC, 0600) ||
+	    !add_open(STDERR_FILENO, stderr_path,
+		      O_WRONLY | O_CREAT | O_TRUNC, 0600)) {
+		return std::nullopt;
+	}
+#if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
+#if __GLIBC_PREREQ(2, 34)
+	int closefrom_rc =
+		posix_spawn_file_actions_addclosefrom_np(&file_actions, 3);
+	if (closefrom_rc != 0) {
+		SPDLOG_ERROR(
+			"Unable to prepare PTX pass runner closefrom action: {}",
+			strerror(closefrom_rc));
+		return std::nullopt;
+	}
+#endif
+#endif
+
+	std::vector<std::string> arg_strs = { runner_path.string(), mode,
+					      pass_library.string() };
+	if (output_bytes) {
+		arg_strs.emplace_back("--output-bytes");
+		arg_strs.emplace_back(std::to_string(*output_bytes));
+	}
+	std::vector<char *> argv;
+	argv.reserve(arg_strs.size() + 1);
+	for (auto &arg : arg_strs)
+		argv.push_back(arg.data());
+	argv.push_back(nullptr);
+
+	std::vector<std::string> env_strs;
+	for (char **p = ::environ; p && *p; ++p) {
+		if (strncmp(*p, "LD_PRELOAD=", 11) == 0 ||
+		    strncmp(*p, "LD_AUDIT=", 9) == 0)
+			continue;
+		env_strs.emplace_back(*p);
+	}
+	env_strs.emplace_back("LD_PRELOAD=");
+	env_strs.emplace_back("LD_AUDIT=");
+	std::vector<char *> envp;
+	envp.reserve(env_strs.size() + 1);
+	for (auto &env : env_strs)
+		envp.push_back(env.data());
+	envp.push_back(nullptr);
+
+	pid_t child_pid = -1;
+	spawn_rc = posix_spawnp(&child_pid, runner_path.c_str(), &file_actions,
+				nullptr, argv.data(), envp.data());
+	if (spawn_rc != 0) {
+		SPDLOG_ERROR("Unable to spawn PTX pass runner {} for {}: {}",
+			     runner_path.c_str(), pass_library.c_str(),
+			     strerror(spawn_rc));
+		return std::nullopt;
+	}
+	int status = 0;
+	pid_t waited_pid = -1;
+	do {
+		waited_pid = waitpid(child_pid, &status, 0);
+	} while (waited_pid < 0 && errno == EINTR);
+	if (waited_pid < 0) {
+		SPDLOG_ERROR("waitpid failed for PTX pass runner {}: {}",
+			     runner_path.c_str(), strerror(errno));
+		return std::nullopt;
+	}
+	if (WIFEXITED(status) && WEXITSTATUS(status) != 0) {
+		std::ifstream efs(stderr_path);
+		std::string err((std::istreambuf_iterator<char>(efs)),
+				std::istreambuf_iterator<char>());
+		SPDLOG_ERROR(
+			"PTX pass runner {} failed for {} with exit code {}: {}",
+			runner_path.c_str(), pass_library.c_str(),
+			WEXITSTATUS(status), err);
+		return std::nullopt;
+	}
+	if (WIFSIGNALED(status)) {
+		std::ifstream efs(stderr_path);
+		std::string err((std::istreambuf_iterator<char>(efs)),
+				std::istreambuf_iterator<char>());
+		SPDLOG_ERROR(
+			"PTX pass runner {} for {} was terminated by signal {}: {}",
+			runner_path.c_str(), pass_library.c_str(),
+			WTERMSIG(status), err);
+		return std::nullopt;
+	}
+	if (!WIFEXITED(status)) {
+		std::ifstream efs(stderr_path);
+		std::string err((std::istreambuf_iterator<char>(efs)),
+				std::istreambuf_iterator<char>());
+		SPDLOG_ERROR(
+			"PTX pass runner {} for {} ended with wait status {}: {}",
+			runner_path.c_str(), pass_library.c_str(), status, err);
+		return std::nullopt;
+	}
+#else
+	std::vector<std::string> args = { mode, pass_library.string() };
+	if (output_bytes) {
+		args.emplace_back("--output-bytes");
+		args.emplace_back(std::to_string(*output_bytes));
+	}
+	boost::process::environment child_env =
+		boost::this_process::environment();
+	child_env["LD_AUDIT"] = "";
+	child_env["LD_PRELOAD"] = "";
+	try {
+		boost::process::child child(
+			runner_path.string(), boost::process::args(args),
+			boost::process::env = child_env,
+			boost::process::std_in < stdin_path.string(),
+			boost::process::std_out > stdout_path.string(),
+			boost::process::std_err > stderr_path.string());
+		child.wait();
+		if (child.exit_code() != 0) {
+			std::ifstream efs(stderr_path);
+			std::string err((std::istreambuf_iterator<char>(efs)),
+					std::istreambuf_iterator<char>());
+			SPDLOG_ERROR(
+				"PTX pass runner {} failed for {} with exit code {}: {}",
+				runner_path.c_str(), pass_library.c_str(),
+				child.exit_code(), err);
+			return std::nullopt;
+		}
+	} catch (const std::exception &e) {
+		SPDLOG_ERROR("Unable to run PTX pass runner {} for {}: {}",
+			     runner_path.c_str(), pass_library.c_str(),
+			     e.what());
+		return std::nullopt;
+	}
+#endif
+
+	std::ifstream ifs(stdout_path);
+	if (!ifs.is_open()) {
+		SPDLOG_ERROR("Unable to read PTX pass runner output {}",
+			     stdout_path.c_str());
+		return std::nullopt;
+	}
+	return std::string(std::istreambuf_iterator<char>(ifs),
+			   std::istreambuf_iterator<char>());
+}
 } // namespace
 
 nv_attach_hook_state &nv_attach_get_hook_state()
@@ -178,7 +410,7 @@ int nv_attach_impl::create_attach_with_ebpf_callback(
 	} else {
 		attach_point_name = func_name;
 	}
-	struct pass_cfg_with_exec_path *matched = nullptr;
+	const struct pass_cfg_with_library_path *matched = nullptr;
 	for (const auto &pd : this->pass_configurations) {
 		if (pd->pass_config.attach_type != attach_type)
 			continue;
@@ -223,7 +455,7 @@ int nv_attach_impl::create_attach_with_ebpf_callback(
 				    (uintptr_t)this->shared_mem_ptr);
 		}
 		SPDLOG_INFO("Recorded pass {} for func {}",
-			    matched->executable_path.c_str(), func_name);
+			    matched->library_path.c_str(), func_name);
 		start_late_bootstrap_async();
 		return id;
 	}
@@ -517,41 +749,26 @@ nv_attach_impl::nv_attach_impl()
 	}
 	auto paths = split_by_colon(ptx_pass_libraries);
 	for (const auto &path : paths) {
-		SPDLOG_INFO("Found path: {}, executing..", path.c_str());
-		void *handle = dlmopen(LM_ID_NEWLM, path.c_str(),
-				       RTLD_NOW | RTLD_LOCAL);
-		if (!handle) {
-			SPDLOG_ERROR(
-				"Unable to load dynamic library of pass {}: {}",
-				path.c_str(), dlerror());
-			continue;
-		}
-		auto print_config =
-			(print_config_fn)dlsym(handle, "print_config");
-		if (!print_config) {
-			SPDLOG_ERROR("Symbol print_config not found in {}",
-				     path.c_str());
-			continue;
-		}
-		auto process_input =
-			(process_input_fn)dlsym(handle, "process_input");
-		if (!process_input) {
-			SPDLOG_ERROR("Symbol process_input not found in {}",
-				     path.c_str());
-			continue;
-		}
+		SPDLOG_INFO("Found path: {}, loading config..", path.c_str());
 		ptxpass::pass_config::PassConfig config;
-		std::vector<char> buf(10 << 20);
-		print_config(buf.size(), buf.data());
+		auto output = run_ptxpass_runner("--config", path, nullptr,
+						 kPtxPassConfigOutputBytes);
+		if (!output)
+			continue;
 
-		auto json = nlohmann::json::parse(buf.data());
-		ptxpass::pass_config::from_json(json, config);
-		SPDLOG_INFO("Retrived config of {}", path.c_str());
-		SPDLOG_DEBUG("Config {}", json.dump(4));
-		this->pass_configurations.emplace_back(
-			std::make_unique<pass_cfg_with_exec_path>(
-				path, config, print_config, process_input,
-				handle));
+		try {
+			auto json = nlohmann::json::parse(*output);
+			ptxpass::pass_config::from_json(json, config);
+			SPDLOG_INFO("Retrieved config of {}", path.c_str());
+			SPDLOG_DEBUG("Config {}", json.dump(4));
+			this->pass_configurations.emplace_back(
+				std::make_unique<pass_cfg_with_library_path>(
+					path, config));
+		} catch (const std::exception &e) {
+			SPDLOG_ERROR(
+				"Unable to parse PTX pass config from {}: {}",
+				path.c_str(), e.what());
+		}
 	}
 	{
 		this->ptx_compiler = *load_nv_attach_impl_ptx_compiler(
@@ -896,7 +1113,9 @@ nv_attach_impl::hack_fatbin(std::map<std::string, std::string> all_ptx)
 	std::mutex map_mutex;
 	std::mutex cache_mutex;
 	for (auto &[file_name, original_ptx] : all_ptx) {
-		boost::asio::post(pool, [this, original_ptx, file_name, &map_mutex, &ptx_out, &cache_mutex]() -> void {
+		boost::asio::post(pool, [this, original_ptx, file_name,
+					 &map_mutex, &ptx_out,
+					 &cache_mutex]() -> void {
 			auto current_ptx = original_ptx;
 			SPDLOG_INFO("Patching PTX: {}", file_name);
 			bool should_add_trampoline = false;
@@ -954,72 +1173,68 @@ nv_attach_impl::hack_fatbin(std::map<std::string, std::string> all_ptx)
 							sha256_string);
 						bool parsed = false;
 						std::string last_parse_error;
-						constexpr size_t kMinBufBytes =
-							1U << 20; // 1 MiB
-						constexpr size_t kMaxBufBytes =
-							64U << 20; // 64 MiB
-						for (size_t buf_bytes =
-							     kMinBufBytes;
-						     buf_bytes <= kMaxBufBytes;
-						     buf_bytes <<= 1) {
-							try {
-								std::vector<char> buf(
-									buf_bytes);
-								buf.back() =
-									'\0';
-								const int len =
-									(buf_bytes >
-									 (size_t)std::numeric_limits<
-										 int>::
-										 max()) ?
-										std::numeric_limits<
-											int>::
-											max() :
-										(int)buf_bytes;
-								int err =
+						size_t output_bytes =
+							kInitialPtxPassProcessOutputBytes;
+						while (true) {
+							auto output =
+								run_ptxpass_runner(
+									"--process",
 									hook_entry
 										.config
-										->process_input(
-											input_json
-												.c_str(),
-											len,
-											buf.data());
-								if (err !=
-								    ptxpass::ExitCode::
-									    Success) {
-									SPDLOG_ERROR(
-										"Unable to run pass on kernel {}: {}",
-										kernel,
-										(int)err);
-									return;
-								}
-
-								auto json = nlohmann::json::parse(
-									buf.data(),
-									nullptr,
-									/*allow_exceptions=*/
-									true,
-									/*ignore_comments=*/
-									true);
+										->library_path,
+									&input_json,
+									output_bytes);
+							if (!output) {
+								SPDLOG_ERROR(
+									"PTX pass runner failed while patching kernel {}",
+									kernel);
+								return;
+							}
+							try {
+								auto json =
+									nlohmann::json::parse(
+										*output,
+										nullptr,
+										/*allow_exceptions=*/
+										true,
+										/*ignore_comments=*/
+										true);
 								using namespace ptxpass::
 									runtime_response;
-								from_json(json,
-									  resp);
+								from_json(json, resp);
 								parsed = true;
 								break;
-							} catch (
-								const std::exception
-									&e) {
+							} catch (const std::exception &e) {
 								last_parse_error =
 									e.what();
 							}
+							bool output_may_be_truncated =
+								output->size() + 1 >=
+								output_bytes;
+							if (!output_may_be_truncated ||
+							    output_bytes >=
+								    kMaxPtxPassProcessOutputBytes)
+								break;
+							size_t next_output_bytes =
+								output_bytes * 2;
+							if (next_output_bytes >
+							    kMaxPtxPassProcessOutputBytes)
+								next_output_bytes =
+									kMaxPtxPassProcessOutputBytes;
+							if (next_output_bytes ==
+							    output_bytes)
+								break;
+							output_bytes =
+								next_output_bytes;
+							SPDLOG_WARN(
+								"PTX pass output for kernel {} may be truncated; retrying with {} bytes",
+								kernel,
+								output_bytes);
 						}
 						if (!parsed) {
 							SPDLOG_ERROR(
-								"Unable to parse PTX pass output for kernel {} (max {} MiB), last error: {}",
+								"Unable to parse PTX pass output for kernel {}, last error: {}",
 								kernel,
-								(kMaxBufBytes >>
-								 20),
 								last_parse_error);
 							return;
 						}

--- a/attach/nv_attach_impl/nv_attach_impl.hpp
+++ b/attach/nv_attach_impl/nv_attach_impl.hpp
@@ -9,7 +9,6 @@
 #include <cstdint>
 #include <cuda_runtime.h>
 #include <cuda_runtime_api.h>
-#include <dlfcn.h>
 #include <filesystem>
 #include <map>
 #include <memory>
@@ -33,9 +32,6 @@ namespace bpftime
 {
 namespace attach
 {
-
-using print_config_fn = void (*)(int length, char *out);
-using process_input_fn = int (*)(const char *input, int length, char *output);
 
 std::string filter_compiled_ptx_for_ebpf_program(std::string input,
 						 std::string);
@@ -81,38 +77,27 @@ struct nv_attach_entry {
 						       // for pass
 	// Extra serialized parameters (JSON string) reserved for future use
 	std::optional<std::string> extras;
-	struct pass_cfg_with_exec_path *config;
+	const struct pass_cfg_with_library_path *config;
 };
 
-struct pass_cfg_with_exec_path {
-	std::filesystem::path executable_path;
+struct pass_cfg_with_library_path {
+	std::filesystem::path library_path;
 	ptxpass::pass_config::PassConfig pass_config;
-	print_config_fn print_config;
-	process_input_fn process_input;
 
-	void *handle;
-
-	pass_cfg_with_exec_path(std::filesystem::path path,
-				ptxpass::pass_config::PassConfig config,
-				print_config_fn print_config,
-				process_input_fn process_input, void *handle)
-		: executable_path(path), pass_config(config),
-		  print_config(print_config), process_input(process_input),
-		  handle(handle)
+	pass_cfg_with_library_path(std::filesystem::path path,
+				   ptxpass::pass_config::PassConfig config)
+		: library_path(path), pass_config(config)
 	{
 	}
 
-	pass_cfg_with_exec_path(const pass_cfg_with_exec_path &) = delete;
-	pass_cfg_with_exec_path &
-	operator=(const pass_cfg_with_exec_path &) = delete;
-	pass_cfg_with_exec_path(pass_cfg_with_exec_path &&) = default;
-	pass_cfg_with_exec_path &
-	operator=(pass_cfg_with_exec_path &&) = default;
+	pass_cfg_with_library_path(const pass_cfg_with_library_path &) = delete;
+	pass_cfg_with_library_path &
+	operator=(const pass_cfg_with_library_path &) = delete;
+	pass_cfg_with_library_path(pass_cfg_with_library_path &&) = default;
+	pass_cfg_with_library_path &
+	operator=(pass_cfg_with_library_path &&) = default;
 
-	~pass_cfg_with_exec_path()
-	{
-		dlclose(handle);
-	}
+	~pass_cfg_with_library_path() = default;
 };
 
 struct nv_attach_hook_state {
@@ -245,7 +230,7 @@ class nv_attach_impl final : public base_attach_impl {
 		hooker_contexts;
 	std::map<int, nv_attach_entry> hook_entries;
 	// discovered pass definitions
-	std::vector<std::unique_ptr<pass_cfg_with_exec_path>>
+	std::vector<std::unique_ptr<pass_cfg_with_library_path>>
 		pass_configurations;
 	std::map<std::string, ptxpass::runtime_response::RuntimeResponse>
 		patch_cache;

--- a/attach/nv_attach_impl/pass/ptxpass_runner.cpp
+++ b/attach/nv_attach_impl/pass/ptxpass_runner.cpp
@@ -1,0 +1,193 @@
+#include <cerrno>
+#include <charconv>
+#include <cstdlib>
+#include <cstring>
+#include <dirent.h>
+#include <dlfcn.h>
+#include <cstdio>
+#include <iostream>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+using print_config_fn = void (*)(int length, char *out);
+using process_input_fn = int (*)(const char *input, int length, char *output);
+
+namespace
+{
+constexpr size_t kDefaultConfigOutputBytes = 256U << 10;
+constexpr size_t kDefaultProcessOutputBytes = 1U << 20;
+constexpr size_t kMaxOutputBytes = 64U << 20;
+
+void usage(const char *argv0)
+{
+	std::cerr << "Usage: " << argv0
+		  << " (--config|--process) <pass-library> [--output-bytes N]\n";
+}
+
+bool parse_size(const char *text, size_t &out)
+{
+	const char *end = text + std::strlen(text);
+	auto [ptr, ec] = std::from_chars(text, end, out);
+	return ec == std::errc() && ptr == end;
+}
+
+std::string read_stdin()
+{
+	return std::string(std::istreambuf_iterator<char>(std::cin),
+			   std::istreambuf_iterator<char>());
+}
+
+size_t nul_terminated_length(const std::vector<char> &buffer)
+{
+	const void *nul = std::memchr(buffer.data(), '\0', buffer.size());
+	if (nul == nullptr)
+		return buffer.size();
+	return static_cast<const char *>(nul) - buffer.data();
+}
+
+void close_inherited_fds()
+{
+#if defined(__linux__)
+	DIR *dir = opendir("/proc/self/fd");
+	if (dir != nullptr) {
+		int self_fd = dirfd(dir);
+		std::vector<int> fds;
+		for (dirent *entry = readdir(dir); entry != nullptr;
+		     entry = readdir(dir)) {
+			char *end = nullptr;
+			errno = 0;
+			long fd = std::strtol(entry->d_name, &end, 10);
+			if (errno != 0 || end == entry->d_name || *end != '\0' ||
+			    fd <= STDERR_FILENO || fd == self_fd ||
+			    fd > std::numeric_limits<int>::max())
+				continue;
+			fds.push_back(static_cast<int>(fd));
+		}
+		closedir(dir);
+		for (int fd : fds)
+			close(fd);
+		return;
+	}
+#endif
+	long max_fd = sysconf(_SC_OPEN_MAX);
+	if (max_fd < 0)
+		max_fd = 1024;
+	if (max_fd > std::numeric_limits<int>::max())
+		max_fd = std::numeric_limits<int>::max();
+	for (int fd = STDERR_FILENO + 1; fd < max_fd; fd++)
+		close(fd);
+}
+} // namespace
+
+int main(int argc, char **argv)
+{
+	if (argc < 3) {
+		usage(argv[0]);
+		return 64;
+	}
+
+	const std::string mode = argv[1];
+	const char *library_path = argv[2];
+	if (mode != "--config" && mode != "--process") {
+		usage(argv[0]);
+		return 64;
+	}
+	size_t output_bytes = kDefaultProcessOutputBytes;
+	if (mode == "--config")
+		output_bytes = kDefaultConfigOutputBytes;
+	for (int i = 3; i < argc; i++) {
+		if (std::strcmp(argv[i], "--output-bytes") == 0 &&
+		    i + 1 < argc) {
+			if (!parse_size(argv[++i], output_bytes) ||
+			    output_bytes == 0 || output_bytes > kMaxOutputBytes ||
+			    output_bytes >
+				    (size_t)std::numeric_limits<int>::max()) {
+				std::cerr << "Invalid --output-bytes value\n";
+				return 64;
+			}
+			continue;
+		}
+		usage(argv[0]);
+		return 64;
+	}
+	close_inherited_fds();
+
+	fflush(stdout);
+	int saved_stdout = dup(STDOUT_FILENO);
+	if (saved_stdout == -1 || dup2(STDERR_FILENO, STDOUT_FILENO) == -1) {
+		std::cerr << "Unable to redirect pass stdout: "
+			  << std::strerror(errno) << "\n";
+		if (saved_stdout != -1)
+			close(saved_stdout);
+		return 70;
+	}
+	auto restore_stdout = [&]() -> bool {
+		std::cout.flush();
+		std::clog.flush();
+		std::cerr.flush();
+		fflush(stdout);
+		if (dup2(saved_stdout, STDOUT_FILENO) == -1) {
+			std::cerr << "Unable to restore stdout: "
+				  << std::strerror(errno) << "\n";
+			close(saved_stdout);
+			saved_stdout = -1;
+			return false;
+		}
+		close(saved_stdout);
+		saved_stdout = -1;
+		return true;
+	};
+
+	std::unique_ptr<void, int (*)(void *)> handle(
+		dlopen(library_path, RTLD_NOW | RTLD_LOCAL), dlclose);
+	if (!handle) {
+		std::cerr << "Unable to load PTX pass " << library_path << ": "
+			  << dlerror() << "\n";
+		return 66;
+	}
+
+	std::vector<char> output(output_bytes, '\0');
+	const int output_len = static_cast<int>(output.size());
+
+	if (mode == "--config") {
+		auto print_config =
+			reinterpret_cast<print_config_fn>(
+				dlsym(handle.get(), "print_config"));
+		if (!print_config) {
+			std::cerr << "Symbol print_config not found in "
+				  << library_path << "\n";
+			return 66;
+		}
+		print_config(output_len, output.data());
+		if (!restore_stdout())
+			return 70;
+		std::cout.write(output.data(), nul_terminated_length(output));
+		return 0;
+	}
+
+	if (mode == "--process") {
+		auto process_input =
+			reinterpret_cast<process_input_fn>(
+				dlsym(handle.get(), "process_input"));
+		if (!process_input) {
+			std::cerr << "Symbol process_input not found in "
+				  << library_path << "\n";
+			return 66;
+		}
+		std::string input = read_stdin();
+		int rc = process_input(input.c_str(), output_len, output.data());
+		if (!restore_stdout())
+			return 70;
+		if (rc != 0)
+			return rc;
+		std::cout.write(output.data(), nul_terminated_length(output));
+		return 0;
+	}
+
+	usage(argv[0]);
+	return 64;
+}

--- a/runtime/include/bpf_attach_ctx.hpp
+++ b/runtime/include/bpf_attach_ctx.hpp
@@ -207,6 +207,7 @@ private:
 #ifdef BPFTIME_ENABLE_CUDA_ATTACH
 	// Start host thread for handling map requests from CUDA
 	void start_cuda_watcher_thread();
+	void stop_cuda_watcher_thread();
 	std::unique_ptr<cuda::CUDAContext> cuda_ctx;
 	std::thread cuda_watcher_thread;
 #endif

--- a/runtime/src/attach/bpf_attach_ctx.cpp
+++ b/runtime/src/attach/bpf_attach_ctx.cpp
@@ -163,9 +163,7 @@ bpf_attach_ctx::~bpf_attach_ctx()
 	SPDLOG_INFO("Destructor: bpf_attach_ctx");
 #ifdef BPFTIME_ENABLE_CUDA_ATTACH
 	if (cuda_ctx) {
-		cuda_ctx->cuda_watcher_should_stop->store(true);
-		if (cuda_watcher_thread.joinable())
-			cuda_watcher_thread.join();
+		stop_cuda_watcher_thread();
 	}
 #endif
 }

--- a/runtime/src/attach/bpf_attach_ctx_cuda.cpp
+++ b/runtime/src/attach/bpf_attach_ctx_cuda.cpp
@@ -7,6 +7,7 @@
 #include <optional>
 #include <cstdlib>
 #include <mutex>
+#include <system_error>
 #include <thread>
 #include <spdlog/spdlog.h>
 #include "cuda.h"
@@ -279,6 +280,38 @@ void bpf_attach_ctx::start_cuda_watcher_thread()
 		std::lock_guard<std::mutex> guard(g_cuda_watcher_mutex);
 		g_cuda_watcher_thread = &cuda_watcher_thread;
 		g_cuda_watcher_stop_flag = flag;
+	}
+}
+
+void bpf_attach_ctx::stop_cuda_watcher_thread()
+{
+	if (!cuda_ctx)
+		return;
+	auto flag = cuda_ctx->cuda_watcher_should_stop;
+	if (flag)
+		flag->store(true, std::memory_order_release);
+	{
+		std::lock_guard<std::mutex> guard(g_cuda_watcher_mutex);
+		if (g_cuda_watcher_thread == &cuda_watcher_thread) {
+			g_cuda_watcher_thread = nullptr;
+			g_cuda_watcher_stop_flag.reset();
+		}
+	}
+	if (cuda_watcher_thread.joinable()) {
+		try {
+			cuda_watcher_thread.join();
+		} catch (const std::system_error &ex) {
+			SPDLOG_WARN("Failed to join CUDA watcher thread: {}",
+				    ex.what());
+			try {
+				if (cuda_watcher_thread.joinable())
+					cuda_watcher_thread.detach();
+			} catch (const std::system_error &detach_ex) {
+				SPDLOG_WARN(
+					"Failed to detach CUDA watcher thread after join failure: {}",
+					detach_ex.what());
+			}
+		}
 	}
 }
 std::vector<attach::MapBasicInfo>

--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -745,6 +745,11 @@ bpftime_shm::bpftime_shm(const char *shm_name, shm_open_type type)
 	if (open_type == shm_open_type::SHM_OPEN_ONLY) {
 		auto pair = segment.find<cuda::CommSharedMem>(
 			"cuda_comm_shared_mem");
+		for (int i = 0; pair.first == nullptr && i < 100; i++) {
+			usleep(10000);
+			pair = segment.find<cuda::CommSharedMem>(
+				"cuda_comm_shared_mem");
+		}
 		if (pair.first == nullptr) {
 			SPDLOG_ERROR(
 				"CommSharedMem not found in shared memory; did syscall-server initialize CUDA support?");
@@ -755,7 +760,8 @@ bpftime_shm::bpftime_shm(const char *shm_name, shm_open_type type)
 		// Register the shared communication memory for CUDA device
 		// mapping. This must happen after we have located the
 		// CommSharedMem in the shared segment.
-		register_cuda_host_memory();
+		if (cuda_comm_shared_mem != nullptr)
+			register_cuda_host_memory();
 	} else {
 		auto pair = segment.find<cuda::CommSharedMem>(
 			"cuda_comm_shared_mem");

--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -115,9 +115,20 @@ syscall_context::syscall_context()
 	SPDLOG_INFO("The log will be written to: {}",
 		    runtime_config.get_logger_output_path());
 	spdlog::cfg::load_env_levels();
+}
+
 #ifdef BPFTIME_ENABLE_CUDA_ATTACH
+void syscall_context::initialize_cuda()
+{
 	SPDLOG_INFO("Initializing CUDA at syscall-server side");
-	initializing_cuda = true;
+	initializing_cuda.store(true, std::memory_order_release);
+	struct cuda_init_guard {
+		std::atomic<bool> &flag;
+		~cuda_init_guard()
+		{
+			flag.store(false, std::memory_order_release);
+		}
+	} guard{ initializing_cuda };
 	if (auto err = cuInit(0); err != CUDA_SUCCESS) {
 		SPDLOG_ERROR(
 			"Unable to initialize CUDA from syscall server side: {}",
@@ -126,9 +137,8 @@ syscall_context::syscall_context()
 			"Unable to initialize CUDA from syscall server side");
 	}
 	SPDLOG_INFO("CUDA initialized at syscall server side");
-	initializing_cuda = false;
-#endif
 }
+#endif
 
 void syscall_context::try_startup()
 {
@@ -139,7 +149,9 @@ void syscall_context::try_startup()
 
 int syscall_context::handle_close(int fd)
 {
-	if (!enable_mock || initializing_cuda || !enable_mock_after_initialized)
+	if (!enable_mock ||
+	    initializing_cuda.load(std::memory_order_acquire) ||
+	    !enable_mock_after_initialized)
 		return orig_close_fn(fd);
 	SPDLOG_DEBUG("Calling mocked close");
 	try_startup();
@@ -159,7 +171,9 @@ int syscall_context::handle_close(int fd)
 int syscall_context::handle_openat(int fd, const char *file, int oflag,
 				   unsigned short mode)
 {
-	if (!enable_mock || initializing_cuda || !enable_mock_after_initialized)
+	if (!enable_mock ||
+	    initializing_cuda.load(std::memory_order_acquire) ||
+	    !enable_mock_after_initialized)
 		return orig_openat_fn(fd, file, oflag, mode);
 	try_startup();
 	auto path = resolve_filename_and_fd_to_full_path(fd, file);
@@ -186,7 +200,9 @@ int syscall_context::handle_openat(int fd, const char *file, int oflag,
 int syscall_context::handle_open(const char *file, int oflag,
 				 unsigned short mode)
 {
-	if (!enable_mock || initializing_cuda || !enable_mock_after_initialized)
+	if (!enable_mock ||
+	    initializing_cuda.load(std::memory_order_acquire) ||
+	    !enable_mock_after_initialized)
 		return orig_open_fn(file, oflag, mode);
 	SPDLOG_DEBUG("Calling mocked open");
 	try_startup();
@@ -207,7 +223,9 @@ int syscall_context::handle_open(const char *file, int oflag,
 
 ssize_t syscall_context::handle_read(int fd, void *buf, size_t count)
 {
-	if (!enable_mock || initializing_cuda || !enable_mock_after_initialized)
+	if (!enable_mock ||
+	    initializing_cuda.load(std::memory_order_acquire) ||
+	    !enable_mock_after_initialized)
 		return orig_read_fn(fd, buf, count);
 	SPDLOG_DEBUG("Calling mocked read");
 	try_startup();
@@ -354,7 +372,9 @@ int syscall_context::create_kernel_bpf_prog_in_userspace(int cmd,
 
 long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 {
-	if (!enable_mock || initializing_cuda || !enable_mock_after_initialized)
+	if (!enable_mock ||
+	    initializing_cuda.load(std::memory_order_acquire) ||
+	    !enable_mock_after_initialized)
 		return orig_syscall_fn(__NR_bpf, (long)cmd,
 				       (long)(uintptr_t)attr, (long)size);
 	try_startup();
@@ -674,7 +694,9 @@ long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 int syscall_context::handle_perfevent(perf_event_attr *attr, pid_t pid, int cpu,
 				      int group_fd, unsigned long flags)
 {
-	if (!enable_mock || initializing_cuda || !enable_mock_after_initialized)
+	if (!enable_mock ||
+	    initializing_cuda.load(std::memory_order_acquire) ||
+	    !enable_mock_after_initialized)
 		return orig_syscall_fn(__NR_perf_event_open,
 				       (uint64_t)(uintptr_t)attr, (uint64_t)pid,
 				       (uint64_t)cpu, (uint64_t)group_fd,
@@ -803,7 +825,8 @@ int syscall_context::handle_perfevent(perf_event_attr *attr, pid_t pid, int cpu,
 void *syscall_context::handle_mmap(void *addr, size_t length, int prot,
 				   int flags, int fd, off64_t offset)
 {
-	if (!enable_mock || run_with_kernel || initializing_cuda ||
+	if (!enable_mock || run_with_kernel ||
+	    initializing_cuda.load(std::memory_order_acquire) ||
 	    !enable_mock_after_initialized)
 		return orig_mmap_fn(addr, length, prot, flags, fd, offset);
 	try_startup();
@@ -814,7 +837,8 @@ void *syscall_context::handle_mmap(void *addr, size_t length, int prot,
 void *syscall_context::handle_mmap64(void *addr, size_t length, int prot,
 				     int flags, int fd, off64_t offset)
 {
-	if (!enable_mock || run_with_kernel || initializing_cuda)
+	if (!enable_mock || run_with_kernel ||
+	    initializing_cuda.load(std::memory_order_acquire))
 		return orig_mmap64_fn(addr, length, prot, flags, fd, offset);
 	try_startup();
 	SPDLOG_DEBUG("Calling mocked mmap64");
@@ -867,11 +891,12 @@ void *syscall_context::handle_mmap64(void *addr, size_t length, int prot,
 
 int syscall_context::handle_ioctl(int fd, unsigned long req, unsigned long data)
 {
-	if (!enable_mock || initializing_cuda ||
-	    !enable_mock_after_initialized) {
+	bool cuda_initializing =
+		initializing_cuda.load(std::memory_order_acquire);
+	if (!enable_mock || cuda_initializing || !enable_mock_after_initialized) {
 		SPDLOG_DEBUG(
 			"Calling original ioctl, enable_lock={}, initializing_cuda={}",
-			enable_mock, initializing_cuda);
+			enable_mock, cuda_initializing);
 		return orig_ioctl_fn(fd, req, data);
 	}
 	SPDLOG_DEBUG("Calling mocked ioctl..");
@@ -924,7 +949,8 @@ int syscall_context::handle_ioctl(int fd, unsigned long req, unsigned long data)
 
 int syscall_context::handle_epoll_create1(int flags)
 {
-	if (!enable_mock || run_with_kernel || initializing_cuda ||
+	if (!enable_mock || run_with_kernel ||
+	    initializing_cuda.load(std::memory_order_acquire) ||
 	    !enable_mock_after_initialized)
 		return orig_epoll_create1_fn(flags);
 	try_startup();
@@ -963,7 +989,8 @@ int syscall_context::handle_epoll_ctl(int epfd, int op, int fd,
 int syscall_context::handle_epoll_wait(int epfd, epoll_event *evt,
 				       int maxevents, int timeout)
 {
-	if (!enable_mock || run_with_kernel || initializing_cuda ||
+	if (!enable_mock || run_with_kernel ||
+	    initializing_cuda.load(std::memory_order_acquire) ||
 	    !enable_mock_after_initialized)
 		return orig_epoll_wait_fn(epfd, evt, maxevents, timeout);
 	try_startup();
@@ -975,7 +1002,8 @@ int syscall_context::handle_epoll_wait(int epfd, epoll_event *evt,
 
 int syscall_context::handle_munmap(void *addr, size_t size)
 {
-	if (!enable_mock || run_with_kernel || initializing_cuda ||
+	if (!enable_mock || run_with_kernel ||
+	    initializing_cuda.load(std::memory_order_acquire) ||
 	    !enable_mock_after_initialized)
 		return orig_munmap_fn(addr, size);
 	try_startup();
@@ -992,7 +1020,9 @@ int syscall_context::handle_munmap(void *addr, size_t size)
 
 FILE *syscall_context::handle_fopen(const char *pathname, const char *flags)
 {
-	if (!enable_mock || initializing_cuda || !enable_mock_after_initialized)
+	if (!enable_mock ||
+	    initializing_cuda.load(std::memory_order_acquire) ||
+	    !enable_mock_after_initialized)
 		return orig_fopen_fn(pathname, flags);
 	SPDLOG_DEBUG("Calling mocked fopen");
 	try_startup();
@@ -1024,7 +1054,8 @@ FILE *syscall_context::handle_fopen(const char *pathname, const char *flags)
 int syscall_context::handle_dup3(int oldfd, int newfd, int flags)
 {
 	SPDLOG_DEBUG("Calling mocked dup3 {}, {}", oldfd, newfd);
-	if (!enable_mock || run_with_kernel || initializing_cuda ||
+	if (!enable_mock || run_with_kernel ||
+	    initializing_cuda.load(std::memory_order_acquire) ||
 	    !enable_mock_after_initialized)
 		return orig_syscall_fn(__NR_dup3, (long)oldfd, (long)newfd,
 				       (long)flags);
@@ -1039,7 +1070,8 @@ int syscall_context::handle_dup3(int oldfd, int newfd, int flags)
 int syscall_context::handle_memfd_create(const char *name, int flags)
 {
 	SPDLOG_DEBUG("Calling mocked memfd_create {}, {}", name, flags);
-	if (!enable_mock || initializing_cuda ||
+	if (!enable_mock ||
+	    initializing_cuda.load(std::memory_order_acquire) ||
 	    !enable_mock_after_initialized) {
 		SPDLOG_DEBUG("Calling original dup3");
 		return orig_syscall_fn(__NR_dup3, (long)name, (long)flags);

--- a/runtime/syscall-server/syscall_context.hpp
+++ b/runtime/syscall-server/syscall_context.hpp
@@ -20,6 +20,7 @@
 #include <spdlog/spdlog.h>
 #include <unordered_set>
 #include <pthread.h>
+#include <atomic>
 #include <future>
 #include <thread>
 // #include "pos/include/common.h"
@@ -156,7 +157,7 @@ class syscall_context {
 	// enable mock the syscall behavior in userspace
 	bool enable_mock = true;
 	// Initializing CUDA
-	bool initializing_cuda = false;
+	std::atomic<bool> initializing_cuda{ false };
 	// Whether enable mock after syscall server has been initialized
 	bool enable_mock_after_initialized = true;
 	syscall_context();
@@ -191,6 +192,7 @@ class syscall_context {
 	int handle_memfd_create(const char *name, int flags);
 
 #if defined(BPFTIME_ENABLE_CUDA_ATTACH)
+	void initialize_cuda();
 	int poll_gpu_ringbuf_map(int mapfd, void *ctx,
 
 				 void (*)(const void *, uint64_t, void *));

--- a/runtime/syscall-server/syscall_server_utils.cpp
+++ b/runtime/syscall-server/syscall_server_utils.cpp
@@ -50,6 +50,9 @@ void start_up(syscall_context &ctx)
 
 		bpftime_initialize_global_shm(
 			shm_open_type::SHM_CREATE_OR_OPEN);
+#if defined(BPFTIME_ENABLE_CUDA_ATTACH)
+		ctx.initialize_cuda();
+#endif
 		shm_holder.global_shared_memory.begin_new_session();
 		shm_holder.global_shared_memory.set_mock_setter([&](bool flg) {
 			ctx.enable_mock_after_initialized = flg;


### PR DESCRIPTION
## Summary

Split the PTX pass isolation change from the GPU runtime race fix.

- add a dedicated `bpftime_ptxpass_runner` executable for PTX pass `print_config` and `process_input` calls
- run pass libraries in a subprocess with `LD_PRELOAD` and `LD_AUDIT` cleared
- reserve runner stdout for JSON by redirecting pass stdout to stderr
- restore executable permissions when artifact transfer drops the executable bit

## Current status

This remains a draft and is not merge-ready. The prerequisite GPU race fix was merged in #582, but this branch now conflicts with `master`. After rebasing, the remaining non-outdated review findings must be addressed: bounded process output allocation, inherited file descriptors in the spawned runner, and config pointer constness.

## Validation recorded on the branch

- `git diff --check`
- configured and built the GPU/runner targets with CUDA 12.9 and Ninja
- the earlier combined branch passed its checks before this change was split out