### PR TITLE
fix:symbols not found:llvm_orc_registerEHFrameSectionWrapper caused by dockerfile's llvm version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,23 +4,23 @@ WORKDIR /bpftime
 RUN apt-get update && apt-get install -y --no-install-recommends \
         libelf1 libelf-dev zlib1g-dev make cmake git libboost1.74-all-dev \
         binutils-dev libyaml-cpp-dev gcc g++ ca-certificates \
-        clang-17 llvm-17 llvm-17-dev
+        clang-16 llvm-16 llvm-16-dev
 
 COPY . .
 
 RUN git submodule update --init --recursive
 
 ENV BPFTIME_VM_NAME=llvm 
-ENV LLVM_DIR=/usr/lib/llvm-17/lib/cmake/llvm
-ENV PATH="${PATH}:/usr/lib/llvm-17/bin"
+ENV LLVM_DIR=/usr/lib/llvm-16/lib/cmake/llvm
+ENV PATH="${PATH}:/usr/lib/llvm-16/bin"
 
 RUN rm -rf build && mkdir build && cmake -Bbuild \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DBUILD_BPFTIME_DAEMON=1 \
-    -DCMAKE_C_COMPILER=/usr/lib/llvm-17/bin/clang \
-    -DCMAKE_CXX_COMPILER=/usr/lib/llvm-17/bin/clang++ \
-    -DLLVM_CONFIG=/usr/lib/llvm-17/bin/llvm-config \
-    -DLLVM_DIR=/usr/lib/llvm-17/lib/cmake/llvm
+    -DCMAKE_C_COMPILER=/usr/lib/llvm-16/bin/clang \
+    -DCMAKE_CXX_COMPILER=/usr/lib/llvm-16/bin/clang++ \
+    -DLLVM_CONFIG=/usr/lib/llvm-16/bin/llvm-config \
+    -DLLVM_DIR=/usr/lib/llvm-16/lib/cmake/llvm
 
 RUN cd build && make -j$(nproc)
 RUN cd build && make install


### PR DESCRIPTION
fix:symbols not found:llvm_orc_registerEHFrameSectionWrapper caused by dockerfile's llvm version

Fixes #424



<!--# Pull Request Template-->

## Description

When test malloc example in ghcr.io/eunomia-bpf/bpftime:latest images according to [uprobe-and-uretprobe doc](https://eunomia.dev/zh/bpftime/documents/usage/#uprobe-and-uretprobe), a error happened:
```bash
docker run -it --rm --name test_bpftime -v "$(pwd)":/workdir -w /workdir ghcr.io/eunomia-bpf/bpftime:latest /bin/bash

make -C example/malloc # Build the eBPF program example
bpftime load ./example/malloc/malloc

# In another terminal
bpftime start ./example/malloc/victim

[2026-06-16 09:38:42.113] [info] [bpftime_config.cpp:129] Using VM: llvm
[2026-06-16 09:38:43.040] [info] [bpftime_config.cpp:129] Using VM: llvm
[2026-06-16 09:38:43.040] [info] [bpftime_shm_internal.cpp:842] Global shm constructed. shm_open_type 1 for bpftime_maps_shm
[2026-06-16 09:38:43.040] [info] [bpftime_shm_internal.cpp:44] Global shm initialized
Symbols not found: [ llvm_orc_registerEHFrameSectionWrapper ]
[2026-06-16 09:38:43.044] [error] Program exited abnormally, code=1
```

Fixes # (424)

## Type of change

<!--Please delete options that are not relevant.-->

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Build a new docker images to fix this problem according to updated dockerfile(llvm 17 -> llvm 16)
