### PR TITLE
fix(cuda): register patched kernels by PTX entry name for late attach

### DIFF
--- a/attach/nv_attach_impl/nv_attach_impl.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl.cpp
@@ -1567,6 +1567,23 @@ std::vector<std::string> nv_attach_impl::collect_all_kernels_to_patch() const
 	return kernels;
 }
 
+static std::vector<std::string>
+collect_ptx_entry_functions(const std::map<std::string, std::string> &all_ptx)
+{
+	static const std::regex kernel_entry(
+		R"((?:\.visible\s+)?\.entry\s+([A-Za-z_.$][A-Za-z0-9_.$]*)\s*\()");
+	std::set<std::string> entries;
+	for (const auto &[_, ptx] : all_ptx) {
+		for (std::sregex_iterator it(ptx.begin(), ptx.end(),
+					     kernel_entry),
+		     end;
+		     it != end; ++it) {
+			entries.insert((*it)[1].str());
+		}
+	}
+	return std::vector<std::string>(entries.begin(), entries.end());
+}
+
 void nv_attach_impl::build_host_symbol_cache_once()
 {
 	std::call_once(host_symbol_cache_once, [&]() {
@@ -1641,15 +1658,17 @@ nv_attach_impl::resolve_host_function_symbol(void *addr)
 
 void nv_attach_impl::prefill_patched_kernel_functions_from_loaded_fatbins()
 {
-	auto kernels = collect_all_kernels_to_patch();
-	if (kernels.empty())
-		return;
 	if (fatbin_records.empty())
 		return;
 
 	for (const auto &rec_uptr : fatbin_records) {
 		auto *rec = rec_uptr.get();
 		if (rec == nullptr)
+			continue;
+		auto kernels = collect_ptx_entry_functions(rec->original_ptx);
+		if (kernels.empty())
+			kernels = collect_all_kernels_to_patch();
+		if (kernels.empty())
 			continue;
 		for (const auto &ptx : rec->ptxs) {
 			for (const auto &kernel : kernels) {
@@ -1661,6 +1680,9 @@ void nv_attach_impl::prefill_patched_kernel_functions_from_loaded_fatbins()
 								       func);
 					record_original_cufunction_name(func,
 									kernel);
+					SPDLOG_DEBUG(
+						"Prefilled patched CUDA kernel {}",
+						kernel);
 				}
 			}
 		}

--- a/attach/nv_attach_impl/nv_attach_impl_frida_setup.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl_frida_setup.cpp
@@ -233,6 +233,13 @@ cuda_launch_kernel_common(nv_attach_impl *impl, void *original_fn_ptr,
 			impl->record_patched_launch(stream);
 			return cudaSuccess;
 		}
+		SPDLOG_DEBUG(
+			"Late attach launch: resolved {} but no patched CUfunction is registered",
+			name->c_str());
+	} else {
+		SPDLOG_DEBUG(
+			"Late attach launch: unable to resolve host function {:x}",
+			(uintptr_t)func);
 	}
 
 	return original(func, grid_dim, block_dim, args, shared_mem, stream);

--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -574,9 +574,20 @@ int bpftime_shm::add_bpf_link(int fd, struct bpf_link_create_args *args)
 	// accepted.
 	if (args->attach_type == BPFTIME_BPF_PERF_EVENT_ATTACH_TYPE &&
 	    !is_perf_event_handler_fd(args->target_fd)) {
-		SPDLOG_ERROR(
-			"add_bpf_link: target_fd {} is not a perf-event handler for BPF_PERF_EVENT link",
-			args->target_fd);
+		int target_fd_for_log =
+			args->target_fd == static_cast<uint32_t>(-1) ?
+				-1 :
+				static_cast<int>(args->target_fd);
+		// libbpf probes perf-link support with target_fd=-1 and expects
+		// EBADF, so don't report that expected probe as an error.
+		if (args->target_fd == static_cast<uint32_t>(-1)) {
+			SPDLOG_DEBUG(
+				"add_bpf_link: rejecting expected libbpf perf-link probe with target_fd -1");
+		} else {
+			SPDLOG_ERROR(
+				"add_bpf_link: target_fd {} is not a perf-event handler for BPF_PERF_EVENT link",
+				target_fd_for_log);
+		}
 		errno = EBADF;
 		return -1;
 	}

--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -596,8 +596,11 @@ long syscall_context::handle_sysbpf(int cmd, union bpf_attr *attr, size_t size)
 		auto prog_fd = attr->link_create.prog_fd;
 		auto target_fd = attr->link_create.target_fd;
 		auto attach_type = attr->link_create.attach_type;
+		int target_fd_for_log = target_fd == static_cast<uint32_t>(-1) ?
+						-1 :
+						static_cast<int>(target_fd);
 		SPDLOG_DEBUG("Creating link {} -> {}, attach type {}", prog_fd,
-			     target_fd, attach_type);
+			     target_fd_for_log, attach_type);
 		if (run_with_kernel && !bpftime_is_perf_event_fd(target_fd)) {
 			return orig_syscall_fn(__NR_bpf, (long)cmd,
 					       (long)(uintptr_t)attr,


### PR DESCRIPTION
Fix CUDA late attach launch routing for PTX-patched kernels.

The late attach path resolved cudaLaunchKernel host stubs to real PTX entry names, but prefilled patched CUfunction mappings using eBPF attach point names such as __memcapture. This key mismatch caused launches to fall back to the original CUDA kernel even after PTX patching succeeded.

This change extracts real .entry names from loaded PTX and registers patched CUfunctions by those names, so late attach can route launches to the patched module. It also downgrades expected libbpf perf-link probe failures from error logs to debug logs.