### PR TITLE
fix: Link bpftime_llvm_vm symbols with --whole-archive

### DIFF
--- a/tools/aot/CMakeLists.txt
+++ b/tools/aot/CMakeLists.txt
@@ -18,8 +18,20 @@ if(${BPFTIME_ENABLE_CUDA_ATTACH})
     include(../../cmake/cuda.cmake)
     find_cuda()
     target_link_directories(bpftime-aot-cli PRIVATE ${CUDA_LIBRARY_PATH})
+    # Use --whole-archive to include all symbols from bpftime_llvm_vm
+    # This ensures the constructor function register_llvm_vm_factory() is linked
+    target_link_options(bpftime-aot-cli PRIVATE 
+        "-Wl,--whole-archive" 
+        "$<TARGET_FILE:bpftime_llvm_vm>" 
+        "-Wl,--no-whole-archive")
     target_link_libraries(bpftime-aot-cli PRIVATE -L/usr/lib/llvm-20/lib/ spdlog::spdlog argparse bpftime_vm_compat bpftime_llvm_vm runtime ${LIBBPF_LIBRARIES} elf z ${LLVM_LIBRARIES} ${llvm_libs} ${CUDA_LIBS} bpftime_nv_attach_impl)
 else()
+    # Use --whole-archive to include all symbols from bpftime_llvm_vm
+    # This ensures the constructor function register_llvm_vm_factory() is linked
+    target_link_options(bpftime-aot-cli PRIVATE 
+        "-Wl,--whole-archive" 
+        "$<TARGET_FILE:bpftime_llvm_vm>" 
+        "-Wl,--no-whole-archive")
     target_link_libraries(bpftime-aot-cli PRIVATE -L/usr/lib/llvm-20/lib/ spdlog::spdlog argparse bpftime_vm_compat bpftime_llvm_vm runtime ${LIBBPF_LIBRARIES} elf z ${LLVM_LIBRARIES} ${llvm_libs})
 endif()
 set_property(TARGET bpftime-aot-cli PROPERTY CXX_STANDARD 20)


### PR DESCRIPTION
Fixes missing register_llvm_vm_factory() symbol that caused 'Unknown VM type requested: llvm' error in bpftime-aot.

Fixes #587

## Description

When executing `bpftime-aot compile`, the LLVM VM factory is not registered, causing runtime error: "Unknown VM type requested: llvm". 

The root cause is that `register_llvm_vm_factory()` uses `__attribute__((constructor))` for self-registration but has no direct callers. When linking static libraries, the linker skips unreferenced symbols, causing the constructor to not be linked into the final executable.

**Fix**: Add `--whole-archive` linker option to force inclusion of all symbols from `bpftime_llvm_vm` static library. This approach is already successfully used in `runtime/syscall-server/CMakeLists.txt`.

Fixes #587

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Verified symbol presence in static library: `readelf -sW ./build/vm/compat/llvm-vm/libbpftime_llvm_vm.a | grep register_llvm_vm_factory`
- [x] Verified symbol missing in final executable before fix: `nm build/tools/aot/bpftime-aot | grep register_llvm_vm_factory`
- [x] Built and tested `bpftime-aot compile` successfully after fix

**Test Configuration**:

- Firmware version: NingOS V3.0 (2.0.2501)
- Hardware: x86_64

## Checklist

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings