### PR TITLE
fix: Handle null tracepoint_id in JSON import for non-tracepoint perf…

### DIFF
--- a/runtime/src/bpftime_shm_json.cpp
+++ b/runtime/src/bpftime_shm_json.cpp
@@ -130,7 +130,9 @@ static int import_shm_handler_from_json(bpftime_shm &shm, json value, int fd)
 	} else if (handler_type == "bpf_perf_event_handler") {
 		int type = value["attr"]["type"];
 		int pid = value["attr"]["pid"];
-		int tracepoint_id = value["attr"]["tracepoint_id"];
+		int tracepoint_id = 0;
+		if ((bpf_event_type)type == bpf_event_type::PERF_TYPE_TRACEPOINT)
+			tracepoint_id = value["attr"]["tracepoint_id"];		
 		switch ((bpf_event_type)type) {
 		case bpf_event_type::BPF_TYPE_UPROBE: {
 			int ref_ctr_off = value["attr"]["ref_ctr_off"];


### PR DESCRIPTION
Fixes nlohmann::json type_error.302 crash when importing uprobe perf_event handlers.

Fixes #589

## Description

When executing `bpftimetool import` to import JSON files containing uprobe perf_event handlers, the program crashes with `nlohmann::json::type_error.302: type must be number, but is null`.

**Fix**: Only read `tracepoint_id` when perf_event type is `PERF_TYPE_TRACEPOINT`. For other types (uprobe, software), use default value 0.

Fixes #589

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Exported and imported uprobe perf_event handler JSON successfully
- [x] Verified no crash with previously failing JSON file
- [x] Tested tracepoint perf_event handlers still work correctly

**Test Configuration**:

- Firmware version: NingOS V3.0 (2.0.2501)
- Hardware: x86_64
- Toolchain: GCC

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
