### PR TITLE
fix: Add validation to prevent export to shared memory device

### DIFF
--- a/tools/bpftimetool/main.cpp
+++ b/tools/bpftimetool/main.cpp
@@ -175,8 +175,20 @@ int main(int argc, char *argv[])
 			     << endl;
 			return 1;
 		}
-		bpftime_initialize_global_shm(shm_open_type::SHM_OPEN_ONLY);
 		auto filename = std::string(argv[2]);
+
+		// Check if output file is the current shared memory device
+		std::string shm_name = bpftime::get_global_shm_name();
+		std::string shm_path = "/dev/shm/" + shm_name;
+		if (filename == shm_path) {
+			cerr << "Error: Output file cannot be the shared memory device file." << endl
+			     << "Hint: export outputs to JSON file, not to shared memory itself." << endl
+			     << "Current shared memory: " << shm_path << endl
+			     << "Example: " << argv[0] << " export /tmp/output.json" << endl;
+			return 1;
+		}		
+
+		bpftime_initialize_global_shm(shm_open_type::SHM_OPEN_ONLY);
 		return bpftime_export_global_shm_to_json(filename.c_str());
 	} else if (cmd == "import") {
 		if (argc != 3) {


### PR DESCRIPTION
Fixes Bus error crash when exporting to shared memory device file.

Fixes #591

## Description

When executing `bpftimetool export` with the shared memory device file as output path (e.g., `/dev/shm/bpftime_maps_shm`), the program crashed with Bus error (SIGBUS).


**Fix**: Add parameter validation to check if the output file path matches the current shared memory device file. If matched, reject the operation with a helpful error message.

**Implementation**:
- Dynamically get current shared memory name using `bpftime::get_global_shm_name()`
- Check if output file equals `/dev/shm/<shm_name>`
- Support custom shared memory name via `BPFTIME_GLOBAL_SHM_NAME` environment variable
- Allow output to other files in `/dev/shm/` directory (only reject the exact shared memory file)

Fixes #591

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Tested with default shared memory name (`bpftime_maps_shm`)
- [x] Tested with custom shared memory name via environment variable
- [x] Verified error message is displayed correctly
- [x] Verified valid export operations still work

**Test Configuration**:

- Firmware version: NingOS V3.0 (2.0.2501)
- Hardware: x86_64
- Toolchain: GCC


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
