### PR TITLE
fix(runtime): handle shared memory exhaustion

### DIFF
--- a/runtime/src/handler/perf_event_handler.cpp
+++ b/runtime/src/handler/perf_event_handler.cpp
@@ -9,7 +9,6 @@
 #include "bpftime_epoll.h"
 #endif
 #include "spdlog/spdlog.h"
-#include <boost/container/throw_exception.hpp>
 #include <boost/interprocess/detail/segment_manager_helper.hpp>
 #include <boost/interprocess/smart_ptr/shared_ptr.hpp>
 #include <cstring>
@@ -284,9 +283,7 @@ void *software_perf_event_buffer::ensure_mmap_buffer(size_t buffer_size)
 		};
 		try {
 			mmap_buffer.resize(buffer_size);
-		} catch (const boost::interprocess::bad_alloc &e) {
-			return report_allocation_failure(e);
-		} catch (const boost::container::length_error_t &e) {
+		} catch (const std::exception &e) {
 			return report_allocation_failure(e);
 		}
 		// Update data size in the mmap header

--- a/runtime/src/handler/perf_event_handler.cpp
+++ b/runtime/src/handler/perf_event_handler.cpp
@@ -9,6 +9,7 @@
 #include "bpftime_epoll.h"
 #endif
 #include "spdlog/spdlog.h"
+#include <boost/container/throw_exception.hpp>
 #include <boost/interprocess/detail/segment_manager_helper.hpp>
 #include <boost/interprocess/smart_ptr/shared_ptr.hpp>
 #include <cstring>
@@ -19,6 +20,7 @@
 #include <spdlog/fmt/bin_to_hex.h>
 #include <atomic>
 #include <cerrno>
+#include <exception>
 #include <limits>
 #include <unordered_map>
 #include <variant>
@@ -262,16 +264,33 @@ bool software_perf_event_buffer::has_data() const
 
 void *software_perf_event_buffer::ensure_mmap_buffer(size_t buffer_size)
 {
+	const size_t page_size = static_cast<size_t>(pagesize);
 	if (buffer_size > mmap_buffer.size()) {
-		SPDLOG_DEBUG("Expanding mmap buffer size to {}", buffer_size);
-		mmap_buffer.resize(buffer_size);
-		// Update data size in the mmap header
-		get_header_ref().data_size = buffer_size - pagesize;
-		if (popcnt(buffer_size - pagesize) != 1) {
+		if (buffer_size < page_size ||
+		    popcnt(buffer_size - page_size) != 1) {
 			SPDLOG_ERROR(
 				"Data size of a perf event buffer must be power of 2");
+			errno = EINVAL;
 			return nullptr;
 		}
+		SPDLOG_DEBUG("Expanding mmap buffer size to {}", buffer_size);
+		auto report_allocation_failure = [&](const std::exception
+							     &error) {
+			SPDLOG_ERROR(
+				"Unable to allocate {}-byte perf buffer: {}",
+				buffer_size, error.what());
+			errno = ENOMEM;
+			return nullptr;
+		};
+		try {
+			mmap_buffer.resize(buffer_size);
+		} catch (const boost::interprocess::bad_alloc &e) {
+			return report_allocation_failure(e);
+		} catch (const boost::container::length_error_t &e) {
+			return report_allocation_failure(e);
+		}
+		// Update data size in the mmap header
+		get_header_ref().data_size = buffer_size - page_size;
 	}
 	return mmap_buffer.data();
 }

--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -5,7 +5,6 @@
  */
 #include "bpftime_logger.hpp"
 #include "bpftime_shm.hpp"
-#include <boost/container/throw_exception.hpp>
 #include <boost/interprocess/exceptions.hpp>
 #ifdef ENABLE_BPFTIME_VERIFIER
 #include <bpftime-verifier.hpp>
@@ -161,8 +160,6 @@ void syscall_context::try_startup()
 	try {
 		start_up(*this);
 	} catch (const boost::interprocess::bad_alloc &e) {
-		exit_for_startup_allocation_failure(e);
-	} catch (const boost::container::length_error_t &e) {
 		exit_for_startup_allocation_failure(e);
 	}
 	enable_mock.store(true, std::memory_order_relaxed);
@@ -903,6 +900,9 @@ void *syscall_context::handle_mmap64(void *addr, size_t length, int prot,
 		    ptr != nullptr) {
 			mocked_mmap_values.insert((uintptr_t)ptr);
 			return ptr;
+		}
+		if (errno == 0) {
+			errno = ENOMEM;
 		}
 		return MAP_FAILED;
 	}

--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -895,6 +895,7 @@ void *syscall_context::handle_mmap64(void *addr, size_t length, int prot,
 	} else if (fd != -1 && bpftime_is_software_perf_event(fd)) {
 		SPDLOG_DEBUG(
 			"Entering mocked mmap64: software perf event handler");
+		errno = 0;
 		if (auto ptr = bpftime_get_software_perf_event_raw_buffer(
 			    fd, length);
 		    ptr != nullptr) {

--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -5,6 +5,8 @@
  */
 #include "bpftime_logger.hpp"
 #include "bpftime_shm.hpp"
+#include <boost/container/throw_exception.hpp>
+#include <boost/interprocess/exceptions.hpp>
 #ifdef ENABLE_BPFTIME_VERIFIER
 #include <bpftime-verifier.hpp>
 #endif
@@ -33,6 +35,7 @@
 #include "spdlog/spdlog.h"
 #include <cerrno>
 #include <cstdlib>
+#include <exception>
 #include <iterator>
 #include "syscall_server_utils.hpp"
 #include <optional>
@@ -67,6 +70,18 @@ using namespace bpftime_epoll;
 namespace fmt_lib = spdlog::fmt_lib;
 
 namespace {
+[[noreturn]] void
+exit_for_startup_allocation_failure(const std::exception &error)
+{
+	auto config = bpftime::construct_agent_config_from_env();
+	SPDLOG_CRITICAL(
+		"Unable to initialize bpftime shared memory ({} MiB, {} fd slots): {}",
+		config.shm_memory_size, config.max_fd_count, error.what());
+	SPDLOG_CRITICAL(
+		"Increase BPFTIME_SHM_MEMORY_MB or decrease BPFTIME_MAX_FD_COUNT");
+	std::exit(EXIT_FAILURE);
+}
+
 std::string format_verifier_program_dump(const uint64_t *instructions,
 					 size_t instruction_count)
 {
@@ -143,7 +158,13 @@ void syscall_context::initialize_cuda()
 void syscall_context::try_startup()
 {
 	enable_mock.store(false, std::memory_order_relaxed);
-	start_up(*this);
+	try {
+		start_up(*this);
+	} catch (const boost::interprocess::bad_alloc &e) {
+		exit_for_startup_allocation_failure(e);
+	} catch (const boost::container::length_error_t &e) {
+		exit_for_startup_allocation_failure(e);
+	}
 	enable_mock.store(true, std::memory_order_relaxed);
 }
 
@@ -883,6 +904,7 @@ void *syscall_context::handle_mmap64(void *addr, size_t length, int prot,
 			mocked_mmap_values.insert((uintptr_t)ptr);
 			return ptr;
 		}
+		return MAP_FAILED;
 	}
 	SPDLOG_DEBUG(
 		"Calling original mmap64: addr={}, length={}, prot={}, flags={}, fd={}, offset={}",

--- a/runtime/syscall-server/syscall_server_main.cpp
+++ b/runtime/syscall-server/syscall_server_main.cpp
@@ -9,8 +9,11 @@
 #else
 #include <asm/unistd_64.h>
 #endif
+#include <boost/container/throw_exception.hpp>
 #include <boost/interprocess/exceptions.hpp>
+#include <cerrno>
 #include <cstdio>
+#include <exception>
 #if __linux__
 #include "linux/bpf.h"
 #include <asm-generic/errno-base.h>
@@ -22,6 +25,8 @@
 #include <spdlog/cfg/env.h>
 #include <cstdarg>
 #include <sched.h>
+#include <sys/mman.h>
+#include <type_traits>
 
 // Helper function for safe logging with pointer parameters
 inline const char* safe_ptr_str(const char* ptr) {
@@ -76,16 +81,26 @@ template <typename F, typename... Args>
 auto handle_exceptions(F &&f, Args &&...args) noexcept
 	-> decltype(f(std::forward<Args>(args)...))
 {
+	using result_type = decltype(f(std::forward<Args>(args)...));
+	auto report_allocation_failure = [](const std::exception &error)
+		-> result_type {
+		SPDLOG_ERROR("Shared memory allocation failed: {}", error.what());
+		SPDLOG_ERROR(
+			"Returning ENOMEM; consider increasing BPFTIME_SHM_MEMORY_MB");
+		errno = ENOMEM;
+		if constexpr (std::is_pointer_v<result_type>) {
+			return MAP_FAILED;
+		} else {
+			return static_cast<result_type>(-1);
+		}
+	};
 	try {
 		return f(std::forward<Args>(args)...);
 	} catch (const boost::interprocess::bad_alloc &e) {
-		SPDLOG_ERROR("Boost interprocess bad_alloc: {}", e.what());
-		SPDLOG_ERROR("Consider increasing the shared memory size by "
-			     "setting the BPFTIME_SHM_MEMORY_MB env var.");
-		std::exit(1);
-		// Terminate the program after logging the exception
+		return report_allocation_failure(e);
+	} catch (const boost::container::length_error_t &e) {
+		return report_allocation_failure(e);
 	}
-	// More exceptions can be added here
 }
 
 extern "C" int epoll_wait(int epfd, epoll_event *evt, int maxevents,

--- a/runtime/syscall-server/syscall_server_main.cpp
+++ b/runtime/syscall-server/syscall_server_main.cpp
@@ -9,11 +9,8 @@
 #else
 #include <asm/unistd_64.h>
 #endif
-#include <boost/container/throw_exception.hpp>
 #include <boost/interprocess/exceptions.hpp>
-#include <cerrno>
 #include <cstdio>
-#include <exception>
 #if __linux__
 #include "linux/bpf.h"
 #include <asm-generic/errno-base.h>
@@ -25,8 +22,6 @@
 #include <spdlog/cfg/env.h>
 #include <cstdarg>
 #include <sched.h>
-#include <sys/mman.h>
-#include <type_traits>
 
 // Helper function for safe logging with pointer parameters
 inline const char* safe_ptr_str(const char* ptr) {
@@ -81,26 +76,16 @@ template <typename F, typename... Args>
 auto handle_exceptions(F &&f, Args &&...args) noexcept
 	-> decltype(f(std::forward<Args>(args)...))
 {
-	using result_type = decltype(f(std::forward<Args>(args)...));
-	auto report_allocation_failure = [](const std::exception &error)
-		-> result_type {
-		SPDLOG_ERROR("Shared memory allocation failed: {}", error.what());
-		SPDLOG_ERROR(
-			"Returning ENOMEM; consider increasing BPFTIME_SHM_MEMORY_MB");
-		errno = ENOMEM;
-		if constexpr (std::is_pointer_v<result_type>) {
-			return MAP_FAILED;
-		} else {
-			return static_cast<result_type>(-1);
-		}
-	};
 	try {
 		return f(std::forward<Args>(args)...);
 	} catch (const boost::interprocess::bad_alloc &e) {
-		return report_allocation_failure(e);
-	} catch (const boost::container::length_error_t &e) {
-		return report_allocation_failure(e);
+		SPDLOG_ERROR("Boost interprocess bad_alloc: {}", e.what());
+		SPDLOG_ERROR("Consider increasing the shared memory size by "
+			     "setting the BPFTIME_SHM_MEMORY_MB env var.");
+		std::exit(1);
+		// Terminate the program after logging the exception
 	}
+	// More exceptions can be added here
 }
 
 extern "C" int epoll_wait(int epfd, epoll_event *evt, int maxevents,

--- a/runtime/unit-test/CMakeLists.txt
+++ b/runtime/unit-test/CMakeLists.txt
@@ -32,6 +32,7 @@ set(TEST_SOURCES
     test_bpftime_shm_json.cpp
     test_probe.cpp
     test_config.cpp
+    test_shm_allocation_failure.cpp
     test_software_perf_event.cpp
 
     attach_with_ebpf/test_attach_filter_with_ebpf.cpp
@@ -50,6 +51,20 @@ if(${BPFTIME_ENABLE_CUDA_ATTACH})
 endif()
 option(TEST_LCOV "option for lcov" OFF)
 add_executable(bpftime_runtime_tests ${TEST_SOURCES})
+
+if(UNIX AND NOT APPLE)
+    add_executable(bpftime-shm-allocation-test-helper
+        assets/shm_allocation_test_helper.c)
+    set_property(TARGET bpftime-shm-allocation-test-helper PROPERTY C_STANDARD 99)
+    add_dependencies(bpftime_runtime_tests
+        bpftime-syscall-server
+        bpftime-shm-allocation-test-helper)
+    file(GENERATE
+        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/shm_allocation_test_paths.hpp"
+        CONTENT "#define BPFTIME_SHM_ALLOCATION_TEST_HELPER \"$<TARGET_FILE:bpftime-shm-allocation-test-helper>\"\n#define BPFTIME_SYSCALL_SERVER_LIBRARY \"$<TARGET_FILE:bpftime-syscall-server>\"\n")
+    target_include_directories(bpftime_runtime_tests PRIVATE
+        "${CMAKE_CURRENT_BINARY_DIR}")
+endif()
 
 if(${TEST_LCOV})
     target_compile_options(bpftime_runtime_tests PRIVATE -fprofile-arcs -ftest-coverage -fprofile-update=atomic)

--- a/runtime/unit-test/assets/shm_allocation_test_helper.c
+++ b/runtime/unit-test/assets/shm_allocation_test_helper.c
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (c) 2026, eunomia-bpf org
+ * All rights reserved.
+ */
+#include <errno.h>
+#include <linux/bpf.h>
+#include <linux/perf_event.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+static int trigger_startup(void)
+{
+	union bpf_attr attr;
+	memset(&attr, 0, sizeof(attr));
+	attr.map_type = BPF_MAP_TYPE_HASH;
+	attr.key_size = sizeof(int);
+	attr.value_size = sizeof(int);
+	attr.max_entries = 1;
+	memcpy(attr.map_name, "allocation_test", sizeof("allocation_test"));
+
+	(void)syscall(__NR_bpf, BPF_MAP_CREATE, &attr, sizeof(attr));
+	return 100;
+}
+
+static int trigger_perf_mmap(void)
+{
+	struct perf_event_attr attr;
+	memset(&attr, 0, sizeof(attr));
+	attr.type = PERF_TYPE_SOFTWARE;
+	attr.size = sizeof(attr);
+	attr.config = PERF_COUNT_SW_CPU_CLOCK;
+	attr.sample_type = PERF_SAMPLE_RAW;
+
+	int fd = syscall(__NR_perf_event_open, &attr, -1, 0, -1, 0);
+	if (fd < 0) {
+		perror("perf_event_open");
+		return 2;
+	}
+
+	size_t length = (size_t)getpagesize() + 8 * 1024 * 1024;
+	errno = 0;
+	void *buffer = mmap(NULL, length, PROT_READ | PROT_WRITE,
+			    MAP_SHARED, fd, 0);
+	if (buffer != MAP_FAILED || errno != ENOMEM) {
+		fprintf(stderr, "mmap=%p errno=%d\n", buffer, errno);
+		return 3;
+	}
+	return 0;
+}
+
+int main(int argc, char **argv)
+{
+	if (argc != 2) {
+		return 64;
+	}
+	if (strcmp(argv[1], "startup") == 0) {
+		return trigger_startup();
+	}
+	if (strcmp(argv[1], "perf-mmap") == 0) {
+		return trigger_perf_mmap();
+	}
+	return 64;
+}

--- a/runtime/unit-test/assets/shm_allocation_test_helper.c
+++ b/runtime/unit-test/assets/shm_allocation_test_helper.c
@@ -4,7 +4,7 @@
  * All rights reserved.
  */
 #include <errno.h>
-#include <linux/bpf.h>
+#include <fcntl.h>
 #include <linux/perf_event.h>
 #include <stdio.h>
 #include <string.h>
@@ -14,15 +14,14 @@
 
 static int trigger_startup(void)
 {
-	union bpf_attr attr;
-	memset(&attr, 0, sizeof(attr));
-	attr.map_type = BPF_MAP_TYPE_HASH;
-	attr.key_size = sizeof(int);
-	attr.value_size = sizeof(int);
-	attr.max_entries = 1;
-	memcpy(attr.map_name, "allocation_test", sizeof("allocation_test"));
-
-	(void)syscall(__NR_bpf, BPF_MAP_CREATE, &attr, sizeof(attr));
+	/* open() is intentionally not wrapped by handle_exceptions(), so this
+	 * verifies that try_startup() itself converts bad_alloc into exit(1).
+	 */
+	int fd = open("/dev/null", O_RDONLY, 0);
+	if (fd < 0) {
+		return 101;
+	}
+	close(fd);
 	return 100;
 }
 
@@ -42,7 +41,8 @@ static int trigger_perf_mmap(void)
 	}
 
 	size_t length = (size_t)getpagesize() + 8 * 1024 * 1024;
-	errno = 0;
+	/* The interposer must not leak the caller's stale errno on failure. */
+	errno = E2BIG;
 	void *buffer = mmap(NULL, length, PROT_READ | PROT_WRITE,
 			    MAP_SHARED, fd, 0);
 	if (buffer != MAP_FAILED || errno != ENOMEM) {

--- a/runtime/unit-test/test_shm_allocation_failure.cpp
+++ b/runtime/unit-test/test_shm_allocation_failure.cpp
@@ -1,0 +1,67 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (c) 2026, eunomia-bpf org
+ * All rights reserved.
+ */
+#include "catch2/catch_test_macros.hpp"
+
+#if defined(__linux__)
+#include "shm_allocation_test_paths.hpp"
+
+#include <boost/interprocess/shared_memory_object.hpp>
+#include <cerrno>
+#include <cstdlib>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace
+{
+int run_allocation_helper(const char *mode, const char *memory_mb,
+			  const char *max_fd_count)
+{
+	const std::string shm_name =
+		"bpftime-shm-allocation-test-" + std::string(mode) + "-" +
+		std::to_string(getpid());
+	boost::interprocess::shared_memory_object::remove(shm_name.c_str());
+
+	pid_t pid = fork();
+	REQUIRE(pid >= 0);
+	if (pid == 0) {
+		if (setenv("BPFTIME_GLOBAL_SHM_NAME", shm_name.c_str(), 1) != 0 ||
+		    setenv("BPFTIME_LOG_OUTPUT", "console", 1) != 0 ||
+		    setenv("BPFTIME_SHM_MEMORY_MB", memory_mb, 1) != 0 ||
+		    setenv("BPFTIME_MAX_FD_COUNT", max_fd_count, 1) != 0 ||
+		    setenv("LD_PRELOAD", BPFTIME_SYSCALL_SERVER_LIBRARY, 1) != 0) {
+			_exit(126);
+		}
+		execl(BPFTIME_SHM_ALLOCATION_TEST_HELPER,
+		      BPFTIME_SHM_ALLOCATION_TEST_HELPER, mode, nullptr);
+		_exit(127);
+	}
+
+	int status = 0;
+	while (waitpid(pid, &status, 0) == -1) {
+		REQUIRE(errno == EINTR);
+	}
+	boost::interprocess::shared_memory_object::remove(shm_name.c_str());
+	return status;
+}
+} // namespace
+
+TEST_CASE("Syscall server exits cleanly when startup shared memory is too small",
+	  "[allocation][syscall_server]")
+{
+	int status = run_allocation_helper("startup", "64", "1048576");
+	REQUIRE(WIFEXITED(status));
+	REQUIRE(WEXITSTATUS(status) == 1);
+}
+
+TEST_CASE("Syscall server perf mmap reports shared memory exhaustion",
+	  "[allocation][syscall_server]")
+{
+	int status = run_allocation_helper("perf-mmap", "4", "128");
+	REQUIRE(WIFEXITED(status));
+	REQUIRE(WEXITSTATUS(status) == 0);
+}
+#endif

--- a/runtime/unit-test/test_software_perf_event.cpp
+++ b/runtime/unit-test/test_software_perf_event.cpp
@@ -4,6 +4,7 @@
 #include "common_def.hpp"
 #include <atomic>
 #include <boost/interprocess/managed_shared_memory.hpp>
+#include <cerrno>
 #include <cstring>
 #include <string>
 #include <thread>
@@ -184,4 +185,27 @@ TEST_CASE("Software perf event producer shards rotate after mmap resize",
 	REQUIRE(actual.producer == payload.producer);
 	REQUIRE(actual.sequence == payload.sequence);
 	REQUIRE(tail + record_header.size == head);
+}
+
+TEST_CASE("Software perf event mmap reports shared memory exhaustion",
+	  "[perf_event][software_perf_event]")
+{
+	const std::string shared_memory_name =
+		"SoftwarePerfEventExhaustionTestShm-" +
+		std::to_string(getpid());
+	const size_t shared_memory_size = 1024 * 1024;
+	shm_remove remover{ std::string(shared_memory_name) };
+
+	boost::interprocess::managed_shared_memory shm(
+		boost::interprocess::create_only, shared_memory_name.c_str(),
+		shared_memory_size);
+
+	auto *perf = shm.construct<bpftime::software_perf_event_data>(
+		"perf")(0, 0, 0, shm);
+	REQUIRE(perf != nullptr);
+
+	const size_t ring_size = 2 * 1024 * 1024;
+	errno = 0;
+	REQUIRE(perf->ensure_mmap_buffer(getpagesize() + ring_size) == nullptr);
+	REQUIRE(errno == ENOMEM);
 }

--- a/usage.md
+++ b/usage.md
@@ -225,6 +225,8 @@ Sometimes larger maps may need more memory, you can set the memory size for shar
 BPFTIME_SHM_MEMORY_MB=1024 LD_PRELOAD=~/.bpftime/libbpftime-syscall-server.so example/malloc/malloc
 ```
 
+The shared memory also contains the handler table. Its capacity can be set with `BPFTIME_MAX_FD_COUNT` (the default is 6144), and larger values require more shared memory before any maps or perf buffers are allocated. If startup reports insufficient shared memory, increase `BPFTIME_SHM_MEMORY_MB` or reduce `BPFTIME_MAX_FD_COUNT`. Allocation failures while creating a perf buffer are reported to the caller as `ENOMEM`.
+
 ## Verifier
 
 Since the primary goal of bpftime is to stay aligned with kernel eBPF, it is recommended to use the kernel's eBPF verifier to ensure program safety.


### PR DESCRIPTION
## Summary

- exit cleanly with status 1 and an actionable message when syscall-server startup cannot allocate its configured shared-memory state
- return `MAP_FAILED` with deterministic `ENOMEM` when a software perf-event buffer cannot grow, without changing allocation handling for unrelated syscall paths
- validate perf ring sizes before mutation and document the relationship between shared-memory size and fd-table capacity
- add real `LD_PRELOAD` process tests for both startup failure and the exported `mmap()` boundary

## Testing

- `cmake --build build --target bpftime_runtime_tests -j2`
- `./build/runtime/unit-test/bpftime_runtime_tests "[allocation]"` (2 test cases, 6 assertions)
- `./build/runtime/unit-test/bpftime_runtime_tests "[perf_event]"` (3 test cases, 8279 assertions)
- unfiltered local suite: 76 test cases, 74 passed; the same two environment-dependent failures occur on the unchanged baseline (`Test shm progs attach` and `Test tail calling from userspace to kernel`)
- `git diff --check`

Closes #596