### PR TITLE
fix(runtime): isolate maps with colliding public names

### DIFF
--- a/runtime/src/handler/map_handler.cpp
+++ b/runtime/src/handler/map_handler.cpp
@@ -784,16 +784,14 @@ int bpf_map_handler::map_init(managed_shared_memory &memory)
 	switch (type) {
 	case bpf_map_type::BPF_MAP_TYPE_HASH: {
 #ifdef BPFTIME_USE_VAR_HASH_MAP
-		map_impl_ptr =
-			memory.construct<hash_map_impl>(
-				boost::interprocess::anonymous_instance)(
-				memory, key_size, value_size, max_entries,
-				static_cast<uint32_t>(flags));
+		map_impl_ptr = memory.construct<hash_map_impl>(
+			boost::interprocess::anonymous_instance)(
+			memory, key_size, value_size, max_entries,
+			static_cast<uint32_t>(flags));
 #else
-		map_impl_ptr =
-			memory.construct<hash_map_impl>(
-				boost::interprocess::anonymous_instance)(
-				memory, max_entries, key_size, value_size);
+		map_impl_ptr = memory.construct<hash_map_impl>(
+			boost::interprocess::anonymous_instance)(
+			memory, max_entries, key_size, value_size);
 #endif
 		init_refcnt();
 		return 0;
@@ -820,7 +818,7 @@ int bpf_map_handler::map_init(managed_shared_memory &memory)
 		}
 		map_impl_ptr = memory.construct<ringbuf_map_impl>(
 			boost::interprocess::anonymous_instance)(max_entries,
-							      memory);
+								 memory);
 		init_refcnt();
 		return 0;
 	}
@@ -889,7 +887,8 @@ int bpf_map_handler::map_init(managed_shared_memory &memory)
 	case bpf_map_type::BPF_MAP_TYPE_KERNEL_USER_ARRAY: {
 		map_impl_ptr = memory.construct<array_map_kernel_user_impl>(
 			boost::interprocess::anonymous_instance)(
-			memory, attr.kernel_bpf_map_id, value_size, max_entries);
+			memory, attr.kernel_bpf_map_id, value_size,
+			max_entries);
 		init_refcnt();
 		return 0;
 	}
@@ -935,7 +934,7 @@ int bpf_map_handler::map_init(managed_shared_memory &memory)
 	case bpf_map_type::BPF_MAP_TYPE_ARRAY_OF_MAPS: {
 		map_impl_ptr = memory.construct<array_map_of_maps_impl>(
 			boost::interprocess::anonymous_instance)(memory,
-							      max_entries);
+								 max_entries);
 		init_refcnt();
 		return 0;
 	}
@@ -1034,7 +1033,8 @@ int bpf_map_handler::map_init(managed_shared_memory &memory)
 			    name.c_str());
 		map_impl_ptr = memory.construct<array_map_kernel_gpu_impl>(
 			boost::interprocess::anonymous_instance)(
-			memory, attr.kernel_bpf_map_id, value_size, max_entries);
+			memory, attr.kernel_bpf_map_id, value_size,
+			max_entries);
 		init_refcnt();
 		shm_holder.global_shared_memory.set_enable_mock(true);
 		return 0;
@@ -1061,11 +1061,11 @@ int bpf_map_handler::map_init(managed_shared_memory &memory)
 		const uint64_t requested_thread_count = thread_count;
 		while (thread_count > 0) {
 			try {
-				map_impl_ptr =
-					memory.construct<nv_gpu_ringbuf_map_impl>(
-						boost::interprocess::anonymous_instance)(
-						memory, value_size, max_entries,
-						thread_count);
+				map_impl_ptr = memory.construct<
+					nv_gpu_ringbuf_map_impl>(
+					boost::interprocess::anonymous_instance)(
+					memory, value_size, max_entries,
+					thread_count);
 				break;
 			} catch (const boost::interprocess::bad_alloc &) {
 				if (thread_count <= 1) {
@@ -1200,8 +1200,8 @@ void bpf_map_handler::map_free(managed_shared_memory &memory) const
 			static_cast<percpu_array_map_kernel_user_impl *>(impl));
 		break;
 	case bpf_map_type::BPF_MAP_TYPE_KERNEL_USER_PERF_EVENT_ARRAY:
-		memory.destroy_ptr(static_cast<
-				   perf_event_array_kernel_user_impl *>(impl));
+		memory.destroy_ptr(
+			static_cast<perf_event_array_kernel_user_impl *>(impl));
 		break;
 	case bpf_map_type::BPF_MAP_TYPE_PROG_ARRAY:
 		memory.destroy_ptr(static_cast<prog_array_map_impl *>(impl));
@@ -1230,10 +1230,12 @@ void bpf_map_handler::map_free(managed_shared_memory &memory) const
 			static_cast<nv_gpu_shared_array_map_impl *>(impl));
 		break;
 	case bpf_map_type::BPF_MAP_TYPE_GPU_RINGBUF_MAP:
-		memory.destroy_ptr(static_cast<nv_gpu_ringbuf_map_impl *>(impl));
+		memory.destroy_ptr(
+			static_cast<nv_gpu_ringbuf_map_impl *>(impl));
 		break;
 	case bpf_map_type::BPF_MAP_TYPE_GPU_KERNEL_SHARED_ARRAY_MAP: {
-		memory.destroy_ptr(static_cast<array_map_kernel_gpu_impl *>(impl));
+		memory.destroy_ptr(
+			static_cast<array_map_kernel_gpu_impl *>(impl));
 		break;
 	}
 	case bpf_map_type::BPF_MAP_TYPE_PERGPUTD_ARRAY_HOST_MAP:

--- a/runtime/src/handler/map_handler.cpp
+++ b/runtime/src/handler/map_handler.cpp
@@ -61,11 +61,6 @@ bpftime_map_ops global_map_ops_table[(int)bpf_map_type::BPF_MAP_TYPE_MAX] = {
 	{ 0 }
 };
 
-std::string bpf_map_handler::get_container_name() const
-{
-	return "ebpf_map_fd_" + std::string(name.c_str());
-}
-
 uint32_t bpf_map_handler::get_value_size() const
 {
 	return value_size;
@@ -786,17 +781,18 @@ int bpf_map_handler::map_init(managed_shared_memory &memory)
 		}
 	};
 
-	auto container_name = get_container_name();
 	switch (type) {
 	case bpf_map_type::BPF_MAP_TYPE_HASH: {
 #ifdef BPFTIME_USE_VAR_HASH_MAP
 		map_impl_ptr =
-			memory.construct<hash_map_impl>(container_name.c_str())(
+			memory.construct<hash_map_impl>(
+				boost::interprocess::anonymous_instance)(
 				memory, key_size, value_size, max_entries,
 				static_cast<uint32_t>(flags));
 #else
 		map_impl_ptr =
-			memory.construct<hash_map_impl>(container_name.c_str())(
+			memory.construct<hash_map_impl>(
+				boost::interprocess::anonymous_instance)(
 				memory, max_entries, key_size, value_size);
 #endif
 		init_refcnt();
@@ -804,8 +800,8 @@ int bpf_map_handler::map_init(managed_shared_memory &memory)
 	}
 	case bpf_map_type::BPF_MAP_TYPE_ARRAY: {
 		map_impl_ptr = memory.construct<array_map_impl>(
-			container_name.c_str())(memory, value_size,
-						max_entries);
+			boost::interprocess::anonymous_instance)(
+			memory, value_size, max_entries);
 		init_refcnt();
 		return 0;
 	}
@@ -823,42 +819,43 @@ int bpf_map_handler::map_init(managed_shared_memory &memory)
 			return -1;
 		}
 		map_impl_ptr = memory.construct<ringbuf_map_impl>(
-			container_name.c_str())(max_entries, memory);
+			boost::interprocess::anonymous_instance)(max_entries,
+							      memory);
 		init_refcnt();
 		return 0;
 	}
 	case bpf_map_type::BPF_MAP_TYPE_PERF_EVENT_ARRAY: {
 		map_impl_ptr = memory.construct<perf_event_array_map_impl>(
-			container_name.c_str())(memory, key_size, value_size,
-						max_entries);
+			boost::interprocess::anonymous_instance)(
+			memory, key_size, value_size, max_entries);
 		init_refcnt();
 		return 0;
 	}
 	case bpf_map_type::BPF_MAP_TYPE_PERCPU_ARRAY: {
 		map_impl_ptr = memory.construct<per_cpu_array_map_impl>(
-			container_name.c_str())(memory, value_size,
-						max_entries);
+			boost::interprocess::anonymous_instance)(
+			memory, value_size, max_entries);
 		init_refcnt();
 		return 0;
 	}
 	case bpf_map_type::BPF_MAP_TYPE_PERCPU_HASH: {
 		map_impl_ptr = memory.construct<per_cpu_hash_map_impl>(
-			container_name.c_str())(memory, key_size, value_size,
-						max_entries);
+			boost::interprocess::anonymous_instance)(
+			memory, key_size, value_size, max_entries);
 		init_refcnt();
 		return 0;
 	}
 	case bpf_map_type::BPF_MAP_TYPE_QUEUE: {
 		map_impl_ptr = memory.construct<queue_map_impl>(
-			container_name.c_str())(memory, value_size,
-						max_entries);
+			boost::interprocess::anonymous_instance)(
+			memory, value_size, max_entries);
 		init_refcnt();
 		return 0;
 	}
 	case bpf_map_type::BPF_MAP_TYPE_STACK: {
 		map_impl_ptr = memory.construct<stack_map_impl>(
-			container_name.c_str())(memory, value_size,
-						max_entries);
+			boost::interprocess::anonymous_instance)(
+			memory, value_size, max_entries);
 		init_refcnt();
 		return 0;
 	}
@@ -882,8 +879,8 @@ int bpf_map_handler::map_init(managed_shared_memory &memory)
 		BloomHashAlgorithm hash_algo = BloomHashAlgorithm::JHASH;
 
 		map_impl_ptr = memory.construct<bloom_filter_map_impl>(
-			container_name.c_str())(memory, value_size, max_entries,
-						nr_hashes, hash_algo);
+			boost::interprocess::anonymous_instance)(
+			memory, value_size, max_entries, nr_hashes, hash_algo);
 		init_refcnt();
 		return 0;
 	}
@@ -891,29 +888,30 @@ int bpf_map_handler::map_init(managed_shared_memory &memory)
 #ifdef BPFTIME_BUILD_WITH_LIBBPF
 	case bpf_map_type::BPF_MAP_TYPE_KERNEL_USER_ARRAY: {
 		map_impl_ptr = memory.construct<array_map_kernel_user_impl>(
-			container_name.c_str())(memory, attr.kernel_bpf_map_id,
-						value_size, max_entries);
+			boost::interprocess::anonymous_instance)(
+			memory, attr.kernel_bpf_map_id, value_size, max_entries);
 		init_refcnt();
 		return 0;
 	}
 	case bpf_map_type::BPF_MAP_TYPE_KERNEL_USER_HASH: {
 		map_impl_ptr = memory.construct<hash_map_kernel_user_impl>(
-			container_name.c_str())(memory, attr.kernel_bpf_map_id);
+			boost::interprocess::anonymous_instance)(
+			memory, attr.kernel_bpf_map_id);
 		init_refcnt();
 		return 0;
 	}
 	case bpf_map_type::BPF_MAP_TYPE_KERNEL_USER_PERCPU_ARRAY: {
 		map_impl_ptr =
 			memory.construct<percpu_array_map_kernel_user_impl>(
-				container_name.c_str())(memory,
-							attr.kernel_bpf_map_id);
+				boost::interprocess::anonymous_instance)(
+				memory, attr.kernel_bpf_map_id);
 		init_refcnt();
 		return 0;
 	}
 	case bpf_map_type::BPF_MAP_TYPE_KERNEL_USER_PERF_EVENT_ARRAY: {
 		map_impl_ptr =
 			memory.construct<perf_event_array_kernel_user_impl>(
-				container_name.c_str())(
+				boost::interprocess::anonymous_instance)(
 				memory, 4, 4, sysconf(_SC_NPROCESSORS_ONLN),
 				attr.kernel_bpf_map_id);
 		init_refcnt();
@@ -921,29 +919,30 @@ int bpf_map_handler::map_init(managed_shared_memory &memory)
 	}
 	case bpf_map_type::BPF_MAP_TYPE_PROG_ARRAY: {
 		map_impl_ptr = memory.construct<prog_array_map_impl>(
-			container_name.c_str())(memory, key_size, value_size,
-						max_entries);
+			boost::interprocess::anonymous_instance)(
+			memory, key_size, value_size, max_entries);
 		init_refcnt();
 		return 0;
 	}
 	case bpf_map_type::BPF_MAP_TYPE_STACK_TRACE: {
 		map_impl_ptr = memory.construct<stack_trace_map_impl>(
-			container_name.c_str())(memory, key_size, value_size,
-						max_entries);
+			boost::interprocess::anonymous_instance)(
+			memory, key_size, value_size, max_entries);
 		init_refcnt();
 		return 0;
 	}
 #endif
 	case bpf_map_type::BPF_MAP_TYPE_ARRAY_OF_MAPS: {
 		map_impl_ptr = memory.construct<array_map_of_maps_impl>(
-			container_name.c_str())(memory, max_entries);
+			boost::interprocess::anonymous_instance)(memory,
+							      max_entries);
 		init_refcnt();
 		return 0;
 	}
 	case bpf_map_type::BPF_MAP_TYPE_LRU_HASH: {
 		map_impl_ptr = memory.construct<lru_var_hash_map_impl>(
-			container_name.c_str())(memory, key_size, value_size,
-						max_entries);
+			boost::interprocess::anonymous_instance)(
+			memory, key_size, value_size, max_entries);
 		init_refcnt();
 		return 0;
 	}
@@ -967,10 +966,10 @@ int bpf_map_handler::map_init(managed_shared_memory &memory)
 		}
 		SPDLOG_INFO(
 			"Map {} (nv_gpu_shared_hash_map_impl) shared hashmap",
-			container_name.c_str());
+			name.c_str());
 		map_impl_ptr = memory.construct<nv_gpu_shared_hash_map_impl>(
-			container_name.c_str())(memory, max_entries, key_size,
-						value_size);
+			boost::interprocess::anonymous_instance)(
+			memory, max_entries, key_size, value_size);
 		init_refcnt();
 		shm_holder.global_shared_memory.set_enable_mock(true);
 		return 0;
@@ -994,10 +993,10 @@ int bpf_map_handler::map_init(managed_shared_memory &memory)
 		auto thread_count = get_thread_count(attr);
 		SPDLOG_INFO(
 			"Map {} (nv_gpu_per_thread_array_map_impl) has space for thread count {}",
-			container_name.c_str(), thread_count);
+			name.c_str(), thread_count);
 		map_impl_ptr =
 			memory.construct<nv_gpu_per_thread_array_map_impl>(
-				container_name.c_str())(
+				boost::interprocess::anonymous_instance)(
 				memory, value_size, max_entries, thread_count);
 		init_refcnt();
 		shm_holder.global_shared_memory.set_enable_mock(true);
@@ -1014,10 +1013,10 @@ int bpf_map_handler::map_init(managed_shared_memory &memory)
 		}
 		SPDLOG_INFO(
 			"Map {} (nv_gpu_shared_array_map_impl) shared array",
-			container_name.c_str());
+			name.c_str());
 		map_impl_ptr = memory.construct<nv_gpu_shared_array_map_impl>(
-			container_name.c_str())(memory, value_size,
-						max_entries);
+			boost::interprocess::anonymous_instance)(
+			memory, value_size, max_entries);
 		init_refcnt();
 		shm_holder.global_shared_memory.set_enable_mock(true);
 		return 0;
@@ -1032,10 +1031,10 @@ int bpf_map_handler::map_init(managed_shared_memory &memory)
 				gettid(), (uintptr_t)context);
 		}
 		SPDLOG_INFO("Map {} (array_map_kernel_gpu_impl) shared array",
-			    container_name.c_str());
+			    name.c_str());
 		map_impl_ptr = memory.construct<array_map_kernel_gpu_impl>(
-			container_name.c_str())(memory, attr.kernel_bpf_map_id,
-						value_size, max_entries);
+			boost::interprocess::anonymous_instance)(
+			memory, attr.kernel_bpf_map_id, value_size, max_entries);
 		init_refcnt();
 		shm_holder.global_shared_memory.set_enable_mock(true);
 		return 0;
@@ -1058,13 +1057,13 @@ int bpf_map_handler::map_init(managed_shared_memory &memory)
 		auto thread_count = get_thread_count(attr);
 		SPDLOG_INFO(
 			"Map {} (nv_gpu_ringbuf_map_impl) has space for thread count {}",
-			container_name.c_str(), thread_count);
+			name.c_str(), thread_count);
 		const uint64_t requested_thread_count = thread_count;
 		while (thread_count > 0) {
 			try {
 				map_impl_ptr =
 					memory.construct<nv_gpu_ringbuf_map_impl>(
-						container_name.c_str())(
+						boost::interprocess::anonymous_instance)(
 						memory, value_size, max_entries,
 						thread_count);
 				break;
@@ -1091,27 +1090,29 @@ int bpf_map_handler::map_init(managed_shared_memory &memory)
 	case bpf_map_type::BPF_MAP_TYPE_PERGPUTD_ARRAY_HOST_MAP: {
 		SPDLOG_INFO(
 			"Map {} (nv_gpu_array_host_map_impl) has space for thread count {}",
-			container_name.c_str(), attr.gpu_thread_count);
+			name.c_str(), attr.gpu_thread_count);
 		map_impl_ptr = memory.construct<nv_gpu_array_host_map_impl>(
-			container_name.c_str())(memory, value_size, max_entries,
-						attr.gpu_thread_count);
+			boost::interprocess::anonymous_instance)(
+			memory, value_size, max_entries, attr.gpu_thread_count);
+		init_refcnt();
 		return 0;
 	}
 	case bpf_map_type::BPF_MAP_TYPE_GPU_ARRAY_HOST_MAP: {
 		SPDLOG_INFO(
 			"Map {} (nv_gpu_shared_array_host_map_impl) shared array",
-			container_name.c_str());
+			name.c_str());
 		map_impl_ptr =
 			memory.construct<nv_gpu_shared_array_host_map_impl>(
-				container_name.c_str())(memory, value_size,
-							max_entries);
+				boost::interprocess::anonymous_instance)(
+				memory, value_size, max_entries);
+		init_refcnt();
 		return 0;
 	}
 #endif
 	case bpf_map_type::BPF_MAP_TYPE_LPM_TRIE: {
 		map_impl_ptr = memory.construct<lpm_trie_map_impl>(
-			container_name.c_str())(memory, key_size, value_size,
-						max_entries);
+			boost::interprocess::anonymous_instance)(
+			memory, key_size, value_size, max_entries);
 		init_refcnt();
 		return 0;
 	}
@@ -1139,6 +1140,7 @@ void bpf_map_handler::map_free(managed_shared_memory &memory) const
 	if (map_impl_ptr.get() == nullptr) {
 		return;
 	}
+	void *impl = map_impl_ptr.get();
 
 	if (map_refcnt_ptr.get() != nullptr) {
 		auto prev = map_refcnt_ptr->fetch_sub(1,
@@ -1149,99 +1151,98 @@ void bpf_map_handler::map_free(managed_shared_memory &memory) const
 			return;
 		}
 		memory.destroy_ptr(map_refcnt_ptr.get());
-		map_impl_ptr = nullptr;
 		map_refcnt_ptr = nullptr;
 	}
 
-	auto container_name = get_container_name();
 	switch (type) {
 	case bpf_map_type::BPF_MAP_TYPE_HASH:
-		memory.destroy<hash_map_impl>(container_name.c_str());
+		memory.destroy_ptr(static_cast<hash_map_impl *>(impl));
 		break;
 	case bpf_map_type::BPF_MAP_TYPE_ARRAY:
-		memory.destroy<array_map_impl>(container_name.c_str());
+		memory.destroy_ptr(static_cast<array_map_impl *>(impl));
 		break;
 	case bpf_map_type::BPF_MAP_TYPE_RINGBUF:
-		memory.destroy<ringbuf_map_impl>(container_name.c_str());
+		memory.destroy_ptr(static_cast<ringbuf_map_impl *>(impl));
 		break;
 	case bpf_map_type::BPF_MAP_TYPE_PERF_EVENT_ARRAY:
-		memory.destroy<perf_event_array_map_impl>(
-			container_name.c_str());
+		memory.destroy_ptr(
+			static_cast<perf_event_array_map_impl *>(impl));
 		break;
 	case bpf_map_type::BPF_MAP_TYPE_PERCPU_ARRAY:
-		memory.destroy<per_cpu_array_map_impl>(container_name.c_str());
+		memory.destroy_ptr(static_cast<per_cpu_array_map_impl *>(impl));
 		break;
 	case bpf_map_type::BPF_MAP_TYPE_PERCPU_HASH:
-		memory.destroy<per_cpu_hash_map_impl>(container_name.c_str());
-		break;
-	case bpf_map_type::BPF_MAP_TYPE_STACK_TRACE:
-		memory.destroy<stack_trace_map_impl>(container_name.c_str());
+		memory.destroy_ptr(static_cast<per_cpu_hash_map_impl *>(impl));
 		break;
 	case bpf_map_type::BPF_MAP_TYPE_QUEUE:
-		memory.destroy<queue_map_impl>(container_name.c_str());
+		memory.destroy_ptr(static_cast<queue_map_impl *>(impl));
 		break;
 	case bpf_map_type::BPF_MAP_TYPE_STACK:
-		memory.destroy<stack_map_impl>(container_name.c_str());
+		memory.destroy_ptr(static_cast<stack_map_impl *>(impl));
 		break;
 	case bpf_map_type::BPF_MAP_TYPE_BLOOM_FILTER:
-		memory.destroy<bloom_filter_map_impl>(container_name.c_str());
+		memory.destroy_ptr(static_cast<bloom_filter_map_impl *>(impl));
 		break;
 #ifdef BPFTIME_BUILD_WITH_LIBBPF
+	case bpf_map_type::BPF_MAP_TYPE_STACK_TRACE:
+		memory.destroy_ptr(static_cast<stack_trace_map_impl *>(impl));
+		break;
 	case bpf_map_type::BPF_MAP_TYPE_KERNEL_USER_ARRAY:
-		memory.destroy<array_map_kernel_user_impl>(
-			container_name.c_str());
+		memory.destroy_ptr(
+			static_cast<array_map_kernel_user_impl *>(impl));
 		break;
 	case bpf_map_type::BPF_MAP_TYPE_KERNEL_USER_HASH:
-		memory.destroy<hash_map_kernel_user_impl>(
-			container_name.c_str());
+		memory.destroy_ptr(
+			static_cast<hash_map_kernel_user_impl *>(impl));
 		break;
 	case bpf_map_type::BPF_MAP_TYPE_KERNEL_USER_PERCPU_ARRAY:
-		memory.destroy<percpu_array_map_kernel_user_impl>(
-			container_name.c_str());
+		memory.destroy_ptr(
+			static_cast<percpu_array_map_kernel_user_impl *>(impl));
 		break;
 	case bpf_map_type::BPF_MAP_TYPE_KERNEL_USER_PERF_EVENT_ARRAY:
-		memory.destroy<perf_event_array_kernel_user_impl>(
-			container_name.c_str());
+		memory.destroy_ptr(static_cast<
+				   perf_event_array_kernel_user_impl *>(impl));
 		break;
 	case bpf_map_type::BPF_MAP_TYPE_PROG_ARRAY:
-		memory.destroy<prog_array_map_impl>(container_name.c_str());
+		memory.destroy_ptr(static_cast<prog_array_map_impl *>(impl));
+		break;
+#endif
+	case bpf_map_type::BPF_MAP_TYPE_ARRAY_OF_MAPS:
+		memory.destroy_ptr(static_cast<array_map_of_maps_impl *>(impl));
 		break;
 	case bpf_map_type::BPF_MAP_TYPE_LRU_HASH:
-		memory.destroy<lru_var_hash_map_impl>(container_name.c_str());
+		memory.destroy_ptr(static_cast<lru_var_hash_map_impl *>(impl));
 		break;
 	case bpf_map_type::BPF_MAP_TYPE_LPM_TRIE:
-		memory.destroy<lpm_trie_map_impl>(container_name.c_str());
+		memory.destroy_ptr(static_cast<lpm_trie_map_impl *>(impl));
 		break;
-
-#endif
 #if defined(BPFTIME_ENABLE_CUDA_ATTACH)
 	case bpf_map_type::BPF_MAP_TYPE_GPU_HASH_MAP:
-		memory.destroy<nv_gpu_shared_hash_map_impl>(
-			container_name.c_str());
+		memory.destroy_ptr(
+			static_cast<nv_gpu_shared_hash_map_impl *>(impl));
 		break;
 	case bpf_map_type::BPF_MAP_TYPE_PERGPUTD_ARRAY_MAP:
-		memory.destroy<nv_gpu_per_thread_array_map_impl>(
-			container_name.c_str());
+		memory.destroy_ptr(
+			static_cast<nv_gpu_per_thread_array_map_impl *>(impl));
 		break;
 	case bpf_map_type::BPF_MAP_TYPE_GPU_ARRAY_MAP:
-		memory.destroy<nv_gpu_shared_array_map_impl>(
-			container_name.c_str());
+		memory.destroy_ptr(
+			static_cast<nv_gpu_shared_array_map_impl *>(impl));
 		break;
 	case bpf_map_type::BPF_MAP_TYPE_GPU_RINGBUF_MAP:
-		memory.destroy<nv_gpu_ringbuf_map_impl>(container_name.c_str());
+		memory.destroy_ptr(static_cast<nv_gpu_ringbuf_map_impl *>(impl));
 		break;
 	case bpf_map_type::BPF_MAP_TYPE_GPU_KERNEL_SHARED_ARRAY_MAP: {
-		memory.destroy<array_map_kernel_gpu_impl>(
-			container_name.c_str());
+		memory.destroy_ptr(static_cast<array_map_kernel_gpu_impl *>(impl));
 		break;
 	}
 	case bpf_map_type::BPF_MAP_TYPE_PERGPUTD_ARRAY_HOST_MAP:
-		memory.destroy<nv_gpu_array_host_map_impl>(
-			container_name.c_str());
+		memory.destroy_ptr(
+			static_cast<nv_gpu_array_host_map_impl *>(impl));
 		break;
 	case bpf_map_type::BPF_MAP_TYPE_GPU_ARRAY_HOST_MAP:
-		memory.destroy<nv_gpu_shared_array_host_map_impl>(
-			container_name.c_str());
+		memory.destroy_ptr(
+			static_cast<nv_gpu_shared_array_host_map_impl *>(impl));
 		break;
 #endif
 	default:

--- a/runtime/src/handler/map_handler.hpp
+++ b/runtime/src/handler/map_handler.hpp
@@ -275,7 +275,6 @@ class bpf_map_handler {
 #endif
     private:
 	int id = 0;
-	std::string get_container_name() const;
 	mutable pthread_spinlock_t map_lock;
 	// The underlying data structure of the map
 	mutable general_map_impl_ptr map_impl_ptr;

--- a/runtime/unit-test/maps/test_shm_hash_maps.cpp
+++ b/runtime/unit-test/maps/test_shm_hash_maps.cpp
@@ -6,6 +6,7 @@
 #include "catch2/catch_test_macros.hpp"
 #include "spdlog/spdlog.h"
 #include "bpftime_handler.hpp"
+#include <array>
 #include <boost/interprocess/creation_tags.hpp>
 #include <cstdint>
 #include <linux/bpf.h>
@@ -132,4 +133,87 @@ TEST_CASE("Test shm hash maps with sub process")
 		REQUIRE(segment.find<handler_manager>(HANDLER_NAME).first ==
 			nullptr);
 	}
+}
+
+TEST_CASE("Hash maps with colliding public names remain independent",
+	  "[maps][map_name]")
+{
+	static const char *collision_shm_name =
+		"bpftime_map_name_collision_test";
+	struct shm_remove remover(collision_shm_name);
+	managed_shared_memory segment(create_only, collision_shm_name, 8 << 20);
+	auto *manager = segment.construct<handler_manager>(HANDLER_NAME)(
+		segment, MIN_MAX_FD_COUNT);
+	const auto named_objects_before_maps = segment.get_num_named_objects();
+	const auto free_memory_before_maps = segment.get_free_memory();
+
+	bpf_map_attr attr{
+		.type = BPF_MAP_TYPE_HASH,
+		.key_size = sizeof(uint32_t),
+		.value_size = sizeof(uint64_t),
+		.max_ents = 16,
+	};
+	/* The first pair models two kernel-truncated names; the remaining pairs
+	 * cover identical short names and anonymous public names.
+	 */
+	constexpr std::array<const char *, 6> names = {
+		"libc_malloc_cal", "libc_malloc_cal", "same", "same", "", ""
+	};
+	std::array<uint64_t, names.size()> expected_values{};
+	const uint32_t key = 1;
+
+	for (std::size_t i = 0; i < names.size(); i++) {
+		const int fd = static_cast<int>(i + 1);
+		REQUIRE(manager->set_handler(
+				fd, bpf_map_handler(fd, names[i], segment, attr),
+				segment) == fd);
+		REQUIRE(segment.get_num_named_objects() ==
+			named_objects_before_maps);
+
+		auto &map = std::get<bpf_map_handler>((*manager)[fd]);
+		REQUIRE(std::string(map.name.c_str()) == names[i]);
+		expected_values[i] = 100 + i;
+		REQUIRE(map.map_update_elem(&key, &expected_values[i], BPF_ANY) ==
+			0);
+	}
+
+	for (std::size_t i = 0; i < names.size(); i++) {
+		auto &map =
+			std::get<bpf_map_handler>((*manager)[static_cast<int>(i + 1)]);
+		auto *value = static_cast<const uint64_t *>(
+			map.map_lookup_elem(&key));
+		REQUIRE(value != nullptr);
+		REQUIRE(*value == expected_values[i]);
+	}
+
+	constexpr int source_fd = 1;
+	constexpr int duplicate_fd = 7;
+	auto &source = std::get<bpf_map_handler>((*manager)[source_fd]);
+	bpf_map_handler duplicate(duplicate_fd, source.name.c_str(), segment,
+				  source.attr);
+	duplicate.share_map_impl_from(source);
+	source.inc_map_refcount();
+	REQUIRE(manager->set_handler(duplicate_fd, std::move(duplicate),
+				     segment) == duplicate_fd);
+
+	manager->clear_id_at(source_fd, segment);
+	auto &shared_map =
+		std::get<bpf_map_handler>((*manager)[duplicate_fd]);
+	auto *shared_value = static_cast<const uint64_t *>(
+		shared_map.map_lookup_elem(&key));
+	REQUIRE(shared_value != nullptr);
+	REQUIRE(*shared_value == expected_values[0]);
+
+	manager->clear_id_at(duplicate_fd, segment);
+	auto &independent_peer = std::get<bpf_map_handler>((*manager)[2]);
+	auto *peer_value = static_cast<const uint64_t *>(
+		independent_peer.map_lookup_elem(&key));
+	REQUIRE(peer_value != nullptr);
+	REQUIRE(*peer_value == expected_values[1]);
+
+	manager->clear_all(segment);
+	REQUIRE(segment.get_num_named_objects() == named_objects_before_maps);
+	REQUIRE(segment.get_free_memory() == free_memory_before_maps);
+	segment.destroy_ptr(manager);
+	shared_memory_object::remove(collision_shm_name);
 }

--- a/runtime/unit-test/maps/test_shm_hash_maps.cpp
+++ b/runtime/unit-test/maps/test_shm_hash_maps.cpp
@@ -142,8 +142,8 @@ TEST_CASE("Hash maps with colliding public names remain independent",
 		"bpftime_map_name_collision_test";
 	struct shm_remove remover(collision_shm_name);
 	managed_shared_memory segment(create_only, collision_shm_name, 8 << 20);
-	auto *manager = segment.construct<handler_manager>(HANDLER_NAME)(
-		segment, MIN_MAX_FD_COUNT);
+	auto *manager = segment.construct<handler_manager>(
+		HANDLER_NAME)(segment, MIN_MAX_FD_COUNT);
 	const auto named_objects_before_maps = segment.get_num_named_objects();
 	const auto free_memory_before_maps = segment.get_free_memory();
 
@@ -164,22 +164,23 @@ TEST_CASE("Hash maps with colliding public names remain independent",
 
 	for (std::size_t i = 0; i < names.size(); i++) {
 		const int fd = static_cast<int>(i + 1);
-		REQUIRE(manager->set_handler(
-				fd, bpf_map_handler(fd, names[i], segment, attr),
-				segment) == fd);
+		REQUIRE(manager->set_handler(fd,
+					     bpf_map_handler(fd, names[i],
+							     segment, attr),
+					     segment) == fd);
 		REQUIRE(segment.get_num_named_objects() ==
 			named_objects_before_maps);
 
 		auto &map = std::get<bpf_map_handler>((*manager)[fd]);
 		REQUIRE(std::string(map.name.c_str()) == names[i]);
 		expected_values[i] = 100 + i;
-		REQUIRE(map.map_update_elem(&key, &expected_values[i], BPF_ANY) ==
-			0);
+		REQUIRE(map.map_update_elem(&key, &expected_values[i],
+					    BPF_ANY) == 0);
 	}
 
 	for (std::size_t i = 0; i < names.size(); i++) {
-		auto &map =
-			std::get<bpf_map_handler>((*manager)[static_cast<int>(i + 1)]);
+		auto &map = std::get<bpf_map_handler>(
+			(*manager)[static_cast<int>(i + 1)]);
 		auto *value = static_cast<const uint64_t *>(
 			map.map_lookup_elem(&key));
 		REQUIRE(value != nullptr);
@@ -197,10 +198,9 @@ TEST_CASE("Hash maps with colliding public names remain independent",
 				     segment) == duplicate_fd);
 
 	manager->clear_id_at(source_fd, segment);
-	auto &shared_map =
-		std::get<bpf_map_handler>((*manager)[duplicate_fd]);
-	auto *shared_value = static_cast<const uint64_t *>(
-		shared_map.map_lookup_elem(&key));
+	auto &shared_map = std::get<bpf_map_handler>((*manager)[duplicate_fd]);
+	auto *shared_value =
+		static_cast<const uint64_t *>(shared_map.map_lookup_elem(&key));
 	REQUIRE(shared_value != nullptr);
 	REQUIRE(*shared_value == expected_values[0]);
 

--- a/runtime/unit-test/maps/test_shm_hash_maps.cpp
+++ b/runtime/unit-test/maps/test_shm_hash_maps.cpp
@@ -10,11 +10,24 @@
 #include <boost/interprocess/creation_tags.hpp>
 #include <cstdint>
 #include <linux/bpf.h>
+#include <string>
 #include <sys/wait.h>
 #include <unistd.h>
 
 static const char *SHM_NAME = "my_shm_maps_test";
 static const char *HANDLER_NAME = "my_handler";
+
+struct named_shm_remove {
+	explicit named_shm_remove(const char *name) : name(name)
+	{
+		boost::interprocess::shared_memory_object::remove(name);
+	}
+	~named_shm_remove()
+	{
+		boost::interprocess::shared_memory_object::remove(name);
+	}
+	const char *name;
+};
 
 using namespace boost::interprocess;
 using namespace bpftime;
@@ -140,7 +153,7 @@ TEST_CASE("Hash maps with colliding public names remain independent",
 {
 	static const char *collision_shm_name =
 		"bpftime_map_name_collision_test";
-	struct shm_remove remover(collision_shm_name);
+	named_shm_remove remover(collision_shm_name);
 	managed_shared_memory segment(create_only, collision_shm_name, 8 << 20);
 	auto *manager = segment.construct<handler_manager>(
 		HANDLER_NAME)(segment, MIN_MAX_FD_COUNT);
@@ -215,5 +228,4 @@ TEST_CASE("Hash maps with colliding public names remain independent",
 	REQUIRE(segment.get_num_named_objects() == named_objects_before_maps);
 	REQUIRE(segment.get_free_memory() == free_memory_before_maps);
 	segment.destroy_ptr(manager);
-	shared_memory_object::remove(collision_shm_name);
 }


### PR DESCRIPTION
## Summary

- keep kernel-compatible public map names while allocating each built-in map implementation as an anonymous shared-memory object
- destroy map implementations through their existing offset pointer when the shared dup refcount reaches zero
- extend refcounted lifetime handling to CUDA host map implementations and cover previously missing typed destruction cases
- verify truncated-name collisions, identical short names, empty names, map independence, anonymous allocation, cleanup, and duplicated-fd lifetime

## Testing

- `cmake --build build --target bpftime_runtime_tests -j2`
- `./build/runtime/unit-test/bpftime_runtime_tests "[map_name]"` (1 test case, 43 assertions)
- unfiltered local suite: 74 test cases, 72 passed and 8,592,652 assertions passed; the same two environment-dependent failures occur on the unchanged baseline (`Test shm progs attach` and `Test tail calling from userspace to kernel`)
- `git diff --check origin/master...HEAD`

Closes #595