### PR TITLE
runtime: support bpf_ktime_get_boot_ns

### DIFF
--- a/runtime/src/bpf_helper.cpp
+++ b/runtime/src/bpf_helper.cpp
@@ -315,6 +315,18 @@ uint64_t bpftime_ktime_get_coarse_ns(uint64_t, uint64_t, uint64_t, uint64_t,
 	return spec.tv_sec * (uint64_t)1000000000 + spec.tv_nsec;
 }
 
+uint64_t bpftime_ktime_get_boot_ns(uint64_t, uint64_t, uint64_t, uint64_t,
+				   uint64_t)
+{
+	timespec spec;
+#ifdef CLOCK_BOOTTIME
+	clock_gettime(CLOCK_BOOTTIME, &spec);
+#else
+	clock_gettime(CLOCK_MONOTONIC, &spec);
+#endif
+	return spec.tv_sec * (uint64_t)1000000000 + spec.tv_nsec;
+}
+
 uint64_t bpftime_get_current_pid_tgid(uint64_t, uint64_t, uint64_t, uint64_t,
 				      uint64_t)
 {
@@ -1213,6 +1225,12 @@ bpftime_helper_group::get_kernel_utils_helper_group()
 			    .index = BPF_FUNC_ktime_get_ns,
 			    .name = "bpf_ktime_get_ns",
 			    .fn = (void *)bpftime_ktime_get_ns,
+		    } },
+		  { BPF_FUNC_ktime_get_boot_ns,
+		    bpftime_helper_info{
+			    .index = BPF_FUNC_ktime_get_boot_ns,
+			    .name = "bpf_ktime_get_boot_ns",
+			    .fn = (void *)bpftime_ktime_get_boot_ns,
 		    } },
 		  { BPF_FUNC_trace_printk,
 		    bpftime_helper_info{

--- a/runtime/src/bpf_helper.cpp
+++ b/runtime/src/bpf_helper.cpp
@@ -318,12 +318,12 @@ uint64_t bpftime_ktime_get_coarse_ns(uint64_t, uint64_t, uint64_t, uint64_t,
 uint64_t bpftime_ktime_get_boot_ns(uint64_t, uint64_t, uint64_t, uint64_t,
 				   uint64_t)
 {
-	timespec spec;
+	timespec spec{};
 #ifdef CLOCK_BOOTTIME
-	clock_gettime(CLOCK_BOOTTIME, &spec);
-#else
-	clock_gettime(CLOCK_MONOTONIC, &spec);
+	if (clock_gettime(CLOCK_BOOTTIME, &spec) == 0)
+		return spec.tv_sec * (uint64_t)1000000000 + spec.tv_nsec;
 #endif
+	clock_gettime(CLOCK_MONOTONIC, &spec);
 	return spec.tv_sec * (uint64_t)1000000000 + spec.tv_nsec;
 }
 

--- a/runtime/unit-test/assets/helpers.bpf.c
+++ b/runtime/unit-test/assets/helpers.bpf.c
@@ -19,5 +19,5 @@ int print_and_add1(struct data *d, int sz) {
 	bpf_printk("print_and_add1: %d\n", sz);
 	if (!bpf_ktime_get_boot_ns())
 		return 0;
- 	return 23;
+	return 23;
 }

--- a/runtime/unit-test/assets/helpers.bpf.c
+++ b/runtime/unit-test/assets/helpers.bpf.c
@@ -17,5 +17,7 @@ SEC("uprobe")
 int print_and_add1(struct data *d, int sz) {
 	bpf_printk("print_and_add1\n");
 	bpf_printk("print_and_add1: %d\n", sz);
+	if (!bpf_ktime_get_boot_ns())
+		return 0;
  	return 23;
 }


### PR DESCRIPTION
## Summary

- implement and register helper ID 125 (`bpf_ktime_get_boot_ns`)
- use `CLOCK_BOOTTIME`, with `CLOCK_MONOTONIC` as a portability fallback
- exercise the helper through the LLVM JIT helper regression program

Fixes #608

## Validation

- `cmake -B build -DCMAKE_BUILD_TYPE=Release -DBPFTIME_ENABLE_LTO=NO -DBPFTIME_LLVM_JIT=YES -DBPFTIME_ENABLE_UNIT_TESTING=1`
- `cmake --build build --target bpftime_runtime_tests -j$(nproc)`
- `./build/runtime/unit-test/bpftime_runtime_tests 'Test helpers'` (1 test case, 5 assertions passed)
- full runtime test binary: helper regression passed; 75/77 test cases passed, with the two remaining failures requiring host filesystem/kernel BPF privileges (`Test shm progs attach`, `Test tail calling from userspace to kernel`)
