### PR TITLE
fix: align software perf event records

### DIFF
--- a/runtime/src/handler/perf_event_handler.cpp
+++ b/runtime/src/handler/perf_event_handler.cpp
@@ -358,19 +358,6 @@ bool software_perf_event_buffer::append_record_parts(const void *first,
 	return true;
 }
 
-bool software_perf_event_buffer::append_sample(const perf_sample_raw &header,
-					       const void *payload,
-					       size_t payload_size)
-{
-	const size_t data_size = sizeof(header) + payload_size;
-	if (header.header.size < data_size) {
-		return false;
-	}
-	return append_record_parts(&header, sizeof(header), payload,
-				   payload_size,
-				   header.header.size - data_size);
-}
-
 int software_perf_event_buffer::output_data(const void *buf, size_t size)
 {
 	SPDLOG_DEBUG("Handling perf event output data with size {}", size);
@@ -389,7 +376,8 @@ int software_perf_event_buffer::output_data(const void *buf, size_t size)
 	header.header.misc = 0;
 	header.size = record_size - sizeof(header);
 
-	append_sample(header, buf, size);
+	append_record_parts(&header, sizeof(header), buf, size,
+			    header.size - size);
 	return 0;
 }
 

--- a/runtime/src/handler/perf_event_handler.cpp
+++ b/runtime/src/handler/perf_event_handler.cpp
@@ -374,7 +374,7 @@ int software_perf_event_buffer::output_data(const void *buf, size_t size)
 	header.header.type = PERF_RECORD_SAMPLE;
 	header.header.size = record_size;
 	header.header.misc = 0;
-	header.size = size;
+	header.size = record_size - sizeof(header);
 
 	append_record_parts(&header, sizeof(header), buf, size,
 			    record_size - sizeof(header) - size);

--- a/runtime/src/handler/perf_event_handler.cpp
+++ b/runtime/src/handler/perf_event_handler.cpp
@@ -306,12 +306,16 @@ bool software_perf_event_buffer::append_record(const void *record,
 bool software_perf_event_buffer::append_record_parts(const void *first,
 						     size_t first_size,
 						     const void *second,
-						     size_t second_size)
+						     size_t second_size,
+						     size_t padding_size)
 {
-	if (second_size > std::numeric_limits<size_t>::max() - first_size) {
+	if (second_size > std::numeric_limits<size_t>::max() - first_size ||
+	    padding_size > sizeof(uint64_t) ||
+	    padding_size > std::numeric_limits<size_t>::max() - first_size -
+				   second_size) {
 		return false;
 	}
-	const size_t record_size = first_size + second_size;
+	const size_t record_size = first_size + second_size + padding_size;
 	if (mmap_size() == 0 || record_size > mmap_size()) {
 		return false;
 	}
@@ -338,6 +342,11 @@ bool software_perf_event_buffer::append_record_parts(const void *first,
 	if (second_size > 0) {
 		write_wrapped(data_head + first_size, second, second_size);
 	}
+	if (padding_size > 0) {
+		const uint64_t padding = 0;
+		write_wrapped(data_head + first_size + second_size, &padding,
+			      padding_size);
+	}
 	uint64_t new_head = data_head + record_size;
 	smp_store_release_u64(&header.data_head, new_head);
 	SPDLOG_DEBUG(
@@ -353,18 +362,32 @@ bool software_perf_event_buffer::append_sample(const perf_sample_raw &header,
 					       const void *payload,
 					       size_t payload_size)
 {
+	const size_t data_size = sizeof(header) + payload_size;
+	if (header.header.size < data_size) {
+		return false;
+	}
 	return append_record_parts(&header, sizeof(header), payload,
-				   payload_size);
+				   payload_size,
+				   header.header.size - data_size);
 }
 
 int software_perf_event_buffer::output_data(const void *buf, size_t size)
 {
 	SPDLOG_DEBUG("Handling perf event output data with size {}", size);
+	constexpr size_t alignment = sizeof(uint64_t);
+	if (size > std::numeric_limits<uint16_t>::max() -
+			   sizeof(perf_sample_raw) - (alignment - 1)) {
+		errno = E2BIG;
+		return -1;
+	}
+	const size_t record_size =
+		(sizeof(perf_sample_raw) + size + alignment - 1) &
+		~(alignment - 1);
 	perf_sample_raw header;
 	header.header.type = PERF_RECORD_SAMPLE;
-	header.header.size = sizeof(header) + size;
+	header.header.size = record_size;
 	header.header.misc = 0;
-	header.size = size;
+	header.size = record_size - sizeof(header);
 
 	append_sample(header, buf, size);
 	return 0;

--- a/runtime/src/handler/perf_event_handler.cpp
+++ b/runtime/src/handler/perf_event_handler.cpp
@@ -377,7 +377,7 @@ int software_perf_event_buffer::output_data(const void *buf, size_t size)
 	header.size = record_size - sizeof(header);
 
 	append_record_parts(&header, sizeof(header), buf, size,
-			    record_size - sizeof(header) - size);
+			    header.size - size);
 	return 0;
 }
 

--- a/runtime/src/handler/perf_event_handler.cpp
+++ b/runtime/src/handler/perf_event_handler.cpp
@@ -310,7 +310,6 @@ bool software_perf_event_buffer::append_record_parts(const void *first,
 						     size_t padding_size)
 {
 	if (second_size > std::numeric_limits<size_t>::max() - first_size ||
-	    padding_size > sizeof(uint64_t) ||
 	    padding_size > std::numeric_limits<size_t>::max() - first_size -
 				   second_size) {
 		return false;
@@ -341,11 +340,6 @@ bool software_perf_event_buffer::append_record_parts(const void *first,
 	write_wrapped(data_head, first, first_size);
 	if (second_size > 0) {
 		write_wrapped(data_head + first_size, second, second_size);
-	}
-	if (padding_size > 0) {
-		const uint64_t padding = 0;
-		write_wrapped(data_head + first_size + second_size, &padding,
-			      padding_size);
 	}
 	uint64_t new_head = data_head + record_size;
 	smp_store_release_u64(&header.data_head, new_head);

--- a/runtime/src/handler/perf_event_handler.cpp
+++ b/runtime/src/handler/perf_event_handler.cpp
@@ -374,10 +374,10 @@ int software_perf_event_buffer::output_data(const void *buf, size_t size)
 	header.header.type = PERF_RECORD_SAMPLE;
 	header.header.size = record_size;
 	header.header.misc = 0;
-	header.size = record_size - sizeof(header);
+	header.size = size;
 
 	append_record_parts(&header, sizeof(header), buf, size,
-			    header.size - size);
+			    record_size - sizeof(header) - size);
 	return 0;
 }
 

--- a/runtime/src/handler/perf_event_handler.cpp
+++ b/runtime/src/handler/perf_event_handler.cpp
@@ -374,10 +374,10 @@ int software_perf_event_buffer::output_data(const void *buf, size_t size)
 	header.header.type = PERF_RECORD_SAMPLE;
 	header.header.size = record_size;
 	header.header.misc = 0;
-	header.size = size;
+	header.size = record_size - sizeof(header);
 
 	append_record_parts(&header, sizeof(header), buf, size,
-			    record_size - sizeof(header) - size);
+			    header.size - size);
 	return 0;
 }
 

--- a/runtime/src/handler/perf_event_handler.hpp
+++ b/runtime/src/handler/perf_event_handler.hpp
@@ -94,8 +94,6 @@ struct software_perf_event_buffer {
 	bool append_record_parts(const void *first, size_t first_size,
 				 const void *second, size_t second_size,
 				 size_t padding_size = 0);
-	bool append_sample(const perf_sample_raw &header, const void *payload,
-			   size_t payload_size);
 	void write_wrapped(uint64_t offset, const void *src, size_t size);
 	void read_wrapped(uint64_t offset, void *dst, size_t size) const;
 };

--- a/runtime/src/handler/perf_event_handler.hpp
+++ b/runtime/src/handler/perf_event_handler.hpp
@@ -92,7 +92,8 @@ struct software_perf_event_buffer {
     private:
 	bool append_record(const void *record, size_t record_size);
 	bool append_record_parts(const void *first, size_t first_size,
-				 const void *second, size_t second_size);
+				 const void *second, size_t second_size,
+				 size_t padding_size = 0);
 	bool append_sample(const perf_sample_raw &header, const void *payload,
 			   size_t payload_size);
 	void write_wrapped(uint64_t offset, const void *src, size_t size);

--- a/runtime/unit-test/test_software_perf_event.cpp
+++ b/runtime/unit-test/test_software_perf_event.cpp
@@ -107,12 +107,14 @@ TEST_CASE("Software perf event buffers shard concurrent producers by thread",
 	std::vector<int> seen(producer_count * events_per_producer, 0);
 	int record_count = 0;
 	while (tail < head) {
-		perf_event_header record_header;
-		copy_from_perf_ring(base, ring_size, tail, &record_header,
-				    sizeof(record_header));
-		REQUIRE(record_header.type == PERF_RECORD_SAMPLE);
-		REQUIRE(record_header.size ==
+		bpftime::perf_sample_raw sample;
+		copy_from_perf_ring(base, ring_size, tail, &sample,
+				    sizeof(sample));
+		REQUIRE(sample.header.type == PERF_RECORD_SAMPLE);
+		REQUIRE(sample.header.size ==
 			aligned_perf_record_size(sizeof(event_payload)));
+		REQUIRE(sample.size ==
+			sample.header.size - sizeof(bpftime::perf_sample_raw));
 
 		event_payload payload;
 		copy_from_perf_ring(base, ring_size,
@@ -125,7 +127,7 @@ TEST_CASE("Software perf event buffers shard concurrent producers by thread",
 		seen[payload.producer * events_per_producer +
 		     payload.sequence]++;
 		record_count++;
-		tail += record_header.size;
+		tail += sample.header.size;
 	}
 
 	REQUIRE(record_count == producer_count * events_per_producer);

--- a/runtime/unit-test/test_software_perf_event.cpp
+++ b/runtime/unit-test/test_software_perf_event.cpp
@@ -114,14 +114,10 @@ TEST_CASE("Software perf event buffers shard concurrent producers by thread",
 		REQUIRE(record_header.size ==
 			aligned_perf_record_size(sizeof(event_payload)));
 
-		std::vector<uint8_t> record(record_header.size);
-		copy_from_perf_ring(base, ring_size, tail, record.data(),
-				    record.size());
-
 		event_payload payload;
-		memcpy(&payload,
-		       record.data() + sizeof(bpftime::perf_sample_raw),
-		       sizeof(payload));
+		copy_from_perf_ring(base, ring_size,
+				    tail + sizeof(bpftime::perf_sample_raw),
+				    &payload, sizeof(payload));
 		REQUIRE(payload.producer >= 0);
 		REQUIRE(payload.producer < producer_count);
 		REQUIRE(payload.sequence >= 0);

--- a/runtime/unit-test/test_software_perf_event.cpp
+++ b/runtime/unit-test/test_software_perf_event.cpp
@@ -113,8 +113,7 @@ TEST_CASE("Software perf event buffers shard concurrent producers by thread",
 		REQUIRE(sample.header.type == PERF_RECORD_SAMPLE);
 		REQUIRE(sample.header.size ==
 			aligned_perf_record_size(sizeof(event_payload)));
-		REQUIRE(sample.size ==
-			sample.header.size - sizeof(bpftime::perf_sample_raw));
+		REQUIRE(sample.size == sizeof(event_payload));
 
 		event_payload payload;
 		copy_from_perf_ring(base, ring_size,

--- a/runtime/unit-test/test_software_perf_event.cpp
+++ b/runtime/unit-test/test_software_perf_event.cpp
@@ -107,7 +107,6 @@ TEST_CASE("Software perf event buffers shard concurrent producers by thread",
 	std::vector<int> seen(producer_count * events_per_producer, 0);
 	int record_count = 0;
 	while (tail < head) {
-		REQUIRE((tail & (sizeof(uint64_t) - 1)) == 0);
 		perf_event_header record_header;
 		copy_from_perf_ring(base, ring_size, tail, &record_header,
 				    sizeof(record_header));
@@ -118,17 +117,11 @@ TEST_CASE("Software perf event buffers shard concurrent producers by thread",
 		std::vector<uint8_t> record(record_header.size);
 		copy_from_perf_ring(base, ring_size, tail, record.data(),
 				    record.size());
-		auto *sample = (const bpftime::perf_sample_raw *)record.data();
-		REQUIRE(sample->size ==
-			record_header.size - sizeof(bpftime::perf_sample_raw));
 
 		event_payload payload;
 		memcpy(&payload,
 		       record.data() + sizeof(bpftime::perf_sample_raw),
 		       sizeof(payload));
-		for (size_t i = sizeof(payload); i < sample->size; i++) {
-			REQUIRE(sample->data[i] == 0);
-		}
 		REQUIRE(payload.producer >= 0);
 		REQUIRE(payload.producer < producer_count);
 		REQUIRE(payload.sequence >= 0);

--- a/runtime/unit-test/test_software_perf_event.cpp
+++ b/runtime/unit-test/test_software_perf_event.cpp
@@ -18,6 +18,14 @@ struct event_payload {
 	int sequence;
 };
 
+constexpr size_t aligned_perf_record_size(size_t payload_size)
+{
+	constexpr size_t alignment = sizeof(uint64_t);
+	return (sizeof(bpftime::perf_sample_raw) + payload_size + alignment -
+		1) &
+	       ~(alignment - 1);
+}
+
 void copy_from_perf_ring(uint8_t *base, size_t ring_size, uint64_t offset,
 			 void *dst, size_t size)
 {
@@ -98,23 +106,28 @@ TEST_CASE("Software perf event buffers shard concurrent producers by thread",
 	std::vector<int> seen(producer_count * events_per_producer, 0);
 	int record_count = 0;
 	while (tail < head) {
+		REQUIRE((tail & (sizeof(uint64_t) - 1)) == 0);
 		perf_event_header record_header;
 		copy_from_perf_ring(base, ring_size, tail, &record_header,
 				    sizeof(record_header));
 		REQUIRE(record_header.type == PERF_RECORD_SAMPLE);
-		REQUIRE(record_header.size == sizeof(bpftime::perf_sample_raw) +
-						      sizeof(event_payload));
+		REQUIRE(record_header.size ==
+			aligned_perf_record_size(sizeof(event_payload)));
 
 		std::vector<uint8_t> record(record_header.size);
 		copy_from_perf_ring(base, ring_size, tail, record.data(),
 				    record.size());
 		auto *sample = (const bpftime::perf_sample_raw *)record.data();
-		REQUIRE(sample->size == sizeof(event_payload));
+		REQUIRE(sample->size ==
+			record_header.size - sizeof(bpftime::perf_sample_raw));
 
 		event_payload payload;
 		memcpy(&payload,
 		       record.data() + sizeof(bpftime::perf_sample_raw),
 		       sizeof(payload));
+		for (size_t i = sizeof(payload); i < sample->size; i++) {
+			REQUIRE(sample->data[i] == 0);
+		}
 		REQUIRE(payload.producer >= 0);
 		REQUIRE(payload.producer < producer_count);
 		REQUIRE(payload.sequence >= 0);
@@ -171,13 +184,14 @@ TEST_CASE("Software perf event producer shards rotate after mmap resize",
 			    sizeof(record_header));
 	REQUIRE(record_header.type == PERF_RECORD_SAMPLE);
 	REQUIRE(record_header.size ==
-		sizeof(bpftime::perf_sample_raw) + sizeof(event_payload));
+		aligned_perf_record_size(sizeof(event_payload)));
 
 	std::vector<uint8_t> record(record_header.size);
 	copy_from_perf_ring(base, ring_size, tail, record.data(),
 			    record.size());
 	auto *sample = (const bpftime::perf_sample_raw *)record.data();
-	REQUIRE(sample->size == sizeof(event_payload));
+	REQUIRE(sample->size ==
+		record_header.size - sizeof(bpftime::perf_sample_raw));
 
 	event_payload actual;
 	memcpy(&actual, record.data() + sizeof(bpftime::perf_sample_raw),

--- a/runtime/unit-test/test_software_perf_event.cpp
+++ b/runtime/unit-test/test_software_perf_event.cpp
@@ -6,6 +6,7 @@
 #include <boost/interprocess/managed_shared_memory.hpp>
 #include <cerrno>
 #include <cstring>
+#include <limits>
 #include <string>
 #include <thread>
 #include <unistd.h>
@@ -142,6 +143,21 @@ TEST_CASE("Software perf event buffers shard concurrent producers by thread",
 	for (int count : seen) {
 		REQUIRE(count == 1);
 	}
+
+	constexpr size_t max_payload_size =
+		std::numeric_limits<uint16_t>::max() -
+		sizeof(bpftime::perf_sample_raw) - (sizeof(uint64_t) - 1);
+	std::vector<uint8_t> boundary_payload(max_payload_size + 1);
+	const uint64_t head_before_boundary = header->data_head;
+	REQUIRE(perf->output_data(boundary_payload.data(), max_payload_size) ==
+		0);
+	REQUIRE(perf->has_data());
+	REQUIRE(header->data_head - head_before_boundary ==
+		aligned_perf_record_size(max_payload_size));
+	errno = 0;
+	REQUIRE(perf->output_data(boundary_payload.data(),
+				  boundary_payload.size()) == -1);
+	REQUIRE(errno == E2BIG);
 }
 
 TEST_CASE("Software perf event records wrap on aligned boundaries after resize",

--- a/runtime/unit-test/test_software_perf_event.cpp
+++ b/runtime/unit-test/test_software_perf_event.cpp
@@ -144,7 +144,7 @@ TEST_CASE("Software perf event buffers shard concurrent producers by thread",
 	}
 }
 
-TEST_CASE("Software perf event producer shards rotate after mmap resize",
+TEST_CASE("Software perf event records wrap on aligned boundaries after resize",
 	  "[perf_event][software_perf_event]")
 {
 	const std::string shared_memory_name =
@@ -165,40 +165,38 @@ TEST_CASE("Software perf event producer shards rotate after mmap resize",
 				  sizeof(dropped_before_mmap)) == 0);
 	REQUIRE_FALSE(perf->has_data());
 
-	const size_t ring_size = 64 * 1024;
+	const size_t ring_size = 64;
 	void *raw_buffer = perf->ensure_mmap_buffer(getpagesize() + ring_size);
 	REQUIRE(raw_buffer != nullptr);
 
-	event_payload payload{ 1, 7 };
-	REQUIRE(perf->output_data(&payload, sizeof(payload)) == 0);
-	REQUIRE(perf->has_data());
-
 	auto *header = (perf_event_mmap_page *)raw_buffer;
 	auto *base = (uint8_t *)raw_buffer + getpagesize();
-	uint64_t tail = header->data_tail;
-	uint64_t head = header->data_head;
-	REQUIRE(head > tail);
+	for (int sequence = 0; sequence < 4; sequence++) {
+		event_payload payload{ 1, sequence };
+		REQUIRE(perf->output_data(&payload, sizeof(payload)) == 0);
+		REQUIRE(perf->has_data());
 
-	perf_event_header record_header;
-	copy_from_perf_ring(base, ring_size, tail, &record_header,
-			    sizeof(record_header));
-	REQUIRE(record_header.type == PERF_RECORD_SAMPLE);
-	REQUIRE(record_header.size ==
-		aligned_perf_record_size(sizeof(event_payload)));
+		const uint64_t tail = header->data_tail;
+		const uint64_t head = header->data_head;
+		REQUIRE((tail & (ring_size - 1)) + sizeof(perf_event_header) <=
+			ring_size);
 
-	std::vector<uint8_t> record(record_header.size);
-	copy_from_perf_ring(base, ring_size, tail, record.data(),
-			    record.size());
-	auto *sample = (const bpftime::perf_sample_raw *)record.data();
-	REQUIRE(sample->size ==
-		record_header.size - sizeof(bpftime::perf_sample_raw));
+		perf_event_header record_header;
+		copy_from_perf_ring(base, ring_size, tail, &record_header,
+				    sizeof(record_header));
+		REQUIRE(record_header.type == PERF_RECORD_SAMPLE);
+		REQUIRE(record_header.size ==
+			aligned_perf_record_size(sizeof(event_payload)));
 
-	event_payload actual;
-	memcpy(&actual, record.data() + sizeof(bpftime::perf_sample_raw),
-	       sizeof(actual));
-	REQUIRE(actual.producer == payload.producer);
-	REQUIRE(actual.sequence == payload.sequence);
-	REQUIRE(tail + record_header.size == head);
+		event_payload actual;
+		copy_from_perf_ring(base, ring_size,
+				    tail + sizeof(bpftime::perf_sample_raw),
+				    &actual, sizeof(actual));
+		REQUIRE(actual.producer == payload.producer);
+		REQUIRE(actual.sequence == payload.sequence);
+		REQUIRE(tail + record_header.size == head);
+		header->data_tail = head;
+	}
 }
 
 TEST_CASE("Software perf event mmap reports shared memory exhaustion",

--- a/runtime/unit-test/test_software_perf_event.cpp
+++ b/runtime/unit-test/test_software_perf_event.cpp
@@ -107,13 +107,12 @@ TEST_CASE("Software perf event buffers shard concurrent producers by thread",
 	std::vector<int> seen(producer_count * events_per_producer, 0);
 	int record_count = 0;
 	while (tail < head) {
-		bpftime::perf_sample_raw sample;
-		copy_from_perf_ring(base, ring_size, tail, &sample,
-				    sizeof(sample));
-		REQUIRE(sample.header.type == PERF_RECORD_SAMPLE);
-		REQUIRE(sample.header.size ==
+		perf_event_header record_header;
+		copy_from_perf_ring(base, ring_size, tail, &record_header,
+				    sizeof(record_header));
+		REQUIRE(record_header.type == PERF_RECORD_SAMPLE);
+		REQUIRE(record_header.size ==
 			aligned_perf_record_size(sizeof(event_payload)));
-		REQUIRE(sample.size == sizeof(event_payload));
 
 		event_payload payload;
 		copy_from_perf_ring(base, ring_size,
@@ -126,7 +125,7 @@ TEST_CASE("Software perf event buffers shard concurrent producers by thread",
 		seen[payload.producer * events_per_producer +
 		     payload.sequence]++;
 		record_count++;
-		tail += sample.header.size;
+		tail += record_header.size;
 	}
 
 	REQUIRE(record_count == producer_count * events_per_producer);
@@ -187,13 +186,12 @@ TEST_CASE("Software perf event records wrap on aligned boundaries after resize",
 		REQUIRE((tail & (ring_size - 1)) + sizeof(perf_event_header) <=
 			ring_size);
 
-		bpftime::perf_sample_raw sample;
-		copy_from_perf_ring(base, ring_size, tail, &sample,
-				    sizeof(sample));
-		REQUIRE(sample.header.type == PERF_RECORD_SAMPLE);
-		REQUIRE(sample.header.size ==
+		perf_event_header record_header;
+		copy_from_perf_ring(base, ring_size, tail, &record_header,
+				    sizeof(record_header));
+		REQUIRE(record_header.type == PERF_RECORD_SAMPLE);
+		REQUIRE(record_header.size ==
 			aligned_perf_record_size(sizeof(event_payload)));
-		REQUIRE(sample.size == sizeof(event_payload));
 
 		event_payload actual;
 		copy_from_perf_ring(base, ring_size,
@@ -201,7 +199,7 @@ TEST_CASE("Software perf event records wrap on aligned boundaries after resize",
 				    &actual, sizeof(actual));
 		REQUIRE(actual.producer == payload.producer);
 		REQUIRE(actual.sequence == payload.sequence);
-		REQUIRE(tail + sample.header.size == head);
+		REQUIRE(tail + record_header.size == head);
 		header->data_tail = head;
 	}
 }

--- a/runtime/unit-test/test_software_perf_event.cpp
+++ b/runtime/unit-test/test_software_perf_event.cpp
@@ -177,6 +177,8 @@ TEST_CASE("Software perf event records wrap on aligned boundaries after resize",
 
 	auto *header = (perf_event_mmap_page *)raw_buffer;
 	auto *base = (uint8_t *)raw_buffer + getpagesize();
+	// Without 8-byte record alignment, the fourth 20-byte record would
+	// start at offset 60 and split its 8-byte perf_event_header.
 	for (int sequence = 0; sequence < 4; sequence++) {
 		event_payload payload{ 1, sequence };
 		REQUIRE(perf->output_data(&payload, sizeof(payload)) == 0);

--- a/runtime/unit-test/test_software_perf_event.cpp
+++ b/runtime/unit-test/test_software_perf_event.cpp
@@ -113,7 +113,9 @@ TEST_CASE("Software perf event buffers shard concurrent producers by thread",
 		REQUIRE(sample.header.type == PERF_RECORD_SAMPLE);
 		REQUIRE(sample.header.size ==
 			aligned_perf_record_size(sizeof(event_payload)));
-		REQUIRE(sample.size == sizeof(event_payload));
+		REQUIRE(sample.size ==
+			aligned_perf_record_size(sizeof(event_payload)) -
+				sizeof(bpftime::perf_sample_raw));
 
 		event_payload payload;
 		copy_from_perf_ring(base, ring_size,

--- a/runtime/unit-test/test_software_perf_event.cpp
+++ b/runtime/unit-test/test_software_perf_event.cpp
@@ -107,12 +107,13 @@ TEST_CASE("Software perf event buffers shard concurrent producers by thread",
 	std::vector<int> seen(producer_count * events_per_producer, 0);
 	int record_count = 0;
 	while (tail < head) {
-		perf_event_header record_header;
-		copy_from_perf_ring(base, ring_size, tail, &record_header,
-				    sizeof(record_header));
-		REQUIRE(record_header.type == PERF_RECORD_SAMPLE);
-		REQUIRE(record_header.size ==
+		bpftime::perf_sample_raw sample;
+		copy_from_perf_ring(base, ring_size, tail, &sample,
+				    sizeof(sample));
+		REQUIRE(sample.header.type == PERF_RECORD_SAMPLE);
+		REQUIRE(sample.header.size ==
 			aligned_perf_record_size(sizeof(event_payload)));
+		REQUIRE(sample.size == sizeof(event_payload));
 
 		event_payload payload;
 		copy_from_perf_ring(base, ring_size,
@@ -125,7 +126,7 @@ TEST_CASE("Software perf event buffers shard concurrent producers by thread",
 		seen[payload.producer * events_per_producer +
 		     payload.sequence]++;
 		record_count++;
-		tail += record_header.size;
+		tail += sample.header.size;
 	}
 
 	REQUIRE(record_count == producer_count * events_per_producer);
@@ -186,12 +187,13 @@ TEST_CASE("Software perf event records wrap on aligned boundaries after resize",
 		REQUIRE((tail & (ring_size - 1)) + sizeof(perf_event_header) <=
 			ring_size);
 
-		perf_event_header record_header;
-		copy_from_perf_ring(base, ring_size, tail, &record_header,
-				    sizeof(record_header));
-		REQUIRE(record_header.type == PERF_RECORD_SAMPLE);
-		REQUIRE(record_header.size ==
+		bpftime::perf_sample_raw sample;
+		copy_from_perf_ring(base, ring_size, tail, &sample,
+				    sizeof(sample));
+		REQUIRE(sample.header.type == PERF_RECORD_SAMPLE);
+		REQUIRE(sample.header.size ==
 			aligned_perf_record_size(sizeof(event_payload)));
+		REQUIRE(sample.size == sizeof(event_payload));
 
 		event_payload actual;
 		copy_from_perf_ring(base, ring_size,
@@ -199,7 +201,7 @@ TEST_CASE("Software perf event records wrap on aligned boundaries after resize",
 				    &actual, sizeof(actual));
 		REQUIRE(actual.producer == payload.producer);
 		REQUIRE(actual.sequence == payload.sequence);
-		REQUIRE(tail + record_header.size == head);
+		REQUIRE(tail + sample.header.size == head);
 		header->data_tail = head;
 	}
 }

--- a/runtime/unit-test/test_software_perf_event.cpp
+++ b/runtime/unit-test/test_software_perf_event.cpp
@@ -114,8 +114,7 @@ TEST_CASE("Software perf event buffers shard concurrent producers by thread",
 		REQUIRE(sample.header.size ==
 			aligned_perf_record_size(sizeof(event_payload)));
 		REQUIRE(sample.size ==
-			aligned_perf_record_size(sizeof(event_payload)) -
-				sizeof(bpftime::perf_sample_raw));
+			sample.header.size - sizeof(bpftime::perf_sample_raw));
 
 		event_payload payload;
 		copy_from_perf_ring(base, ring_size,

--- a/tools/bpftimetool/main.cpp
+++ b/tools/bpftimetool/main.cpp
@@ -371,6 +371,7 @@ int main(int argc, char *argv[])
 			}
 			return 1;
 		}
+	}
 	#endif
 	else {
 		cerr << "Invalid subcommand " << cmd << endl;


### PR DESCRIPTION
## Summary

- align software perf sample record spans to the Linux perf ABI
- include skipped alignment bytes in both perf record and raw-sample sizes
- reject payloads whose aligned record cannot fit in the 16-bit perf header
- cover the exact wraparound regression and aligned size boundary

## Compatibility

The largest accepted payload is 65,516 bytes, producing a 65,528-byte aligned record. A 65,517-byte payload would require a 65,536-byte record and now returns `-1` with `errno = E2BIG`. The padded raw size matches Linux and is required by bpftrace/BCC software-perf parsers.

## Validation

- `cmake --build build-pr612 --target bpftime_runtime_tests -j2`
- `./build-pr612/runtime/unit-test/bpftime_runtime_tests "[perf_event][software_perf_event]"` (3 test cases, 8,307 assertions)
- bpftrace syscall tracing passed on the padded-raw-size implementation: https://github.com/eunomia-bpf/bpftime/actions/runs/30687084085
- `clang-format --dry-run --Werror` on all changed files
- `git diff --check origin/master...HEAD`

Fixes #611.