### PR TITLE
fix: close CUDA CLI command branch

### DIFF
--- a/tools/bpftimetool/main.cpp
+++ b/tools/bpftimetool/main.cpp
@@ -371,6 +371,7 @@ int main(int argc, char *argv[])
 			}
 			return 1;
 		}
+	}
 	#endif
 	else {
 		cerr << "Invalid subcommand " << cmd << endl;


### PR DESCRIPTION
## Summary

- close the CUDA-only `run-on-cuda` command branch before the fallback `else`
- restore compilation of `bpftimetool` when `BPFTIME_ENABLE_CUDA_ATTACH=ON`

## Validation

- `cmake -B /tmp/bpftime-cuda-cli.JlWUeK -S . -DCMAKE_BUILD_TYPE=Debug -DBPFTIME_LLVM_JIT=YES -DBPFTIME_ENABLE_CUDA_ATTACH=ON -DBPFTIME_CUDA_ROOT=/usr/local/cuda -DLLVM_DIR=/usr/lib/llvm-15/lib/cmake/llvm`
- `cmake --build /tmp/bpftime-cuda-cli.JlWUeK --target bpftimetool -j2`

The missing brace was exposed by the GPU build job in PR #612.