### PR TITLE
fix: avoid duplicate LLVM VM linkage in CUDA agent

### DIFF
--- a/runtime/agent/CMakeLists.txt
+++ b/runtime/agent/CMakeLists.txt
@@ -36,7 +36,7 @@ endif()
 
 if(${BPFTIME_ENABLE_CUDA_ATTACH})
   add_dependencies(bpftime-agent bpftime_llvm_vm llvmbpf_vm bpftime_vm)
-  target_link_options(bpftime-agent PUBLIC "-Wl,--whole-archive" "$<TARGET_FILE:bpftime_nv_attach_impl>" "$<TARGET_FILE:bpftime_llvm_vm>" "$<TARGET_FILE:bpftime_vm>" "$<TARGET_FILE:llvmbpf_vm>" "-Wl,--no-whole-archive")
+  target_link_options(bpftime-agent PUBLIC "-Wl,--whole-archive" "$<TARGET_FILE:bpftime_nv_attach_impl>" "$<TARGET_FILE:bpftime_vm>" "$<TARGET_FILE:llvmbpf_vm>" "-Wl,--no-whole-archive")
   target_link_libraries(bpftime-agent PUBLIC bpftime_nv_attach_impl)
   target_include_directories(bpftime-agent PUBLIC ${NV_ATTACH_IMPL_INCLUDE})
   set(EXTRA_LINK_LIBS bpftime_llvm_vm


### PR DESCRIPTION
## Summary

- stop whole-archiving `bpftime_llvm_vm` a second time in the CUDA agent link block
- retain the directly embedded LLVM factory object and the existing normal target dependency

This is stacked on #604 because that pull request removes the same duplicate linkage from the common agent path. Relative to #604, this changes one CMake link entry.

## Validation

- configured with `BPFTIME_ENABLE_CUDA_ATTACH=ON` and CUDA 12.9
- built `bpftime-agent` successfully
- inspected the generated link command: the LLVM factory object remains directly embedded, while `libbpftime_llvm_vm.a` is no longer inside the CUDA whole-archive group