### PR TITLE
perf(cuda): skip PTX compilation for missing kernels

### DIFF
--- a/attach/nv_attach_impl/nv_attach_impl.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl.cpp
@@ -1041,6 +1041,9 @@ nv_attach_impl::hack_fatbin(std::map<std::string, std::string> all_ptx)
 						wrap_ptx_with_trampoline(
 							current_ptx));
 			}
+			if (!should_add_trampoline) {
+				return;
+			}
 			std::lock_guard<std::mutex> _guard(map_mutex);
 			ptx_out["patched." + file_name] = std::make_tuple(
 				current_ptx, should_add_trampoline);

--- a/attach/nv_attach_impl/nv_attach_impl.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl.cpp
@@ -1035,15 +1035,10 @@ nv_attach_impl::hack_fatbin(std::map<std::string, std::string> all_ptx)
 						resp.modified;
 				}
 			}
-			if (should_add_trampoline) {
-				current_ptx =
-					ptxpass::filter_out_version_headers_ptx(
-						wrap_ptx_with_trampoline(
-							current_ptx));
-			}
-			if (!should_add_trampoline) {
+			if (!should_add_trampoline)
 				return;
-			}
+			current_ptx = ptxpass::filter_out_version_headers_ptx(
+				wrap_ptx_with_trampoline(current_ptx));
 			std::lock_guard<std::mutex> _guard(map_mutex);
 			ptx_out["patched." + file_name] = std::make_tuple(
 				current_ptx, should_add_trampoline);

--- a/attach/nv_attach_impl/pass/ptxpass_kprobe_entry/main.cpp
+++ b/attach/nv_attach_impl/pass/ptxpass_kprobe_entry/main.cpp
@@ -51,8 +51,6 @@ patch_entry(const std::string &ptx, const std::string &kernel,
 		return { ptx, false };
 	}
 	std::string fname = std::string("__probe_func__") + kernel;
-	auto func_ptx = ptxpass::compile_ebpf_to_ptx_from_words(
-		ebpf_words, "sm_61", fname, add_register_guard, false);
 	std::string out = ptx;
 
 	bool patched_stub_calls = false;
@@ -74,6 +72,8 @@ patch_entry(const std::string &ptx, const std::string &kernel,
 	}
 
 	if (patched_stub_calls) {
+		auto func_ptx = ptxpass::compile_ebpf_to_ptx_from_words(
+			ebpf_words, "sm_61", fname, add_register_guard, false);
 		out = func_ptx + "\n" + out;
 		ptxpass::log_transform_stats("kprobe_entry_stub", 1,
 					     ptx.size(), out.size());
@@ -86,6 +86,8 @@ patch_entry(const std::string &ptx, const std::string &kernel,
 	size_t brace = out.find('{', body.first);
 	if (brace == std::string::npos)
 		return { ptx, false };
+	auto func_ptx = ptxpass::compile_ebpf_to_ptx_from_words(
+		ebpf_words, "sm_61", fname, add_register_guard, false);
 	size_t insertPos = brace + 1;
 	if (insertPos < out.size() && out[insertPos] == '\n')
 		insertPos++;

--- a/attach/nv_attach_impl/pass/ptxpass_kretprobe/main.cpp
+++ b/attach/nv_attach_impl/pass/ptxpass_kretprobe/main.cpp
@@ -39,12 +39,12 @@ patch_retprobe(const std::string &ptx, const std::string &kernel,
 {
 	std::string fname = std::string("__retprobe_func__") + kernel;
 
-	auto func_ptx = ptxpass::compile_ebpf_to_ptx_from_words(
-		ebpf_words, "sm_61", fname, false, false);
 	auto body = ptxpass::find_kernel_body(ptx, kernel);
 	if (body.first == std::string::npos) {
 		return { ptx, false };
 	}
+	auto func_ptx = ptxpass::compile_ebpf_to_ptx_from_words(
+		ebpf_words, "sm_61", fname, false, false);
 	std::string out = ptx;
 	std::string section = out.substr(body.first, body.second - body.first);
 	// PTX kernels can terminate with either 'ret;' or 'exit;'. Some

--- a/attach/nv_attach_impl/test/CMakeLists.txt
+++ b/attach/nv_attach_impl/test/CMakeLists.txt
@@ -26,7 +26,13 @@ if(${ENABLE_EBPF_VERIFIER} AND NOT TARGET Catch2)
     # if not enable verifier, we will use the catch2 from submodule
 endif()
 
-add_dependencies(bpftime_nv_attach_tests Catch2 bpftime_nv_attach_impl ptxpass_core spdlog::spdlog)
+add_dependencies(bpftime_nv_attach_tests Catch2 bpftime_nv_attach_impl
+    ptxpass_core ptxpass_kprobe_entry ptxpass_kretprobe spdlog::spdlog)
+file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/ptxpass_test_paths.hpp"
+    CONTENT "#define BPFTIME_KPROBE_ENTRY_PASS \"$<TARGET_FILE:ptxpass_kprobe_entry>\"\n#define BPFTIME_KRETPROBE_PASS \"$<TARGET_FILE:ptxpass_kretprobe>\"\n")
+target_include_directories(bpftime_nv_attach_tests PRIVATE
+    "${CMAKE_CURRENT_BINARY_DIR}")
+target_link_libraries(bpftime_nv_attach_tests PRIVATE ${CMAKE_DL_LIBS})
 if(${TEST_LCOV})
     target_link_options(bpftime_nv_attach_tests PRIVATE -lgcov)
     target_link_libraries(bpftime_nv_attach_tests PRIVATE Catch2::Catch2WithMain bpftime_nv_attach_impl ptxpass_core spdlog::spdlog gcov cuda)

--- a/attach/nv_attach_impl/test/test_ptxpass.cpp
+++ b/attach/nv_attach_impl/test/test_ptxpass.cpp
@@ -9,6 +9,12 @@
 #include <sstream>
 #include <string>
 #include <vector>
+#if defined(__linux__)
+#include <dlfcn.h>
+#include "ptxpass_test_paths.hpp"
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
 
 using namespace ptxpass;
 
@@ -234,6 +240,53 @@ TEST_CASE("find_kernel_body locates kernel boundaries", "[ptxpass_core]")
 	REQUIRE(not_found_start == std::string::npos);
 	REQUIRE(not_found_end == std::string::npos);
 }
+
+#if defined(__linux__)
+static int run_missing_kernel_pass(const char *path)
+{
+	pid_t pid = fork();
+	if (pid != 0) {
+		int status = 0;
+		if (pid < 0 || waitpid(pid, &status, 0) != pid)
+			return -1;
+		return status;
+	}
+
+	void *handle = dlopen(path, RTLD_NOW | RTLD_LOCAL);
+	if (handle == nullptr)
+		_exit(2);
+	using process_input_fn = int (*)(const char *, int, char *);
+	auto process_input = reinterpret_cast<process_input_fn>(
+		dlsym(handle, "process_input"));
+	if (process_input == nullptr)
+		_exit(3);
+
+	ptxpass::runtime_request::RuntimeRequest request;
+	request.input.full_ptx = MINIMAL_PTX;
+	request.input.to_patch_kernel = "missing_kernel";
+	request.set_ebpf_instructions({ UINT64_MAX });
+	nlohmann::json input = request;
+	char output[4096] = {};
+	if (process_input(input.dump().c_str(), sizeof(output), output) !=
+	    ptxpass::ExitCode::Success)
+		_exit(4);
+	auto response =
+		nlohmann::json::parse(output)
+			.get<ptxpass::runtime_response::RuntimeResponse>();
+	_exit(response.modified || response.output_ptx != MINIMAL_PTX);
+}
+
+TEST_CASE("PTX passes skip eBPF compilation for missing kernels", "[ptxpass]")
+{
+	for (const char *path :
+	     { BPFTIME_KPROBE_ENTRY_PASS, BPFTIME_KRETPROBE_PASS }) {
+		CAPTURE(path);
+		int status = run_missing_kernel_pass(path);
+		REQUIRE(WIFEXITED(status));
+		REQUIRE(WEXITSTATUS(status) == 0);
+	}
+}
+#endif
 
 TEST_CASE("AttachPointMatcher matches attach points", "[ptxpass_core]")
 {

--- a/attach/nv_attach_impl/test/test_ptxpass.cpp
+++ b/attach/nv_attach_impl/test/test_ptxpass.cpp
@@ -267,7 +267,8 @@ static int run_missing_kernel_pass(const char *path)
 	request.set_ebpf_instructions({ UINT64_MAX });
 	nlohmann::json input = request;
 	char output[4096] = {};
-	if (process_input(input.dump().c_str(), sizeof(output), output) !=
+	const int output_size = static_cast<int>(sizeof(output));
+	if (process_input(input.dump().c_str(), output_size, output) !=
 	    ptxpass::ExitCode::Success)
 		_exit(4);
 	auto response =


### PR DESCRIPTION
## Summary

- skip nvcc/module compilation when no PTX pass modifies the input
- defer kprobe and kretprobe eBPF compilation until the requested kernel is found
- add a focused regression covering missing kernels in both passes

Part of #552. Replaces #615 with a clean, narrowly scoped history.

## Scope

This PR is intentionally limited to the missing-kernel fast path: 5 changed files, +71/-11 (net +60). Production code is net zero (+10/-10); the remaining growth is the isolated regression fixture (+54) and its build wiring (+7/-1). It contains no benchmark logs, experimental environment controls, launch fallback behavior, deferred variable registration, or submodule revision.

A dedicated minimality pass reduced the adjacent no-op conditions to one early return plus the existing trampoline wrap. The fork/dlopen regression is necessary because the two PTX passes share an ABI and LLVM's `ExitOnError` can terminate the test process.

## Validation

Exact head: `3debc4a98754c4b57823e1a846130ee828cc5758`

- synchronized with current `master`; the scoped PR diff is unchanged
- CUDA 12.9 CMake configure
- full `bpftime_nv_attach_tests`: 22 test cases, 98 assertions passed
- `git diff --check`
- changed-range clang-format: no changes
- exact-head dedicated review: PASS
- exact-head independent external read-only review: PASS
- Copilot audit: prior inline comment resolved/outdated; fresh exact-head review requested
- exact-head GitHub CI: all reported checks completed with no failures

## Merge status

Ready for maintainer review. This PR remains unmerged pending approval.
