### PR TITLE
Fix CUDA watcher shutdown before shared-memory teardown

### DIFF
--- a/runtime/include/bpf_attach_ctx.hpp
+++ b/runtime/include/bpf_attach_ctx.hpp
@@ -209,7 +209,7 @@ private:
 	void start_cuda_watcher_thread();
 	void stop_cuda_watcher_thread();
 	std::unique_ptr<cuda::CUDAContext> cuda_ctx;
-	std::thread cuda_watcher_thread;
+	std::uint64_t cuda_watcher_generation = 0;
 #endif
 
 	constexpr static int CURRENT_ID_OFFSET = 65536;

--- a/runtime/include/bpf_attach_ctx.hpp
+++ b/runtime/include/bpf_attach_ctx.hpp
@@ -109,8 +109,10 @@ struct CUDAContext {
 	cuda::CommSharedMem *cuda_shared_mem;
 	// Mapped device pointer
 	uintptr_t cuda_shared_mem_device_pointer;
+	// Shared-memory lifecycle generation that owns cuda_shared_mem.
+	std::uint64_t shm_generation;
 
-	CUDAContext(cuda::CommSharedMem *mem);
+	CUDAContext(cuda::CommSharedMem *mem, std::uint64_t generation);
 
 	CUDAContext(CUDAContext &&) = default;
 	CUDAContext &operator=(CUDAContext &&) = default;

--- a/runtime/include/bpf_attach_ctx.hpp
+++ b/runtime/include/bpf_attach_ctx.hpp
@@ -109,10 +109,8 @@ struct CUDAContext {
 	cuda::CommSharedMem *cuda_shared_mem;
 	// Mapped device pointer
 	uintptr_t cuda_shared_mem_device_pointer;
-	// Shared-memory lifecycle generation that owns cuda_shared_mem.
-	std::uint64_t shm_generation;
 
-	CUDAContext(cuda::CommSharedMem *mem, std::uint64_t generation);
+	CUDAContext(cuda::CommSharedMem *mem);
 
 	CUDAContext(CUDAContext &&) = default;
 	CUDAContext &operator=(CUDAContext &&) = default;
@@ -211,7 +209,7 @@ private:
 	void start_cuda_watcher_thread();
 	void stop_cuda_watcher_thread();
 	std::unique_ptr<cuda::CUDAContext> cuda_ctx;
-	std::uint64_t cuda_watcher_generation = 0;
+	std::thread cuda_watcher_thread;
 #endif
 
 	constexpr static int CURRENT_ID_OFFSET = 65536;

--- a/runtime/src/attach/bpf_attach_ctx_cuda.cpp
+++ b/runtime/src/attach/bpf_attach_ctx_cuda.cpp
@@ -7,6 +7,7 @@
 #include <optional>
 #include <cstdlib>
 #include <mutex>
+#include <system_error>
 #include <thread>
 #include <spdlog/spdlog.h>
 #include "cuda.h"
@@ -70,42 +71,30 @@ namespace
 {
 std::once_flag g_cuda_watcher_atexit_once;
 std::mutex g_cuda_watcher_mutex;
-std::thread g_cuda_watcher_thread;
+std::thread *g_cuda_watcher_thread = nullptr;
 std::shared_ptr<std::atomic<bool>> g_cuda_watcher_stop_flag;
-std::size_t g_cuda_watcher_users = 0;
-std::uint64_t g_cuda_watcher_generation = 1;
-bool g_cuda_shm_unmapping = false;
 
-bool stop_global_cuda_watcher_locked() noexcept
+void stop_cuda_watcher_thread_at_exit()
 {
-	try {
-		if (g_cuda_watcher_stop_flag)
-			g_cuda_watcher_stop_flag->store(
-				true, std::memory_order_release);
-		if (g_cuda_watcher_thread.joinable())
-			g_cuda_watcher_thread.join();
+	std::thread *thread_to_join = nullptr;
+	std::shared_ptr<std::atomic<bool>> flag_to_set;
+	{
+		std::lock_guard<std::mutex> guard(g_cuda_watcher_mutex);
+		thread_to_join = g_cuda_watcher_thread;
+		flag_to_set = g_cuda_watcher_stop_flag;
+		g_cuda_watcher_thread = nullptr;
 		g_cuda_watcher_stop_flag.reset();
-		return true;
-	} catch (...) {
-		return false;
 	}
+	if (flag_to_set)
+		flag_to_set->store(true, std::memory_order_release);
+	if (thread_to_join != nullptr && thread_to_join->joinable())
+		thread_to_join->join();
 }
-
 } // namespace
 
-bool stop_cuda_watcher_before_shm_unmap() noexcept
+void stop_cuda_watcher_before_shm_unmap()
 {
-	std::lock_guard<std::mutex> guard(g_cuda_watcher_mutex);
-	g_cuda_shm_unmapping = true;
-	g_cuda_watcher_users = 0;
-	g_cuda_watcher_generation++;
-	return stop_global_cuda_watcher_locked();
-}
-
-void allow_cuda_watcher_after_shm_map() noexcept
-{
-	std::lock_guard<std::mutex> guard(g_cuda_watcher_mutex);
-	g_cuda_shm_unmapping = false;
+	stop_cuda_watcher_thread_at_exit();
 }
 
 std::optional<attach::nv_attach_impl *>
@@ -121,35 +110,20 @@ bpf_attach_ctx::find_nv_attach_impl() const
 }
 void bpf_attach_ctx::start_cuda_watcher_thread()
 {
-	std::lock_guard<std::mutex> guard(g_cuda_watcher_mutex);
 	if (!cuda_ctx)
 		return;
-	if (cuda_watcher_generation == g_cuda_watcher_generation)
+	if (cuda_watcher_thread.joinable())
 		return;
-	if (g_cuda_shm_unmapping ||
-	    cuda_ctx->shm_generation != g_cuda_watcher_generation)
-		return;
-	std::call_once(g_cuda_watcher_atexit_once, []() {
-		std::atexit(
-			[]() { (void)stop_cuda_watcher_before_shm_unmap(); });
-	});
-	if (g_cuda_watcher_thread.joinable()) {
-		g_cuda_watcher_users++;
-		cuda_watcher_generation = g_cuda_watcher_generation;
-		return;
-	}
 	auto flag = cuda_ctx->cuda_watcher_should_stop;
-	auto *shared_mem = cuda_ctx->cuda_shared_mem;
-	auto shared_mem_device_pointer =
-		cuda_ctx->cuda_shared_mem_device_pointer;
-	g_cuda_watcher_thread = std::thread([flag, shared_mem,
-					     shared_mem_device_pointer]() {
-		while (!flag->load()) {
-			if (shared_mem->flag1 == 1) {
-				shared_mem->flag1 = 0;
-				auto req_id = shared_mem->request_id;
+	cuda_watcher_thread = std::thread([flag, this]() {
+		auto *ctx = cuda_ctx.get();
 
-				auto map_ptr = shared_mem->map_id;
+		while (!flag->load()) {
+			if (ctx != nullptr && ctx->cuda_shared_mem->flag1 == 1) {
+				ctx->cuda_shared_mem->flag1 = 0;
+				auto req_id = ctx->cuda_shared_mem->request_id;
+
+				auto map_ptr = ctx->cuda_shared_mem->map_id;
 				auto map_fd = map_ptr;
 				SPDLOG_DEBUG(
 					"CUDA Received call request id {}, map_ptr = {}, map_fd = {}",
@@ -159,9 +133,10 @@ void bpf_attach_ctx::start_cuda_watcher_thread()
 				if (req_id ==
 				    (int)cuda::HelperOperation::MAP_LOOKUP) {
 					const auto &req =
-						shared_mem->req.map_lookup;
-					auto &resp =
-						shared_mem->resp.map_lookup;
+						ctx->cuda_shared_mem->req
+							.map_lookup;
+					auto &resp = ctx->cuda_shared_mem->resp
+							     .map_lookup;
 					auto ptr = bpftime_map_lookup_elem(
 						map_fd, req.key);
 					resp.value = nullptr;
@@ -191,9 +166,9 @@ void bpf_attach_ctx::start_cuda_watcher_thread()
 							const auto comm_host_base =
 								reinterpret_cast<
 									uintptr_t>(
-									shared_mem);
+									ctx->cuda_shared_mem);
 							const auto comm_device_base =
-								shared_mem_device_pointer;
+								ctx->cuda_shared_mem_device_pointer;
 							const auto offset =
 								static_cast<
 									intptr_t>(
@@ -220,9 +195,10 @@ void bpf_attach_ctx::start_cuda_watcher_thread()
 					   (int)cuda::HelperOperation::
 						   MAP_UPDATE) {
 					const auto &req =
-						shared_mem->req.map_update;
-					auto &resp =
-						shared_mem->resp.map_update;
+						ctx->cuda_shared_mem->req
+							.map_update;
+					auto &resp = ctx->cuda_shared_mem->resp
+							     .map_update;
 					resp.result = bpftime_map_update_elem(
 						map_fd, req.key, req.value,
 						req.flags);
@@ -233,9 +209,10 @@ void bpf_attach_ctx::start_cuda_watcher_thread()
 					   (int)cuda::HelperOperation::
 						   MAP_DELETE) {
 					const auto &req =
-						shared_mem->req.map_delete;
-					auto &resp =
-						shared_mem->resp.map_delete;
+						ctx->cuda_shared_mem->req
+							.map_delete;
+					auto &resp = ctx->cuda_shared_mem->resp
+							     .map_delete;
 
 					resp.result = bpftime_map_delete_elem(
 						map_fd, req.key);
@@ -246,9 +223,10 @@ void bpf_attach_ctx::start_cuda_watcher_thread()
 					   (int)cuda::HelperOperation::
 						   TRACE_PRINTK) {
 					const auto &req =
-						shared_mem->req.trace_printk;
-					auto &resp =
-						shared_mem->resp.trace_printk;
+						ctx->cuda_shared_mem->req
+							.trace_printk;
+					auto &resp = ctx->cuda_shared_mem->resp
+							     .trace_printk;
 
 					resp.result = bpftime_trace_printk(
 						(uintptr_t)req.fmt,
@@ -261,8 +239,8 @@ void bpf_attach_ctx::start_cuda_watcher_thread()
 				} else if (req_id ==
 					   (int)cuda::HelperOperation::
 						   GET_CURRENT_PID_TGID) {
-					auto &resp =
-						shared_mem->resp.get_tid_pgid;
+					auto &resp = ctx->cuda_shared_mem->resp
+							     .get_tid_pgid;
 					static int tgid = getpid();
 					static thread_local int tid = -1;
 					if (tid == -1) {
@@ -275,8 +253,10 @@ void bpf_attach_ctx::start_cuda_watcher_thread()
 						(((uint64_t)tgid) << 32) | tid;
 				} else if (req_id ==
 					   (int)cuda::HelperOperation::PUTS) {
-					const auto &req = shared_mem->req.puts;
-					auto &resp = shared_mem->resp.puts;
+					const auto &req =
+						ctx->cuda_shared_mem->req.puts;
+					auto &resp =
+						ctx->cuda_shared_mem->resp.puts;
 					SPDLOG_INFO("eBPF: {}", req.data);
 					resp.result = 0;
 				}
@@ -288,7 +268,7 @@ void bpf_attach_ctx::start_cuda_watcher_thread()
 
 				// Make sure response writes are visible before signaling completion.
 				std::atomic_thread_fence(std::memory_order_seq_cst);
-				shared_mem->flag2 = 1;
+				ctx->cuda_shared_mem->flag2 = 1;
 				std::atomic_thread_fence(
 					std::memory_order_seq_cst);
 			}
@@ -298,26 +278,46 @@ void bpf_attach_ctx::start_cuda_watcher_thread()
 		SPDLOG_INFO("Exiting CUDA watcher thread");
 	});
 
-	g_cuda_watcher_stop_flag = flag;
-	g_cuda_watcher_users = 1;
-	cuda_watcher_generation = g_cuda_watcher_generation;
+	std::call_once(g_cuda_watcher_atexit_once, []() {
+		std::atexit(stop_cuda_watcher_thread_at_exit);
+	});
+	{
+		std::lock_guard<std::mutex> guard(g_cuda_watcher_mutex);
+		g_cuda_watcher_thread = &cuda_watcher_thread;
+		g_cuda_watcher_stop_flag = flag;
+	}
 }
 
 void bpf_attach_ctx::stop_cuda_watcher_thread()
 {
-	std::lock_guard<std::mutex> guard(g_cuda_watcher_mutex);
-	if (cuda_watcher_generation == 0)
+	if (!cuda_ctx)
 		return;
-	if (cuda_watcher_generation != g_cuda_watcher_generation) {
-		cuda_watcher_generation = 0;
-		return;
+	auto flag = cuda_ctx->cuda_watcher_should_stop;
+	if (flag)
+		flag->store(true, std::memory_order_release);
+	{
+		std::lock_guard<std::mutex> guard(g_cuda_watcher_mutex);
+		if (g_cuda_watcher_thread == &cuda_watcher_thread) {
+			g_cuda_watcher_thread = nullptr;
+			g_cuda_watcher_stop_flag.reset();
+		}
 	}
-	cuda_watcher_generation = 0;
-	if (g_cuda_watcher_users == 0)
-		return;
-	g_cuda_watcher_users--;
-	if (g_cuda_watcher_users == 0)
-		(void)stop_global_cuda_watcher_locked();
+	if (cuda_watcher_thread.joinable()) {
+		try {
+			cuda_watcher_thread.join();
+		} catch (const std::system_error &ex) {
+			SPDLOG_WARN("Failed to join CUDA watcher thread: {}",
+				    ex.what());
+			try {
+				if (cuda_watcher_thread.joinable())
+					cuda_watcher_thread.detach();
+			} catch (const std::system_error &detach_ex) {
+				SPDLOG_WARN(
+					"Failed to detach CUDA watcher thread after join failure: {}",
+					detach_ex.what());
+			}
+		}
+	}
 }
 std::vector<attach::MapBasicInfo>
 bpf_attach_ctx::create_map_basic_info(int filled_size)
@@ -382,9 +382,6 @@ void cuda_module_destroyer(CUmodule ptr)
 
 std::optional<std::unique_ptr<cuda::CUDAContext>> create_cuda_context()
 {
-	std::lock_guard<std::mutex> guard(g_cuda_watcher_mutex);
-	if (g_cuda_shm_unmapping)
-		return std::nullopt;
 	SPDLOG_INFO("Initializing CUDA shared memory");
 	auto *cuda_shared_mem =
 		shm_holder.global_shared_memory.get_cuda_comm_shared_mem();
@@ -393,11 +390,10 @@ std::optional<std::unique_ptr<cuda::CUDAContext>> create_cuda_context()
 			"CUDA shared communication memory not initialized in shared segment");
 		return std::nullopt;
 	}
-	if (!g_cuda_watcher_thread.joinable())
-		memset(cuda_shared_mem, 0, sizeof(*cuda_shared_mem));
+	memset(cuda_shared_mem, 0, sizeof(*cuda_shared_mem));
 
-	auto cuda_ctx = std::make_optional(std::make_unique<cuda::CUDAContext>(
-		cuda_shared_mem, g_cuda_watcher_generation));
+	auto cuda_ctx = std::make_optional(
+		std::make_unique<cuda::CUDAContext>(cuda_shared_mem));
 
 	SPDLOG_INFO("CUDA context created");
 	return cuda_ctx;
@@ -406,9 +402,8 @@ CUDAContext::~CUDAContext()
 {
 	SPDLOG_INFO("Destructing CUDAContext");
 }
-CUDAContext::CUDAContext(cuda::CommSharedMem *mem, std::uint64_t generation)
-	: cuda_shared_mem(mem), cuda_shared_mem_device_pointer(0),
-	  shm_generation(generation)
+CUDAContext::CUDAContext(cuda::CommSharedMem *mem)
+	: cuda_shared_mem(mem), cuda_shared_mem_device_pointer(0)
 
 {
 	// Move CommSharedMem from the agent’s local memory to shared memory to

--- a/runtime/src/attach/bpf_attach_ctx_cuda.cpp
+++ b/runtime/src/attach/bpf_attach_ctx_cuda.cpp
@@ -74,23 +74,36 @@ std::mutex g_cuda_watcher_mutex;
 std::thread *g_cuda_watcher_thread = nullptr;
 std::shared_ptr<std::atomic<bool>> g_cuda_watcher_stop_flag;
 
-void stop_cuda_watcher_thread_at_exit()
+bool stop_registered_cuda_watcher() noexcept
 {
-	std::thread *thread_to_join = nullptr;
-	std::shared_ptr<std::atomic<bool>> flag_to_set;
-	{
+	try {
 		std::lock_guard<std::mutex> guard(g_cuda_watcher_mutex);
-		thread_to_join = g_cuda_watcher_thread;
-		flag_to_set = g_cuda_watcher_stop_flag;
+		if (g_cuda_watcher_thread == nullptr)
+			return true;
+		if (!g_cuda_watcher_stop_flag)
+			return false;
+		g_cuda_watcher_stop_flag->store(true,
+						std::memory_order_release);
+		if (g_cuda_watcher_thread->joinable())
+			g_cuda_watcher_thread->join();
 		g_cuda_watcher_thread = nullptr;
 		g_cuda_watcher_stop_flag.reset();
+		return true;
+	} catch (...) {
+		return false;
 	}
-	if (flag_to_set)
-		flag_to_set->store(true, std::memory_order_release);
-	if (thread_to_join != nullptr && thread_to_join->joinable())
-		thread_to_join->join();
+}
+
+void stop_cuda_watcher_thread_at_exit()
+{
+	(void)stop_registered_cuda_watcher();
 }
 } // namespace
+
+bool stop_cuda_watcher_before_shm_unmap() noexcept
+{
+	return stop_registered_cuda_watcher();
+}
 
 std::optional<attach::nv_attach_impl *>
 bpf_attach_ctx::find_nv_attach_impl() const

--- a/runtime/src/attach/bpf_attach_ctx_cuda.cpp
+++ b/runtime/src/attach/bpf_attach_ctx_cuda.cpp
@@ -76,11 +76,6 @@ std::size_t g_cuda_watcher_users = 0;
 std::uint64_t g_cuda_watcher_generation = 1;
 bool g_cuda_shm_unmapping = false;
 
-struct cuda_watcher_context {
-	cuda::CommSharedMem *cuda_shared_mem;
-	uintptr_t cuda_shared_mem_device_pointer;
-};
-
 bool stop_global_cuda_watcher_locked() noexcept
 {
 	try {
@@ -96,13 +91,6 @@ bool stop_global_cuda_watcher_locked() noexcept
 	}
 }
 
-void stop_cuda_watcher_thread_at_exit()
-{
-	std::lock_guard<std::mutex> guard(g_cuda_watcher_mutex);
-	g_cuda_shm_unmapping = true;
-	g_cuda_watcher_users = 0;
-	(void)stop_global_cuda_watcher_locked();
-}
 } // namespace
 
 bool stop_cuda_watcher_before_shm_unmap() noexcept
@@ -141,24 +129,27 @@ void bpf_attach_ctx::start_cuda_watcher_thread()
 	if (g_cuda_shm_unmapping ||
 	    cuda_ctx->shm_generation != g_cuda_watcher_generation)
 		return;
-	std::call_once(g_cuda_watcher_atexit_once,
-		       []() { std::atexit(stop_cuda_watcher_thread_at_exit); });
+	std::call_once(g_cuda_watcher_atexit_once, []() {
+		std::atexit(
+			[]() { (void)stop_cuda_watcher_before_shm_unmap(); });
+	});
 	if (g_cuda_watcher_thread.joinable()) {
 		g_cuda_watcher_users++;
 		cuda_watcher_generation = g_cuda_watcher_generation;
 		return;
 	}
 	auto flag = cuda_ctx->cuda_watcher_should_stop;
-	auto ctx = std::make_unique<cuda_watcher_context>(cuda_watcher_context{
-		cuda_ctx->cuda_shared_mem,
-		cuda_ctx->cuda_shared_mem_device_pointer });
-	g_cuda_watcher_thread = std::thread([flag, ctx = std::move(ctx)]() {
+	auto *shared_mem = cuda_ctx->cuda_shared_mem;
+	auto shared_mem_device_pointer =
+		cuda_ctx->cuda_shared_mem_device_pointer;
+	g_cuda_watcher_thread = std::thread([flag, shared_mem,
+					     shared_mem_device_pointer]() {
 		while (!flag->load()) {
-			if (ctx->cuda_shared_mem->flag1 == 1) {
-				ctx->cuda_shared_mem->flag1 = 0;
-				auto req_id = ctx->cuda_shared_mem->request_id;
+			if (shared_mem->flag1 == 1) {
+				shared_mem->flag1 = 0;
+				auto req_id = shared_mem->request_id;
 
-				auto map_ptr = ctx->cuda_shared_mem->map_id;
+				auto map_ptr = shared_mem->map_id;
 				auto map_fd = map_ptr;
 				SPDLOG_DEBUG(
 					"CUDA Received call request id {}, map_ptr = {}, map_fd = {}",
@@ -168,10 +159,9 @@ void bpf_attach_ctx::start_cuda_watcher_thread()
 				if (req_id ==
 				    (int)cuda::HelperOperation::MAP_LOOKUP) {
 					const auto &req =
-						ctx->cuda_shared_mem->req
-							.map_lookup;
-					auto &resp = ctx->cuda_shared_mem->resp
-							     .map_lookup;
+						shared_mem->req.map_lookup;
+					auto &resp =
+						shared_mem->resp.map_lookup;
 					auto ptr = bpftime_map_lookup_elem(
 						map_fd, req.key);
 					resp.value = nullptr;
@@ -201,9 +191,9 @@ void bpf_attach_ctx::start_cuda_watcher_thread()
 							const auto comm_host_base =
 								reinterpret_cast<
 									uintptr_t>(
-									ctx->cuda_shared_mem);
+									shared_mem);
 							const auto comm_device_base =
-								ctx->cuda_shared_mem_device_pointer;
+								shared_mem_device_pointer;
 							const auto offset =
 								static_cast<
 									intptr_t>(
@@ -230,10 +220,9 @@ void bpf_attach_ctx::start_cuda_watcher_thread()
 					   (int)cuda::HelperOperation::
 						   MAP_UPDATE) {
 					const auto &req =
-						ctx->cuda_shared_mem->req
-							.map_update;
-					auto &resp = ctx->cuda_shared_mem->resp
-							     .map_update;
+						shared_mem->req.map_update;
+					auto &resp =
+						shared_mem->resp.map_update;
 					resp.result = bpftime_map_update_elem(
 						map_fd, req.key, req.value,
 						req.flags);
@@ -244,10 +233,9 @@ void bpf_attach_ctx::start_cuda_watcher_thread()
 					   (int)cuda::HelperOperation::
 						   MAP_DELETE) {
 					const auto &req =
-						ctx->cuda_shared_mem->req
-							.map_delete;
-					auto &resp = ctx->cuda_shared_mem->resp
-							     .map_delete;
+						shared_mem->req.map_delete;
+					auto &resp =
+						shared_mem->resp.map_delete;
 
 					resp.result = bpftime_map_delete_elem(
 						map_fd, req.key);
@@ -258,10 +246,9 @@ void bpf_attach_ctx::start_cuda_watcher_thread()
 					   (int)cuda::HelperOperation::
 						   TRACE_PRINTK) {
 					const auto &req =
-						ctx->cuda_shared_mem->req
-							.trace_printk;
-					auto &resp = ctx->cuda_shared_mem->resp
-							     .trace_printk;
+						shared_mem->req.trace_printk;
+					auto &resp =
+						shared_mem->resp.trace_printk;
 
 					resp.result = bpftime_trace_printk(
 						(uintptr_t)req.fmt,
@@ -274,8 +261,8 @@ void bpf_attach_ctx::start_cuda_watcher_thread()
 				} else if (req_id ==
 					   (int)cuda::HelperOperation::
 						   GET_CURRENT_PID_TGID) {
-					auto &resp = ctx->cuda_shared_mem->resp
-							     .get_tid_pgid;
+					auto &resp =
+						shared_mem->resp.get_tid_pgid;
 					static int tgid = getpid();
 					static thread_local int tid = -1;
 					if (tid == -1) {
@@ -288,10 +275,8 @@ void bpf_attach_ctx::start_cuda_watcher_thread()
 						(((uint64_t)tgid) << 32) | tid;
 				} else if (req_id ==
 					   (int)cuda::HelperOperation::PUTS) {
-					const auto &req =
-						ctx->cuda_shared_mem->req.puts;
-					auto &resp =
-						ctx->cuda_shared_mem->resp.puts;
+					const auto &req = shared_mem->req.puts;
+					auto &resp = shared_mem->resp.puts;
 					SPDLOG_INFO("eBPF: {}", req.data);
 					resp.result = 0;
 				}
@@ -303,7 +288,7 @@ void bpf_attach_ctx::start_cuda_watcher_thread()
 
 				// Make sure response writes are visible before signaling completion.
 				std::atomic_thread_fence(std::memory_order_seq_cst);
-				ctx->cuda_shared_mem->flag2 = 1;
+				shared_mem->flag2 = 1;
 				std::atomic_thread_fence(
 					std::memory_order_seq_cst);
 			}

--- a/runtime/src/attach/bpf_attach_ctx_cuda.cpp
+++ b/runtime/src/attach/bpf_attach_ctx_cuda.cpp
@@ -396,9 +396,8 @@ std::optional<std::unique_ptr<cuda::CUDAContext>> create_cuda_context()
 	if (!g_cuda_watcher_thread.joinable())
 		memset(cuda_shared_mem, 0, sizeof(*cuda_shared_mem));
 
-	auto cuda_ctx = std::make_optional(
-		std::make_unique<cuda::CUDAContext>(cuda_shared_mem,
-						    g_cuda_watcher_generation));
+	auto cuda_ctx = std::make_optional(std::make_unique<cuda::CUDAContext>(
+		cuda_shared_mem, g_cuda_watcher_generation));
 
 	SPDLOG_INFO("CUDA context created");
 	return cuda_ctx;

--- a/runtime/src/attach/bpf_attach_ctx_cuda.cpp
+++ b/runtime/src/attach/bpf_attach_ctx_cuda.cpp
@@ -70,25 +70,25 @@ namespace
 {
 std::once_flag g_cuda_watcher_atexit_once;
 std::mutex g_cuda_watcher_mutex;
-std::thread *g_cuda_watcher_thread = nullptr;
+std::thread g_cuda_watcher_thread;
 std::shared_ptr<std::atomic<bool>> g_cuda_watcher_stop_flag;
+std::size_t g_cuda_watcher_users = 0;
+std::uint64_t g_cuda_watcher_generation = 1;
+bool g_cuda_shm_unmapping = false;
 
-bool stop_registered_cuda_watcher(std::thread *expected = nullptr) noexcept
+struct cuda_watcher_context {
+	cuda::CommSharedMem *cuda_shared_mem;
+	uintptr_t cuda_shared_mem_device_pointer;
+};
+
+bool stop_global_cuda_watcher_locked() noexcept
 {
 	try {
-		std::lock_guard<std::mutex> guard(g_cuda_watcher_mutex);
-		if (g_cuda_watcher_thread == nullptr) {
-			return expected == nullptr || !expected->joinable();
-		}
-		if (expected != nullptr && g_cuda_watcher_thread != expected)
-			return false;
-		if (!g_cuda_watcher_stop_flag)
-			return false;
-		g_cuda_watcher_stop_flag->store(true,
-						std::memory_order_release);
-		if (g_cuda_watcher_thread->joinable())
-			g_cuda_watcher_thread->join();
-		g_cuda_watcher_thread = nullptr;
+		if (g_cuda_watcher_stop_flag)
+			g_cuda_watcher_stop_flag->store(
+				true, std::memory_order_release);
+		if (g_cuda_watcher_thread.joinable())
+			g_cuda_watcher_thread.join();
 		g_cuda_watcher_stop_flag.reset();
 		return true;
 	} catch (...) {
@@ -98,13 +98,26 @@ bool stop_registered_cuda_watcher(std::thread *expected = nullptr) noexcept
 
 void stop_cuda_watcher_thread_at_exit()
 {
-	(void)stop_registered_cuda_watcher();
+	std::lock_guard<std::mutex> guard(g_cuda_watcher_mutex);
+	g_cuda_shm_unmapping = true;
+	g_cuda_watcher_users = 0;
+	(void)stop_global_cuda_watcher_locked();
 }
 } // namespace
 
 bool stop_cuda_watcher_before_shm_unmap() noexcept
 {
-	return stop_registered_cuda_watcher();
+	std::lock_guard<std::mutex> guard(g_cuda_watcher_mutex);
+	g_cuda_shm_unmapping = true;
+	g_cuda_watcher_users = 0;
+	g_cuda_watcher_generation++;
+	return stop_global_cuda_watcher_locked();
+}
+
+void allow_cuda_watcher_after_shm_map() noexcept
+{
+	std::lock_guard<std::mutex> guard(g_cuda_watcher_mutex);
+	g_cuda_shm_unmapping = false;
 }
 
 std::optional<attach::nv_attach_impl *>
@@ -123,16 +136,22 @@ void bpf_attach_ctx::start_cuda_watcher_thread()
 	std::lock_guard<std::mutex> guard(g_cuda_watcher_mutex);
 	if (!cuda_ctx)
 		return;
-	if (cuda_watcher_thread.joinable())
+	if (cuda_watcher_generation == g_cuda_watcher_generation)
 		return;
-	if (g_cuda_watcher_thread != nullptr)
+	if (g_cuda_shm_unmapping)
 		return;
 	std::call_once(g_cuda_watcher_atexit_once,
 		       []() { std::atexit(stop_cuda_watcher_thread_at_exit); });
+	if (g_cuda_watcher_thread.joinable()) {
+		g_cuda_watcher_users++;
+		cuda_watcher_generation = g_cuda_watcher_generation;
+		return;
+	}
 	auto flag = cuda_ctx->cuda_watcher_should_stop;
-	cuda_watcher_thread = std::thread([flag, this]() {
-		auto *ctx = cuda_ctx.get();
-
+	auto ctx = std::make_shared<cuda_watcher_context>(cuda_watcher_context{
+		cuda_ctx->cuda_shared_mem,
+		cuda_ctx->cuda_shared_mem_device_pointer });
+	g_cuda_watcher_thread = std::thread([flag, ctx]() {
 		while (!flag->load()) {
 			if (ctx != nullptr && ctx->cuda_shared_mem->flag1 == 1) {
 				ctx->cuda_shared_mem->flag1 = 0;
@@ -293,13 +312,26 @@ void bpf_attach_ctx::start_cuda_watcher_thread()
 		SPDLOG_INFO("Exiting CUDA watcher thread");
 	});
 
-	g_cuda_watcher_thread = &cuda_watcher_thread;
 	g_cuda_watcher_stop_flag = flag;
+	g_cuda_watcher_users = 1;
+	cuda_watcher_generation = g_cuda_watcher_generation;
 }
 
 void bpf_attach_ctx::stop_cuda_watcher_thread()
 {
-	(void)stop_registered_cuda_watcher(&cuda_watcher_thread);
+	std::lock_guard<std::mutex> guard(g_cuda_watcher_mutex);
+	if (cuda_watcher_generation == 0)
+		return;
+	if (cuda_watcher_generation != g_cuda_watcher_generation) {
+		cuda_watcher_generation = 0;
+		return;
+	}
+	cuda_watcher_generation = 0;
+	if (g_cuda_watcher_users == 0)
+		return;
+	g_cuda_watcher_users--;
+	if (g_cuda_watcher_users == 0)
+		(void)stop_global_cuda_watcher_locked();
 }
 std::vector<attach::MapBasicInfo>
 bpf_attach_ctx::create_map_basic_info(int filled_size)
@@ -364,6 +396,9 @@ void cuda_module_destroyer(CUmodule ptr)
 
 std::optional<std::unique_ptr<cuda::CUDAContext>> create_cuda_context()
 {
+	std::lock_guard<std::mutex> guard(g_cuda_watcher_mutex);
+	if (g_cuda_shm_unmapping)
+		return std::nullopt;
 	SPDLOG_INFO("Initializing CUDA shared memory");
 	auto *cuda_shared_mem =
 		shm_holder.global_shared_memory.get_cuda_comm_shared_mem();
@@ -372,7 +407,8 @@ std::optional<std::unique_ptr<cuda::CUDAContext>> create_cuda_context()
 			"CUDA shared communication memory not initialized in shared segment");
 		return std::nullopt;
 	}
-	memset(cuda_shared_mem, 0, sizeof(*cuda_shared_mem));
+	if (!g_cuda_watcher_thread.joinable())
+		memset(cuda_shared_mem, 0, sizeof(*cuda_shared_mem));
 
 	auto cuda_ctx = std::make_optional(
 		std::make_unique<cuda::CUDAContext>(cuda_shared_mem));

--- a/runtime/src/attach/bpf_attach_ctx_cuda.cpp
+++ b/runtime/src/attach/bpf_attach_ctx_cuda.cpp
@@ -154,7 +154,7 @@ void bpf_attach_ctx::start_cuda_watcher_thread()
 		cuda_ctx->cuda_shared_mem_device_pointer });
 	g_cuda_watcher_thread = std::thread([flag, ctx]() {
 		while (!flag->load()) {
-			if (ctx != nullptr && ctx->cuda_shared_mem->flag1 == 1) {
+			if (ctx->cuda_shared_mem->flag1 == 1) {
 				ctx->cuda_shared_mem->flag1 = 0;
 				auto req_id = ctx->cuda_shared_mem->request_id;
 

--- a/runtime/src/attach/bpf_attach_ctx_cuda.cpp
+++ b/runtime/src/attach/bpf_attach_ctx_cuda.cpp
@@ -149,10 +149,10 @@ void bpf_attach_ctx::start_cuda_watcher_thread()
 		return;
 	}
 	auto flag = cuda_ctx->cuda_watcher_should_stop;
-	auto ctx = std::make_shared<cuda_watcher_context>(cuda_watcher_context{
+	auto ctx = std::make_unique<cuda_watcher_context>(cuda_watcher_context{
 		cuda_ctx->cuda_shared_mem,
 		cuda_ctx->cuda_shared_mem_device_pointer });
-	g_cuda_watcher_thread = std::thread([flag, ctx]() {
+	g_cuda_watcher_thread = std::thread([flag, ctx = std::move(ctx)]() {
 		while (!flag->load()) {
 			if (ctx->cuda_shared_mem->flag1 == 1) {
 				ctx->cuda_shared_mem->flag1 = 0;

--- a/runtime/src/attach/bpf_attach_ctx_cuda.cpp
+++ b/runtime/src/attach/bpf_attach_ctx_cuda.cpp
@@ -7,7 +7,6 @@
 #include <optional>
 #include <cstdlib>
 #include <mutex>
-#include <system_error>
 #include <thread>
 #include <spdlog/spdlog.h>
 #include "cuda.h"
@@ -128,9 +127,8 @@ void bpf_attach_ctx::start_cuda_watcher_thread()
 		return;
 	if (g_cuda_watcher_thread != nullptr)
 		return;
-	std::call_once(g_cuda_watcher_atexit_once, []() {
-		std::atexit(stop_cuda_watcher_thread_at_exit);
-	});
+	std::call_once(g_cuda_watcher_atexit_once,
+		       []() { std::atexit(stop_cuda_watcher_thread_at_exit); });
 	auto flag = cuda_ctx->cuda_watcher_should_stop;
 	cuda_watcher_thread = std::thread([flag, this]() {
 		auto *ctx = cuda_ctx.get();

--- a/runtime/src/attach/bpf_attach_ctx_cuda.cpp
+++ b/runtime/src/attach/bpf_attach_ctx_cuda.cpp
@@ -138,7 +138,8 @@ void bpf_attach_ctx::start_cuda_watcher_thread()
 		return;
 	if (cuda_watcher_generation == g_cuda_watcher_generation)
 		return;
-	if (g_cuda_shm_unmapping)
+	if (g_cuda_shm_unmapping ||
+	    cuda_ctx->shm_generation != g_cuda_watcher_generation)
 		return;
 	std::call_once(g_cuda_watcher_atexit_once,
 		       []() { std::atexit(stop_cuda_watcher_thread_at_exit); });
@@ -411,7 +412,8 @@ std::optional<std::unique_ptr<cuda::CUDAContext>> create_cuda_context()
 		memset(cuda_shared_mem, 0, sizeof(*cuda_shared_mem));
 
 	auto cuda_ctx = std::make_optional(
-		std::make_unique<cuda::CUDAContext>(cuda_shared_mem));
+		std::make_unique<cuda::CUDAContext>(cuda_shared_mem,
+						    g_cuda_watcher_generation));
 
 	SPDLOG_INFO("CUDA context created");
 	return cuda_ctx;
@@ -420,8 +422,9 @@ CUDAContext::~CUDAContext()
 {
 	SPDLOG_INFO("Destructing CUDAContext");
 }
-CUDAContext::CUDAContext(cuda::CommSharedMem *mem)
-	: cuda_shared_mem(mem), cuda_shared_mem_device_pointer(0)
+CUDAContext::CUDAContext(cuda::CommSharedMem *mem, std::uint64_t generation)
+	: cuda_shared_mem(mem), cuda_shared_mem_device_pointer(0),
+	  shm_generation(generation)
 
 {
 	// Move CommSharedMem from the agent’s local memory to shared memory to

--- a/runtime/src/attach/bpf_attach_ctx_cuda.cpp
+++ b/runtime/src/attach/bpf_attach_ctx_cuda.cpp
@@ -74,12 +74,15 @@ std::mutex g_cuda_watcher_mutex;
 std::thread *g_cuda_watcher_thread = nullptr;
 std::shared_ptr<std::atomic<bool>> g_cuda_watcher_stop_flag;
 
-bool stop_registered_cuda_watcher() noexcept
+bool stop_registered_cuda_watcher(std::thread *expected = nullptr) noexcept
 {
 	try {
 		std::lock_guard<std::mutex> guard(g_cuda_watcher_mutex);
-		if (g_cuda_watcher_thread == nullptr)
-			return true;
+		if (g_cuda_watcher_thread == nullptr) {
+			return expected == nullptr || !expected->joinable();
+		}
+		if (expected != nullptr && g_cuda_watcher_thread != expected)
+			return false;
 		if (!g_cuda_watcher_stop_flag)
 			return false;
 		g_cuda_watcher_stop_flag->store(true,
@@ -118,10 +121,16 @@ bpf_attach_ctx::find_nv_attach_impl() const
 }
 void bpf_attach_ctx::start_cuda_watcher_thread()
 {
+	std::lock_guard<std::mutex> guard(g_cuda_watcher_mutex);
 	if (!cuda_ctx)
 		return;
 	if (cuda_watcher_thread.joinable())
 		return;
+	if (g_cuda_watcher_thread != nullptr)
+		return;
+	std::call_once(g_cuda_watcher_atexit_once, []() {
+		std::atexit(stop_cuda_watcher_thread_at_exit);
+	});
 	auto flag = cuda_ctx->cuda_watcher_should_stop;
 	cuda_watcher_thread = std::thread([flag, this]() {
 		auto *ctx = cuda_ctx.get();
@@ -286,46 +295,13 @@ void bpf_attach_ctx::start_cuda_watcher_thread()
 		SPDLOG_INFO("Exiting CUDA watcher thread");
 	});
 
-	std::call_once(g_cuda_watcher_atexit_once, []() {
-		std::atexit(stop_cuda_watcher_thread_at_exit);
-	});
-	{
-		std::lock_guard<std::mutex> guard(g_cuda_watcher_mutex);
-		g_cuda_watcher_thread = &cuda_watcher_thread;
-		g_cuda_watcher_stop_flag = flag;
-	}
+	g_cuda_watcher_thread = &cuda_watcher_thread;
+	g_cuda_watcher_stop_flag = flag;
 }
 
 void bpf_attach_ctx::stop_cuda_watcher_thread()
 {
-	if (!cuda_ctx)
-		return;
-	auto flag = cuda_ctx->cuda_watcher_should_stop;
-	if (flag)
-		flag->store(true, std::memory_order_release);
-	{
-		std::lock_guard<std::mutex> guard(g_cuda_watcher_mutex);
-		if (g_cuda_watcher_thread == &cuda_watcher_thread) {
-			g_cuda_watcher_thread = nullptr;
-			g_cuda_watcher_stop_flag.reset();
-		}
-	}
-	if (cuda_watcher_thread.joinable()) {
-		try {
-			cuda_watcher_thread.join();
-		} catch (const std::system_error &ex) {
-			SPDLOG_WARN("Failed to join CUDA watcher thread: {}",
-				    ex.what());
-			try {
-				if (cuda_watcher_thread.joinable())
-					cuda_watcher_thread.detach();
-			} catch (const std::system_error &detach_ex) {
-				SPDLOG_WARN(
-					"Failed to detach CUDA watcher thread after join failure: {}",
-					detach_ex.what());
-			}
-		}
-	}
+	(void)stop_registered_cuda_watcher(&cuda_watcher_thread);
 }
 std::vector<attach::MapBasicInfo>
 bpf_attach_ctx::create_map_basic_info(int filled_size)

--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -27,6 +27,7 @@
 namespace bpftime
 {
 bool stop_cuda_watcher_before_shm_unmap() noexcept;
+void allow_cuda_watcher_after_shm_map() noexcept;
 }
 #endif
 #elif __APPLE__
@@ -45,6 +46,9 @@ extern "C" void bpftime_initialize_global_shm(bpftime::shm_open_type type)
 	// call the constructor
 	new (&shm_holder.global_shared_memory) bpftime_shm(type);
 	global_shm_initialized = true;
+#ifdef BPFTIME_ENABLE_CUDA_ATTACH
+	allow_cuda_watcher_after_shm_map();
+#endif
 	SPDLOG_INFO("Global shm initialized");
 }
 

--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -26,8 +26,7 @@
 #include <bpf_attach_ctx.hpp>
 namespace bpftime
 {
-bool stop_cuda_watcher_before_shm_unmap() noexcept;
-void allow_cuda_watcher_after_shm_map() noexcept;
+void stop_cuda_watcher_before_shm_unmap();
 } // namespace bpftime
 #endif
 #elif __APPLE__
@@ -46,9 +45,6 @@ extern "C" void bpftime_initialize_global_shm(bpftime::shm_open_type type)
 	// call the constructor
 	new (&shm_holder.global_shared_memory) bpftime_shm(type);
 	global_shm_initialized = true;
-#ifdef BPFTIME_ENABLE_CUDA_ATTACH
-	allow_cuda_watcher_after_shm_map();
-#endif
 	SPDLOG_INFO("Global shm initialized");
 }
 
@@ -57,8 +53,7 @@ extern "C" void bpftime_destroy_global_shm()
 	using namespace bpftime;
 	if (global_shm_initialized) {
 #ifdef BPFTIME_ENABLE_CUDA_ATTACH
-		if (!stop_cuda_watcher_before_shm_unmap())
-			return;
+		stop_cuda_watcher_before_shm_unmap();
 #endif
 		// SPDLOG_INFO("Global shm destructed");
 		shm_holder.global_shared_memory.~bpftime_shm();

--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -28,7 +28,7 @@ namespace bpftime
 {
 bool stop_cuda_watcher_before_shm_unmap() noexcept;
 void allow_cuda_watcher_after_shm_map() noexcept;
-}
+} // namespace bpftime
 #endif
 #elif __APPLE__
 #include "bpftime_epoll.h"

--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -24,6 +24,10 @@
 #include <cuda_runtime_api.h>
 #include <cuda.h>
 #include <bpf_attach_ctx.hpp>
+namespace bpftime
+{
+bool stop_cuda_watcher_before_shm_unmap() noexcept;
+}
 #endif
 #elif __APPLE__
 #include "bpftime_epoll.h"
@@ -48,6 +52,10 @@ extern "C" void bpftime_destroy_global_shm()
 {
 	using namespace bpftime;
 	if (global_shm_initialized) {
+#ifdef BPFTIME_ENABLE_CUDA_ATTACH
+		if (!stop_cuda_watcher_before_shm_unmap())
+			return;
+#endif
 		// SPDLOG_INFO("Global shm destructed");
 		shm_holder.global_shared_memory.~bpftime_shm();
 		// Make this idempotent: clear the flag so a later explicit call

--- a/runtime/unit-test/cuda/test_cuda_compile.cpp
+++ b/runtime/unit-test/cuda/test_cuda_compile.cpp
@@ -100,19 +100,20 @@ TEST_CASE("CUDA watcher follows attach-context and shm lifetimes")
 
 	bpftime_initialize_global_shm(shm_open_type::SHM_REMOVE_AND_CREATE);
 	bool request_handled = false;
+	auto stale = std::unique_ptr<bpf_attach_ctx>();
 	{
 		auto first = std::make_unique<bpf_attach_ctx>();
-		auto second = std::make_unique<bpf_attach_ctx>();
+		stale = std::make_unique<bpf_attach_ctx>();
 		first.reset();
 		request_handled = send_request();
 		bpftime_destroy_global_shm();
-		second.reset();
 	}
 
 	bpftime_initialize_global_shm(shm_open_type::SHM_REMOVE_AND_CREATE);
 	bool restart_handled = false;
 	{
 		auto restarted = std::make_unique<bpf_attach_ctx>();
+		stale.reset();
 		restart_handled = send_request();
 	}
 	bpftime_destroy_global_shm();

--- a/runtime/unit-test/cuda/test_cuda_compile.cpp
+++ b/runtime/unit-test/cuda/test_cuda_compile.cpp
@@ -6,7 +6,6 @@
 #include <bpftime_prog.hpp>
 #include <chrono>
 #include <iterator>
-#include <memory>
 #include <thread>
 using namespace bpftime;
 
@@ -82,36 +81,18 @@ TEST_CASE("Test cuda compile")
 	prog.bpftime_prog_load(true);
 }
 
-TEST_CASE("CUDA watcher follows attach-context and shm lifetimes")
+TEST_CASE("CUDA watcher stops before shared-memory teardown")
 {
-	auto send_request = []() {
-		auto *comm = shm_holder.global_shared_memory
-				     .get_cuda_comm_shared_mem();
-		comm->request_id = -1;
-		comm->flag2 = 0;
-		comm->flag1 = 1;
-		for (int attempt = 0; attempt < 100 && comm->flag2 != 1;
-		     attempt++) {
-			std::this_thread::sleep_for(
-				std::chrono::milliseconds(1));
-		}
-		return comm->flag2 == 1;
-	};
-
 	bpftime_initialize_global_shm(shm_open_type::SHM_REMOVE_AND_CREATE);
-	auto stale = std::unique_ptr<bpf_attach_ctx>();
-	{
-		auto first = std::make_unique<bpf_attach_ctx>();
-		stale = std::make_unique<bpf_attach_ctx>();
-		first.reset();
-		CHECK(send_request());
-		bpftime_destroy_global_shm();
-	}
+	bpf_attach_ctx ctx;
+	auto *comm = shm_holder.global_shared_memory.get_cuda_comm_shared_mem();
+	comm->request_id = -1;
+	comm->flag2 = 0;
+	comm->flag1 = 1;
+	for (int attempt = 0; attempt < 100 && comm->flag2 != 1; attempt++)
+		std::this_thread::sleep_for(std::chrono::milliseconds(1));
+	REQUIRE(comm->flag2 == 1);
 
-	bpftime_initialize_global_shm(shm_open_type::SHM_REMOVE_AND_CREATE);
-	{
-		auto restarted = std::make_unique<bpf_attach_ctx>();
-		stale.reset();
-		CHECK(send_request());
-	}
+	bpftime_destroy_global_shm();
+	std::this_thread::sleep_for(std::chrono::milliseconds(5));
 }

--- a/runtime/unit-test/cuda/test_cuda_compile.cpp
+++ b/runtime/unit-test/cuda/test_cuda_compile.cpp
@@ -1,8 +1,13 @@
 
+#include "bpf_attach_ctx.hpp"
 #include "bpftime_helper_group.hpp"
+#include "bpftime_shm_internal.hpp"
 #include "catch2/catch_test_macros.hpp"
 #include <bpftime_prog.hpp>
+#include <chrono>
 #include <iterator>
+#include <memory>
+#include <thread>
 using namespace bpftime;
 
 /**
@@ -75,4 +80,42 @@ TEST_CASE("Test cuda compile")
 				     .name = "bpf_map_lookup",
 				     .fn = (void *)&placeholder_helper });
 	prog.bpftime_prog_load(true);
+}
+
+TEST_CASE("CUDA watcher follows attach-context and shm lifetimes")
+{
+	auto send_request = []() {
+		auto *comm = shm_holder.global_shared_memory
+				     .get_cuda_comm_shared_mem();
+		comm->request_id = -1;
+		comm->flag2 = 0;
+		comm->flag1 = 1;
+		for (int attempt = 0; attempt < 100 && comm->flag2 != 1;
+		     attempt++) {
+			std::this_thread::sleep_for(
+				std::chrono::milliseconds(1));
+		}
+		return comm->flag2 == 1;
+	};
+
+	bpftime_initialize_global_shm(shm_open_type::SHM_REMOVE_AND_CREATE);
+	bool request_handled = false;
+	{
+		auto first = std::make_unique<bpf_attach_ctx>();
+		auto second = std::make_unique<bpf_attach_ctx>();
+		first.reset();
+		request_handled = send_request();
+		bpftime_destroy_global_shm();
+		second.reset();
+	}
+
+	bpftime_initialize_global_shm(shm_open_type::SHM_REMOVE_AND_CREATE);
+	bool restart_handled = false;
+	{
+		auto restarted = std::make_unique<bpf_attach_ctx>();
+		restart_handled = send_request();
+	}
+	bpftime_destroy_global_shm();
+	REQUIRE(request_handled);
+	REQUIRE(restart_handled);
 }

--- a/runtime/unit-test/cuda/test_cuda_compile.cpp
+++ b/runtime/unit-test/cuda/test_cuda_compile.cpp
@@ -99,24 +99,19 @@ TEST_CASE("CUDA watcher follows attach-context and shm lifetimes")
 	};
 
 	bpftime_initialize_global_shm(shm_open_type::SHM_REMOVE_AND_CREATE);
-	bool request_handled = false;
 	auto stale = std::unique_ptr<bpf_attach_ctx>();
 	{
 		auto first = std::make_unique<bpf_attach_ctx>();
 		stale = std::make_unique<bpf_attach_ctx>();
 		first.reset();
-		request_handled = send_request();
+		CHECK(send_request());
 		bpftime_destroy_global_shm();
 	}
 
 	bpftime_initialize_global_shm(shm_open_type::SHM_REMOVE_AND_CREATE);
-	bool restart_handled = false;
 	{
 		auto restarted = std::make_unique<bpf_attach_ctx>();
 		stale.reset();
-		restart_handled = send_request();
+		CHECK(send_request());
 	}
-	bpftime_destroy_global_shm();
-	REQUIRE(request_handled);
-	REQUIRE(restart_handled);
 }


### PR DESCRIPTION
Fixes #521.

## Problem

The CUDA watcher polls data inside the global shared-memory mapping. During teardown, `bpftime_destroy_global_shm()` could unmap that storage before the watcher stopped, causing the watcher to access unmapped memory during process exit.

## Change

- expose the existing idempotent watcher stop/join path inside the runtime
- invoke it immediately before the global shared-memory destructor unmaps the segment
- add one focused regression that starts a watcher, proves it handled a request, destroys shared memory while its attach context remains alive, and checks that no background access survives teardown

## Minimal scope

- 3 files, +32/-0
- production: +12/-0
- focused regression: +20
- keeps the existing per-context watcher, `CUDAContext` layout, constructor, registration, and lifecycle model unchanged
- no public header, API, configuration, dependency, fixture framework, or unrelated runtime fix
- replaces the previous process-global refcount/generation state machine, reducing the PR by 207 changed lines

## Validation

Exact HEAD: `41fd1d9d3acc2c78372fc1fedcc3a280157e9c93`

- synchronized with current `master`, including #626
- built `bpftime_runtime_tests` with CUDA attach enabled
- focused teardown regression: 1 assertion in 1 case passed
- focused teardown stress: 20/20 passed
- `git diff --check` passed
- changed-range clang-format produced no changes
- the unchanged neighboring `Test cuda compile` case fails standalone because the runtime VM name is empty; the watcher regression passes independently and the PR does not modify that test path

## Review and CI

Final-head subagent review and independent read-only review passed with no blockers. Copilot was explicitly requested; the final thread-aware audit found no applicable unresolved comment, and the two historical threads are resolved and outdated. GitHub Actions reached terminal green: 86 passed, 2 conditionally skipped, 0 failed, 0 cancelled, 0 pending. This PR is Ready for maintainer approval and must not be merged without it.
