### PR TITLE
refactor(cuda): isolate PTX pass execution

### DIFF
--- a/.github/workflows/test-gpu-examples.yml
+++ b/.github/workflows/test-gpu-examples.yml
@@ -584,7 +584,8 @@ jobs:
             build/tools/cli/bpftime \
             build/tools/bpftimetool/bpftimetool \
             build/attach/text_segment_transformer \
-            build/attach/nv_attach_impl; do
+            build/attach/nv_attach_impl \
+            build/attach/nv_attach_impl/bpftime_ptxpass_runner; do
             if [ ! -e "$p" ]; then
               echo "Missing from downloaded artifact: $p"
               missing=1
@@ -607,8 +608,13 @@ jobs:
             chmod +x build/tools/cli/bpftime || true
             ls -la build/tools/cli || true
           fi
+          if [ -f build/attach/nv_attach_impl/bpftime_ptxpass_runner ] && [ ! -x build/attach/nv_attach_impl/bpftime_ptxpass_runner ]; then
+            echo "bpftime_ptxpass_runner exists but is not executable; fixing permissions..."
+            chmod +x build/attach/nv_attach_impl/bpftime_ptxpass_runner
+          fi
           test -x build/tools/bpftimetool/bpftimetool
           test -x build/tools/cli/bpftime
+          test -x build/attach/nv_attach_impl/bpftime_ptxpass_runner
 
       - name: Build GPU example
         run: |

--- a/.github/workflows/test-ptxpass.yml
+++ b/.github/workflows/test-ptxpass.yml
@@ -73,10 +73,9 @@ jobs:
       - name: Build PTX pass targets
         run: |
           cmake --build build --config Debug --target \
-            ptxpass_kprobe_entry ptxpass_kretprobe ptxpass_kprobe_memcapture bpftime_nv_attach_tests -j$(nproc)
+            bpftime_nv_attach_tests -j$(nproc)
 
       - name: Run PTX pass unit tests with Catch2
         shell: bash
         run: |
-          ./build/attach/nv_attach_impl/test/bpftime_nv_attach_tests
-          ctest --test-dir build/attach/nv_attach_impl --output-on-failure -R '^ptxpass-runner-'
+          ctest --test-dir build/attach/nv_attach_impl --output-on-failure

--- a/.github/workflows/test-ptxpass.yml
+++ b/.github/workflows/test-ptxpass.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Build PTX pass targets
         run: |
           cmake --build build --config Debug --target \
-            ptxpass_kprobe_entry ptxpass_kretprobe ptxpass_kprobe_memcapture bpftime_ptxpass_runner ptxpass_runner_test_pass bpftime_nv_attach_tests -j$(nproc)
+            ptxpass_kprobe_entry ptxpass_kretprobe ptxpass_kprobe_memcapture bpftime_nv_attach_tests -j$(nproc)
 
       - name: Run PTX pass unit tests with Catch2
         shell: bash

--- a/.github/workflows/test-ptxpass.yml
+++ b/.github/workflows/test-ptxpass.yml
@@ -73,9 +73,10 @@ jobs:
       - name: Build PTX pass targets
         run: |
           cmake --build build --config Debug --target \
-            ptxpass_kprobe_entry ptxpass_kretprobe ptxpass_kprobe_memcapture bpftime_nv_attach_tests -j$(nproc)
+            ptxpass_kprobe_entry ptxpass_kretprobe ptxpass_kprobe_memcapture bpftime_ptxpass_runner ptxpass_runner_test_pass bpftime_nv_attach_tests -j$(nproc)
 
       - name: Run PTX pass unit tests with Catch2
         shell: bash
         run: |
           ./build/attach/nv_attach_impl/test/bpftime_nv_attach_tests
+          ctest --test-dir build/attach/nv_attach_impl --output-on-failure -R '^ptxpass-runner-'

--- a/attach/nv_attach_impl/CMakeLists.txt
+++ b/attach/nv_attach_impl/CMakeLists.txt
@@ -6,6 +6,10 @@ add_subdirectory(pass/ptxpass_kprobe_entry)
 add_subdirectory(pass/ptxpass_kretprobe)
 add_subdirectory(pass/ptxpass_kprobe_memcapture)
 
+add_executable(bpftime_ptxpass_runner pass/ptxpass_runner.cpp)
+target_link_libraries(bpftime_ptxpass_runner PRIVATE ${CMAKE_DL_LIBS})
+set_property(TARGET bpftime_ptxpass_runner PROPERTY CXX_STANDARD 20)
+
 list(APPEND PTX_PASS_EXECUTABLE $<TARGET_FILE:ptxpass_kprobe_entry>)
 list(APPEND PTX_PASS_EXECUTABLE $<TARGET_FILE:ptxpass_kretprobe>)
 list(APPEND PTX_PASS_EXECUTABLE $<TARGET_FILE:ptxpass_kprobe_memcapture>)
@@ -42,6 +46,7 @@ add_dependencies(
     ptxpass_kprobe_entry
     ptxpass_kretprobe
     ptxpass_kprobe_memcapture
+    bpftime_ptxpass_runner
     nv_attach_impl_ptx_compiler
 )
 set(NV_ATTACH_IMPL_INCLUDE ${CMAKE_CURRENT_SOURCE_DIR} )
@@ -69,7 +74,7 @@ endif()
 # Create a build-time header file with the PTX pass paths
 # This avoids shell escaping issues with colons and quotes
 file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/ptx_pass_config.h"
-     CONTENT "#pragma once\nstatic constexpr const char *DEFAULT_PTX_PASS_EXECUTABLE = \"$<JOIN:${PTX_PASS_EXECUTABLE},:>\";static constexpr const char* DEFAULT_PTX_COMPILER_SHARED_LIB=\"$<JOIN:${PTX_COMPILER_SHARED_LIB},:>\";\n")
+     CONTENT "#pragma once\nstatic constexpr const char *DEFAULT_PTX_PASS_EXECUTABLE = \"$<JOIN:${PTX_PASS_EXECUTABLE},:>\";static constexpr const char *DEFAULT_PTX_PASS_RUNNER_EXECUTABLE = \"$<TARGET_FILE:bpftime_ptxpass_runner>\";static constexpr const char* DEFAULT_PTX_COMPILER_SHARED_LIB=\"$<JOIN:${PTX_COMPILER_SHARED_LIB},:>\";\n")
 
 
 target_link_options(bpftime_nv_attach_impl PUBLIC "-Wl,--whole-archive" "$<TARGET_FILE:bpftime_nv_attach_impl>" "-Wl,--no-whole-archive")

--- a/attach/nv_attach_impl/CMakeLists.txt
+++ b/attach/nv_attach_impl/CMakeLists.txt
@@ -12,6 +12,8 @@ target_link_libraries(bpftime_ptxpass_runner PRIVATE ${CMAKE_DL_LIBS})
 if(BPFTIME_ENABLE_UNIT_TESTING)
   enable_testing()
   add_library(ptxpass_runner_test_pass SHARED pass/ptxpass_runner_test_pass.cpp)
+  add_library(ptxpass_runner_config_only_test_pass SHARED pass/ptxpass_runner_test_pass.cpp)
+  target_compile_definitions(ptxpass_runner_config_only_test_pass PRIVATE PTXPASS_CONFIG_ONLY)
   add_test(
     NAME ptxpass-runner-config
     COMMAND sh -c
@@ -22,6 +24,11 @@ if(BPFTIME_ENABLE_UNIT_TESTING)
     COMMAND sh -c
       "printf input | \"$1\" --process \"$2\" 1024 3>&1 >/dev/null | grep -Fqx '{\"input\":\"input\"}'"
       _ $<TARGET_FILE:bpftime_ptxpass_runner> $<TARGET_FILE:ptxpass_runner_test_pass>)
+  add_test(
+    NAME ptxpass-runner-reject-incomplete-pass
+    COMMAND sh -c
+      "\"$1\" --config \"$2\" 1024 3>/dev/null >/dev/null 2>&1; test $? -eq 66"
+      _ $<TARGET_FILE:bpftime_ptxpass_runner> $<TARGET_FILE:ptxpass_runner_config_only_test_pass>)
 endif()
 
 list(APPEND PTX_PASS_EXECUTABLE $<TARGET_FILE:ptxpass_kprobe_entry>)

--- a/attach/nv_attach_impl/CMakeLists.txt
+++ b/attach/nv_attach_impl/CMakeLists.txt
@@ -15,16 +15,6 @@ if(BPFTIME_ENABLE_UNIT_TESTING)
   add_library(ptxpass_runner_config_only_test_pass SHARED pass/ptxpass_runner_test_pass.cpp)
   target_compile_definitions(ptxpass_runner_config_only_test_pass PRIVATE PTXPASS_CONFIG_ONLY)
   add_test(
-    NAME ptxpass-runner-config
-    COMMAND sh -c
-      "\"$1\" --config \"$2\" 1024 3>&1 >/dev/null | grep -Fqx '{\"mode\":\"config\"}'"
-      _ $<TARGET_FILE:bpftime_ptxpass_runner> $<TARGET_FILE:ptxpass_runner_test_pass>)
-  add_test(
-    NAME ptxpass-runner-process
-    COMMAND sh -c
-      "printf input | \"$1\" --process \"$2\" 1024 3>&1 >/dev/null | grep -Fqx '{\"input\":\"input\"}'"
-      _ $<TARGET_FILE:bpftime_ptxpass_runner> $<TARGET_FILE:ptxpass_runner_test_pass>)
-  add_test(
     NAME ptxpass-runner-reject-incomplete-pass
     COMMAND sh -c
       "\"$1\" --config \"$2\" 1024 3>/dev/null >/dev/null 2>&1; test $? -eq 66"

--- a/attach/nv_attach_impl/CMakeLists.txt
+++ b/attach/nv_attach_impl/CMakeLists.txt
@@ -8,7 +8,21 @@ add_subdirectory(pass/ptxpass_kprobe_memcapture)
 
 add_executable(bpftime_ptxpass_runner pass/ptxpass_runner.cpp)
 target_link_libraries(bpftime_ptxpass_runner PRIVATE ${CMAKE_DL_LIBS})
-set_property(TARGET bpftime_ptxpass_runner PROPERTY CXX_STANDARD 20)
+
+if(BPFTIME_ENABLE_UNIT_TESTING)
+  enable_testing()
+  add_library(ptxpass_runner_test_pass SHARED pass/ptxpass_runner_test_pass.cpp)
+  add_test(
+    NAME ptxpass-runner-config
+    COMMAND sh -c
+      "\"$1\" --config \"$2\" 1024 3>&1 >/dev/null | grep -Fqx '{\"mode\":\"config\"}'"
+      _ $<TARGET_FILE:bpftime_ptxpass_runner> $<TARGET_FILE:ptxpass_runner_test_pass>)
+  add_test(
+    NAME ptxpass-runner-process
+    COMMAND sh -c
+      "printf input | \"$1\" --process \"$2\" 1024 3>&1 >/dev/null | grep -Fqx '{\"input\":\"input\"}'"
+      _ $<TARGET_FILE:bpftime_ptxpass_runner> $<TARGET_FILE:ptxpass_runner_test_pass>)
+endif()
 
 list(APPEND PTX_PASS_EXECUTABLE $<TARGET_FILE:ptxpass_kprobe_entry>)
 list(APPEND PTX_PASS_EXECUTABLE $<TARGET_FILE:ptxpass_kretprobe>)

--- a/attach/nv_attach_impl/nv_attach_impl.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl.cpp
@@ -182,8 +182,6 @@ run_ptxpass_runner(const std::string &mode,
 			continue;
 		env_strs.emplace_back(*p);
 	}
-	env_strs.emplace_back("LD_PRELOAD=");
-	env_strs.emplace_back("LD_AUDIT=");
 	std::vector<char *> envp;
 	envp.reserve(env_strs.size() + 1);
 	for (auto &env : env_strs)

--- a/attach/nv_attach_impl/nv_attach_impl.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl.cpp
@@ -21,6 +21,7 @@
 #include <boost/process/pipe.hpp>
 #include <boost/process/start_dir.hpp>
 #include <chrono>
+#include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <fstream>
@@ -78,61 +79,42 @@ constexpr size_t kPtxPassConfigOutputBytes = 10U << 20;
 constexpr size_t kInitialPtxPassProcessOutputBytes = 1U << 20;
 constexpr size_t kMaxPtxPassProcessOutputBytes = 64U << 20;
 
+using file_ptr = std::unique_ptr<FILE, int (*)(FILE *)>;
+
+static std::string read_file(FILE *file)
+{
+	rewind(file);
+	std::string output;
+	char buffer[4096];
+	while (size_t count = fread(buffer, 1, sizeof(buffer), file))
+		output.append(buffer, count);
+	return output;
+}
+
 static std::optional<std::string>
 run_ptxpass_runner(const std::string &mode,
 		   const std::filesystem::path &pass_library,
 		   const std::string *stdin_payload, size_t output_bytes)
 {
-	const char *configured_runner = getenv("BPFTIME_PTXPASS_RUNNER");
-	const bool using_configured_runner =
-		configured_runner && configured_runner[0] != '\0';
-	std::filesystem::path runner_path =
-		using_configured_runner ? configured_runner :
-					  DEFAULT_PTX_PASS_RUNNER_EXECUTABLE;
-	char tmp_dir_template[] = "/tmp/bpftime-ptxpass-runner.XXXXXX";
-	char *tmp_dir_c = mkdtemp(tmp_dir_template);
-	if (tmp_dir_c == nullptr) {
-		SPDLOG_ERROR("mkdtemp failed for PTX pass runner: {}",
+	const std::filesystem::path runner_path =
+		DEFAULT_PTX_PASS_RUNNER_EXECUTABLE;
+	file_ptr input(tmpfile(), fclose);
+	file_ptr result(tmpfile(), fclose);
+	file_ptr diagnostics(tmpfile(), fclose);
+	if (!input || !result || !diagnostics) {
+		SPDLOG_ERROR("Unable to create PTX pass runner files: {}",
 			     strerror(errno));
 		return std::nullopt;
 	}
-	struct tmp_dir_guard {
-		std::filesystem::path path;
-		~tmp_dir_guard()
-		{
-			std::error_code ec;
-			std::filesystem::remove_all(path, ec);
-		}
-	} guard{ std::filesystem::path(tmp_dir_c) };
-
-	auto stdin_path = guard.path / "stdin.json";
-	auto stdout_path = guard.path / "stdout.json";
-	auto stderr_path = guard.path / "stderr.log";
-	{
-		std::ofstream ofs(stdin_path);
-		if (stdin_payload != nullptr)
-			ofs << *stdin_payload;
-		ofs.close();
-		if (!ofs) {
-			SPDLOG_ERROR("Unable to write PTX pass runner input {}",
-				     stdin_path.c_str());
-			return std::nullopt;
-		}
+	if (stdin_payload != nullptr &&
+	    fwrite(stdin_payload->data(), 1, stdin_payload->size(),
+		   input.get()) != stdin_payload->size()) {
+		SPDLOG_ERROR("Unable to write PTX pass runner input: {}",
+			     strerror(errno));
+		return std::nullopt;
 	}
+	rewind(input.get());
 
-	if (!using_configured_runner &&
-	    access(runner_path.c_str(), X_OK) != 0 && errno == EACCES) {
-		std::error_code ec;
-		std::filesystem::permissions(runner_path,
-					     std::filesystem::perms::owner_exec,
-					     std::filesystem::perm_options::add,
-					     ec);
-		if (ec) {
-			SPDLOG_WARN(
-				"Unable to add execute permission to PTX pass runner {}: {}",
-				runner_path.c_str(), ec.message());
-		}
-	}
 	posix_spawn_file_actions_t file_actions;
 	int spawn_rc = posix_spawn_file_actions_init(&file_actions);
 	if (spawn_rc != 0) {
@@ -148,39 +130,25 @@ run_ptxpass_runner(const std::string &mode,
 			posix_spawn_file_actions_destroy(actions);
 		}
 	} file_actions_cleanup{ &file_actions };
-	const std::tuple<int, std::filesystem::path, int, mode_t> redirects[] = {
-		{ STDIN_FILENO, stdin_path, O_RDONLY, 0 },
-		{ STDOUT_FILENO, stdout_path, O_WRONLY | O_CREAT | O_TRUNC,
-		  0600 },
-		{ STDERR_FILENO, stderr_path, O_WRONLY | O_CREAT | O_TRUNC,
-		  0600 },
+	const std::pair<int, int> redirects[] = {
+		{ fileno(input.get()), STDIN_FILENO },
+		{ fileno(diagnostics.get()), STDOUT_FILENO },
+		{ fileno(diagnostics.get()), STDERR_FILENO },
+		{ fileno(result.get()), 3 },
 	};
-	for (const auto &[fd, path, flags, mode] : redirects) {
-		int rc = posix_spawn_file_actions_addopen(
-			&file_actions, fd, path.c_str(), flags, mode);
+	for (const auto &[source, target] : redirects) {
+		int rc = posix_spawn_file_actions_adddup2(&file_actions, source,
+							  target);
 		if (rc != 0) {
 			SPDLOG_ERROR(
-				"Unable to prepare PTX pass runner fd {} redirection to {}: {}",
-				fd, path.c_str(), strerror(rc));
+				"Unable to prepare PTX pass runner fd {}: {}",
+				target, strerror(rc));
 			return std::nullopt;
 		}
 	}
-#if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
-#if __GLIBC_PREREQ(2, 34)
-	int closefrom_rc =
-		posix_spawn_file_actions_addclosefrom_np(&file_actions, 3);
-	if (closefrom_rc != 0) {
-		SPDLOG_ERROR(
-			"Unable to prepare PTX pass runner closefrom action: {}",
-			strerror(closefrom_rc));
-		return std::nullopt;
-	}
-#endif
-#endif
 
 	std::vector<std::string> arg_strs = { runner_path.string(), mode,
 					      pass_library.string(),
-					      "--output-bytes",
 					      std::to_string(output_bytes) };
 	std::vector<char *> argv;
 	argv.reserve(arg_strs.size() + 1);
@@ -204,8 +172,8 @@ run_ptxpass_runner(const std::string &mode,
 	envp.push_back(nullptr);
 
 	pid_t child_pid = -1;
-	spawn_rc = posix_spawnp(&child_pid, runner_path.c_str(), &file_actions,
-				nullptr, argv.data(), envp.data());
+	spawn_rc = posix_spawn(&child_pid, runner_path.c_str(), &file_actions,
+			       nullptr, argv.data(), envp.data());
 	if (spawn_rc != 0) {
 		SPDLOG_ERROR("Unable to spawn PTX pass runner {} for {}: {}",
 			     runner_path.c_str(), pass_library.c_str(),
@@ -223,9 +191,6 @@ run_ptxpass_runner(const std::string &mode,
 		return std::nullopt;
 	}
 	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
-		std::ifstream efs(stderr_path);
-		std::string err((std::istreambuf_iterator<char>(efs)),
-				std::istreambuf_iterator<char>());
 		std::string reason;
 		if (WIFSIGNALED(status))
 			reason = "signal " + std::to_string(WTERMSIG(status));
@@ -236,18 +201,10 @@ run_ptxpass_runner(const std::string &mode,
 			reason = "wait status " + std::to_string(status);
 		SPDLOG_ERROR("PTX pass runner {} failed for {} with {}: {}",
 			     runner_path.c_str(), pass_library.c_str(), reason,
-			     err);
+			     read_file(diagnostics.get()));
 		return std::nullopt;
 	}
-
-	std::ifstream ifs(stdout_path);
-	if (!ifs.is_open()) {
-		SPDLOG_ERROR("Unable to read PTX pass runner output {}",
-			     stdout_path.c_str());
-		return std::nullopt;
-	}
-	return std::string(std::istreambuf_iterator<char>(ifs),
-			   std::istreambuf_iterator<char>());
+	return read_file(result.get());
 }
 } // namespace
 
@@ -349,7 +306,7 @@ int nv_attach_impl::create_attach_with_ebpf_callback(
 	} else {
 		attach_point_name = func_name;
 	}
-	const struct pass_cfg_with_library_path *matched = nullptr;
+	struct pass_cfg_with_exec_path *matched = nullptr;
 	for (const auto &pd : this->pass_configurations) {
 		if (pd->pass_config.attach_type != attach_type)
 			continue;
@@ -394,7 +351,7 @@ int nv_attach_impl::create_attach_with_ebpf_callback(
 				    (uintptr_t)this->shared_mem_ptr);
 		}
 		SPDLOG_INFO("Recorded pass {} for func {}",
-			    matched->library_path.c_str(), func_name);
+			    matched->executable_path.c_str(), func_name);
 		start_late_bootstrap_async();
 		return id;
 	}
@@ -701,7 +658,7 @@ nv_attach_impl::nv_attach_impl()
 			SPDLOG_INFO("Retrieved config of {}", path.c_str());
 			SPDLOG_DEBUG("Config {}", json.dump(4));
 			this->pass_configurations.emplace_back(
-				std::make_unique<pass_cfg_with_library_path>(
+				std::make_unique<pass_cfg_with_exec_path>(
 					path, config));
 		} catch (const std::exception &e) {
 			SPDLOG_ERROR(
@@ -1117,7 +1074,7 @@ nv_attach_impl::hack_fatbin(std::map<std::string, std::string> all_ptx)
 								"--process",
 								hook_entry
 									.config
-									->library_path,
+									->executable_path,
 								&input_json,
 								output_bytes);
 							if (!output) {

--- a/attach/nv_attach_impl/nv_attach_impl.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl.cpp
@@ -81,6 +81,15 @@ constexpr size_t kMaxPtxPassProcessOutputBytes = 64U << 20;
 
 using file_ptr = std::unique_ptr<FILE, int (*)(FILE *)>;
 
+struct fd_guard {
+	int value;
+	~fd_guard()
+	{
+		if (value >= 0)
+			close(value);
+	}
+};
+
 static std::string read_file(FILE *file)
 {
 	rewind(file);
@@ -114,6 +123,16 @@ run_ptxpass_runner(const std::string &mode,
 		return std::nullopt;
 	}
 	rewind(input.get());
+	fd_guard input_fd{ fcntl(fileno(input.get()), F_DUPFD_CLOEXEC, 4) };
+	fd_guard result_fd{ fcntl(fileno(result.get()), F_DUPFD_CLOEXEC, 4) };
+	fd_guard diagnostics_fd{ fcntl(fileno(diagnostics.get()),
+				       F_DUPFD_CLOEXEC, 4) };
+	if (input_fd.value < 0 || result_fd.value < 0 ||
+	    diagnostics_fd.value < 0) {
+		SPDLOG_ERROR("Unable to duplicate PTX pass runner fds: {}",
+			     strerror(errno));
+		return std::nullopt;
+	}
 
 	posix_spawn_file_actions_t file_actions;
 	int spawn_rc = posix_spawn_file_actions_init(&file_actions);
@@ -131,10 +150,10 @@ run_ptxpass_runner(const std::string &mode,
 		}
 	} file_actions_cleanup{ &file_actions };
 	const std::pair<int, int> redirects[] = {
-		{ fileno(input.get()), STDIN_FILENO },
-		{ fileno(diagnostics.get()), STDOUT_FILENO },
-		{ fileno(diagnostics.get()), STDERR_FILENO },
-		{ fileno(result.get()), 3 },
+		{ input_fd.value, STDIN_FILENO },
+		{ diagnostics_fd.value, STDOUT_FILENO },
+		{ diagnostics_fd.value, STDERR_FILENO },
+		{ result_fd.value, 3 },
 	};
 	for (const auto &[source, target] : redirects) {
 		int rc = posix_spawn_file_actions_adddup2(&file_actions, source,

--- a/attach/nv_attach_impl/nv_attach_impl.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl.cpp
@@ -227,6 +227,14 @@ run_ptxpass_runner(const std::string &mode,
 }
 } // namespace
 
+std::optional<std::string> run_ptxpass_runner_for_test(
+	const std::string &mode, const std::filesystem::path &pass_library,
+	const std::string *stdin_payload, size_t output_bytes)
+{
+	return run_ptxpass_runner(mode, pass_library, stdin_payload,
+				  output_bytes);
+}
+
 nv_attach_hook_state &nv_attach_get_hook_state()
 {
 	std::call_once(g_nv_attach_hook_state_holder.init_once, []() {

--- a/attach/nv_attach_impl/nv_attach_impl.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl.cpp
@@ -1086,9 +1086,11 @@ nv_attach_impl::hack_fatbin(std::map<std::string, std::string> all_ptx)
 							sha256_string);
 						bool parsed = false;
 						std::string last_parse_error;
-						size_t output_bytes =
-							kInitialPtxPassProcessOutputBytes;
-						while (true) {
+						for (size_t output_bytes =
+							     kInitialPtxPassProcessOutputBytes;
+						     output_bytes <=
+						     kMaxPtxPassProcessOutputBytes;
+						     output_bytes <<= 1) {
 							auto output = run_ptxpass_runner(
 								"--process",
 								hook_entry
@@ -1122,30 +1124,16 @@ nv_attach_impl::hack_fatbin(std::map<std::string, std::string> all_ptx)
 								last_parse_error =
 									e.what();
 							}
-							bool output_may_be_truncated =
-								output->size() +
-									1 >=
-								output_bytes;
-							if (!output_may_be_truncated ||
-							    output_bytes >=
+							if (output->size() + 1 <
+								    output_bytes ||
+							    output_bytes ==
 								    kMaxPtxPassProcessOutputBytes)
 								break;
-							size_t next_output_bytes =
-								output_bytes *
-								2;
-							if (next_output_bytes >
-							    kMaxPtxPassProcessOutputBytes)
-								next_output_bytes =
-									kMaxPtxPassProcessOutputBytes;
-							if (next_output_bytes ==
-							    output_bytes)
-								break;
-							output_bytes =
-								next_output_bytes;
 							SPDLOG_WARN(
 								"PTX pass output for kernel {} may be truncated; retrying with {} bytes",
 								kernel,
-								output_bytes);
+								output_bytes *
+									2);
 						}
 						if (!parsed) {
 							SPDLOG_ERROR(

--- a/attach/nv_attach_impl/nv_attach_impl.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl.cpp
@@ -12,7 +12,6 @@
 // #include "spdlog/common.h"
 #include "spdlog/spdlog.h"
 #include <asm/unistd.h> // For architecture-specific syscall numbers
-#include <boost/asio/io_context.hpp>
 #include <boost/asio/post.hpp>
 #include <boost/asio/thread_pool.hpp>
 #include <boost/process.hpp>
@@ -46,23 +45,20 @@
 #include <sys/wait.h>
 #include <sys/user.h>
 #include <sys/uio.h>
-#if __linux__
 #include <spawn.h>
-#endif
 #include <link.h>
 #include <tuple>
 #include <unistd.h>
 #include <variant>
 #include <vector>
 #include <atomic>
+#include <cerrno>
 #include <optional>
 #include <thread>
 #include "ptxpass/core.hpp"
 #include "ptx_pass_config.h"
 
-#if __linux__
 extern "C" char **environ;
-#endif
 
 using namespace bpftime;
 using namespace attach;
@@ -78,6 +74,181 @@ struct nv_attach_hook_state_holder {
 };
 
 static nv_attach_hook_state_holder g_nv_attach_hook_state_holder{};
+constexpr size_t kPtxPassConfigOutputBytes = 10U << 20;
+constexpr size_t kInitialPtxPassProcessOutputBytes = 1U << 20;
+constexpr size_t kMaxPtxPassProcessOutputBytes = 64U << 20;
+
+static std::optional<std::string>
+run_ptxpass_runner(const std::string &mode,
+		   const std::filesystem::path &pass_library,
+		   const std::string *stdin_payload, size_t output_bytes)
+{
+	const char *configured_runner = getenv("BPFTIME_PTXPASS_RUNNER");
+	const bool using_configured_runner =
+		configured_runner && configured_runner[0] != '\0';
+	std::filesystem::path runner_path =
+		using_configured_runner ? configured_runner :
+					  DEFAULT_PTX_PASS_RUNNER_EXECUTABLE;
+	char tmp_dir_template[] = "/tmp/bpftime-ptxpass-runner.XXXXXX";
+	char *tmp_dir_c = mkdtemp(tmp_dir_template);
+	if (tmp_dir_c == nullptr) {
+		SPDLOG_ERROR("mkdtemp failed for PTX pass runner: {}",
+			     strerror(errno));
+		return std::nullopt;
+	}
+	struct tmp_dir_guard {
+		std::filesystem::path path;
+		~tmp_dir_guard()
+		{
+			std::error_code ec;
+			std::filesystem::remove_all(path, ec);
+		}
+	} guard{ std::filesystem::path(tmp_dir_c) };
+
+	auto stdin_path = guard.path / "stdin.json";
+	auto stdout_path = guard.path / "stdout.json";
+	auto stderr_path = guard.path / "stderr.log";
+	{
+		std::ofstream ofs(stdin_path);
+		if (stdin_payload != nullptr)
+			ofs << *stdin_payload;
+		ofs.close();
+		if (!ofs) {
+			SPDLOG_ERROR("Unable to write PTX pass runner input {}",
+				     stdin_path.c_str());
+			return std::nullopt;
+		}
+	}
+
+	if (!using_configured_runner &&
+	    access(runner_path.c_str(), X_OK) != 0 && errno == EACCES) {
+		std::error_code ec;
+		std::filesystem::permissions(runner_path,
+					     std::filesystem::perms::owner_exec,
+					     std::filesystem::perm_options::add,
+					     ec);
+		if (ec) {
+			SPDLOG_WARN(
+				"Unable to add execute permission to PTX pass runner {}: {}",
+				runner_path.c_str(), ec.message());
+		}
+	}
+	posix_spawn_file_actions_t file_actions;
+	int spawn_rc = posix_spawn_file_actions_init(&file_actions);
+	if (spawn_rc != 0) {
+		SPDLOG_ERROR(
+			"posix_spawn_file_actions_init failed for PTX pass runner: {}",
+			strerror(spawn_rc));
+		return std::nullopt;
+	}
+	struct file_actions_guard {
+		posix_spawn_file_actions_t *actions;
+		~file_actions_guard()
+		{
+			posix_spawn_file_actions_destroy(actions);
+		}
+	} file_actions_cleanup{ &file_actions };
+	const std::tuple<int, std::filesystem::path, int, mode_t> redirects[] = {
+		{ STDIN_FILENO, stdin_path, O_RDONLY, 0 },
+		{ STDOUT_FILENO, stdout_path, O_WRONLY | O_CREAT | O_TRUNC,
+		  0600 },
+		{ STDERR_FILENO, stderr_path, O_WRONLY | O_CREAT | O_TRUNC,
+		  0600 },
+	};
+	for (const auto &[fd, path, flags, mode] : redirects) {
+		int rc = posix_spawn_file_actions_addopen(
+			&file_actions, fd, path.c_str(), flags, mode);
+		if (rc != 0) {
+			SPDLOG_ERROR(
+				"Unable to prepare PTX pass runner fd {} redirection to {}: {}",
+				fd, path.c_str(), strerror(rc));
+			return std::nullopt;
+		}
+	}
+#if defined(__GLIBC__) && defined(__GLIBC_PREREQ)
+#if __GLIBC_PREREQ(2, 34)
+	int closefrom_rc =
+		posix_spawn_file_actions_addclosefrom_np(&file_actions, 3);
+	if (closefrom_rc != 0) {
+		SPDLOG_ERROR(
+			"Unable to prepare PTX pass runner closefrom action: {}",
+			strerror(closefrom_rc));
+		return std::nullopt;
+	}
+#endif
+#endif
+
+	std::vector<std::string> arg_strs = { runner_path.string(), mode,
+					      pass_library.string(),
+					      "--output-bytes",
+					      std::to_string(output_bytes) };
+	std::vector<char *> argv;
+	argv.reserve(arg_strs.size() + 1);
+	for (auto &arg : arg_strs)
+		argv.push_back(arg.data());
+	argv.push_back(nullptr);
+
+	std::vector<std::string> env_strs;
+	for (char **p = ::environ; p && *p; ++p) {
+		if (strncmp(*p, "LD_PRELOAD=", 11) == 0 ||
+		    strncmp(*p, "LD_AUDIT=", 9) == 0)
+			continue;
+		env_strs.emplace_back(*p);
+	}
+	env_strs.emplace_back("LD_PRELOAD=");
+	env_strs.emplace_back("LD_AUDIT=");
+	std::vector<char *> envp;
+	envp.reserve(env_strs.size() + 1);
+	for (auto &env : env_strs)
+		envp.push_back(env.data());
+	envp.push_back(nullptr);
+
+	pid_t child_pid = -1;
+	spawn_rc = posix_spawnp(&child_pid, runner_path.c_str(), &file_actions,
+				nullptr, argv.data(), envp.data());
+	if (spawn_rc != 0) {
+		SPDLOG_ERROR("Unable to spawn PTX pass runner {} for {}: {}",
+			     runner_path.c_str(), pass_library.c_str(),
+			     strerror(spawn_rc));
+		return std::nullopt;
+	}
+	int status = 0;
+	pid_t waited_pid = -1;
+	do {
+		waited_pid = waitpid(child_pid, &status, 0);
+	} while (waited_pid < 0 && errno == EINTR);
+	if (waited_pid < 0) {
+		SPDLOG_ERROR("waitpid failed for PTX pass runner {}: {}",
+			     runner_path.c_str(), strerror(errno));
+		return std::nullopt;
+	}
+	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+		std::ifstream efs(stderr_path);
+		std::string err((std::istreambuf_iterator<char>(efs)),
+				std::istreambuf_iterator<char>());
+		std::string reason;
+		if (WIFSIGNALED(status))
+			reason = "signal " + std::to_string(WTERMSIG(status));
+		else if (WIFEXITED(status))
+			reason = "exit code " +
+				 std::to_string(WEXITSTATUS(status));
+		else
+			reason = "wait status " + std::to_string(status);
+		SPDLOG_ERROR("PTX pass runner {} failed for {} with {}: {}",
+			     runner_path.c_str(), pass_library.c_str(), reason,
+			     err);
+		return std::nullopt;
+	}
+
+	std::ifstream ifs(stdout_path);
+	if (!ifs.is_open()) {
+		SPDLOG_ERROR("Unable to read PTX pass runner output {}",
+			     stdout_path.c_str());
+		return std::nullopt;
+	}
+	return std::string(std::istreambuf_iterator<char>(ifs),
+			   std::istreambuf_iterator<char>());
+}
 } // namespace
 
 nv_attach_hook_state &nv_attach_get_hook_state()
@@ -178,7 +349,7 @@ int nv_attach_impl::create_attach_with_ebpf_callback(
 	} else {
 		attach_point_name = func_name;
 	}
-	struct pass_cfg_with_exec_path *matched = nullptr;
+	const struct pass_cfg_with_library_path *matched = nullptr;
 	for (const auto &pd : this->pass_configurations) {
 		if (pd->pass_config.attach_type != attach_type)
 			continue;
@@ -223,7 +394,7 @@ int nv_attach_impl::create_attach_with_ebpf_callback(
 				    (uintptr_t)this->shared_mem_ptr);
 		}
 		SPDLOG_INFO("Recorded pass {} for func {}",
-			    matched->executable_path.c_str(), func_name);
+			    matched->library_path.c_str(), func_name);
 		start_late_bootstrap_async();
 		return id;
 	}
@@ -517,41 +688,26 @@ nv_attach_impl::nv_attach_impl()
 	}
 	auto paths = split_by_colon(ptx_pass_libraries);
 	for (const auto &path : paths) {
-		SPDLOG_INFO("Found path: {}, executing..", path.c_str());
-		void *handle = dlmopen(LM_ID_NEWLM, path.c_str(),
-				       RTLD_NOW | RTLD_LOCAL);
-		if (!handle) {
-			SPDLOG_ERROR(
-				"Unable to load dynamic library of pass {}: {}",
-				path.c_str(), dlerror());
-			continue;
-		}
-		auto print_config =
-			(print_config_fn)dlsym(handle, "print_config");
-		if (!print_config) {
-			SPDLOG_ERROR("Symbol print_config not found in {}",
-				     path.c_str());
-			continue;
-		}
-		auto process_input =
-			(process_input_fn)dlsym(handle, "process_input");
-		if (!process_input) {
-			SPDLOG_ERROR("Symbol process_input not found in {}",
-				     path.c_str());
-			continue;
-		}
+		SPDLOG_INFO("Found path: {}, loading config..", path.c_str());
 		ptxpass::pass_config::PassConfig config;
-		std::vector<char> buf(10 << 20);
-		print_config(buf.size(), buf.data());
+		auto output = run_ptxpass_runner("--config", path, nullptr,
+						 kPtxPassConfigOutputBytes);
+		if (!output)
+			continue;
 
-		auto json = nlohmann::json::parse(buf.data());
-		ptxpass::pass_config::from_json(json, config);
-		SPDLOG_INFO("Retrived config of {}", path.c_str());
-		SPDLOG_DEBUG("Config {}", json.dump(4));
-		this->pass_configurations.emplace_back(
-			std::make_unique<pass_cfg_with_exec_path>(
-				path, config, print_config, process_input,
-				handle));
+		try {
+			auto json = nlohmann::json::parse(*output);
+			ptxpass::pass_config::from_json(json, config);
+			SPDLOG_INFO("Retrieved config of {}", path.c_str());
+			SPDLOG_DEBUG("Config {}", json.dump(4));
+			this->pass_configurations.emplace_back(
+				std::make_unique<pass_cfg_with_library_path>(
+					path, config));
+		} catch (const std::exception &e) {
+			SPDLOG_ERROR(
+				"Unable to parse PTX pass config from {}: {}",
+				path.c_str(), e.what());
+		}
 	}
 	{
 		this->ptx_compiler = *load_nv_attach_impl_ptx_compiler(
@@ -954,48 +1110,25 @@ nv_attach_impl::hack_fatbin(std::map<std::string, std::string> all_ptx)
 							sha256_string);
 						bool parsed = false;
 						std::string last_parse_error;
-						constexpr size_t kMinBufBytes =
-							1U << 20; // 1 MiB
-						constexpr size_t kMaxBufBytes =
-							64U << 20; // 64 MiB
-						for (size_t buf_bytes =
-							     kMinBufBytes;
-						     buf_bytes <= kMaxBufBytes;
-						     buf_bytes <<= 1) {
+						size_t output_bytes =
+							kInitialPtxPassProcessOutputBytes;
+						while (true) {
+							auto output = run_ptxpass_runner(
+								"--process",
+								hook_entry
+									.config
+									->library_path,
+								&input_json,
+								output_bytes);
+							if (!output) {
+								SPDLOG_ERROR(
+									"PTX pass runner failed while patching kernel {}",
+									kernel);
+								return;
+							}
 							try {
-								std::vector<char> buf(
-									buf_bytes);
-								buf.back() =
-									'\0';
-								const int len =
-									(buf_bytes >
-									 (size_t)std::numeric_limits<
-										 int>::
-										 max()) ?
-										std::numeric_limits<
-											int>::
-											max() :
-										(int)buf_bytes;
-								int err =
-									hook_entry
-										.config
-										->process_input(
-											input_json
-												.c_str(),
-											len,
-											buf.data());
-								if (err !=
-								    ptxpass::ExitCode::
-									    Success) {
-									SPDLOG_ERROR(
-										"Unable to run pass on kernel {}: {}",
-										kernel,
-										(int)err);
-									return;
-								}
-
 								auto json = nlohmann::json::parse(
-									buf.data(),
+									*output,
 									nullptr,
 									/*allow_exceptions=*/
 									true,
@@ -1013,13 +1146,35 @@ nv_attach_impl::hack_fatbin(std::map<std::string, std::string> all_ptx)
 								last_parse_error =
 									e.what();
 							}
+							bool output_may_be_truncated =
+								output->size() +
+									1 >=
+								output_bytes;
+							if (!output_may_be_truncated ||
+							    output_bytes >=
+								    kMaxPtxPassProcessOutputBytes)
+								break;
+							size_t next_output_bytes =
+								output_bytes *
+								2;
+							if (next_output_bytes >
+							    kMaxPtxPassProcessOutputBytes)
+								next_output_bytes =
+									kMaxPtxPassProcessOutputBytes;
+							if (next_output_bytes ==
+							    output_bytes)
+								break;
+							output_bytes =
+								next_output_bytes;
+							SPDLOG_WARN(
+								"PTX pass output for kernel {} may be truncated; retrying with {} bytes",
+								kernel,
+								output_bytes);
 						}
 						if (!parsed) {
 							SPDLOG_ERROR(
-								"Unable to parse PTX pass output for kernel {} (max {} MiB), last error: {}",
+								"Unable to parse PTX pass output for kernel {}, last error: {}",
 								kernel,
-								(kMaxBufBytes >>
-								 20),
 								last_parse_error);
 							return;
 						}

--- a/attach/nv_attach_impl/nv_attach_impl.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl.cpp
@@ -47,7 +47,6 @@
 #include <sys/user.h>
 #include <sys/uio.h>
 #include <spawn.h>
-#include <link.h>
 #include <tuple>
 #include <unistd.h>
 #include <variant>

--- a/attach/nv_attach_impl/nv_attach_impl.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl.cpp
@@ -99,8 +99,9 @@ static std::string read_file(FILE *file)
 		output.append(buffer, count);
 	return output;
 }
+} // namespace
 
-static std::optional<std::string>
+std::optional<std::string>
 run_ptxpass_runner(const std::string &mode,
 		   const std::filesystem::path &pass_library,
 		   const std::string *stdin_payload, size_t output_bytes)
@@ -202,12 +203,13 @@ run_ptxpass_runner(const std::string &mode,
 	do {
 		waited_pid = waitpid(child_pid, &status, 0);
 	} while (waited_pid < 0 && errno == EINTR);
-	if (waited_pid < 0) {
+	if (waited_pid < 0 && errno != ECHILD) {
 		SPDLOG_ERROR("waitpid failed for PTX pass runner {}: {}",
 			     runner_path.c_str(), strerror(errno));
 		return std::nullopt;
 	}
-	if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+	if (waited_pid >= 0 &&
+	    (!WIFEXITED(status) || WEXITSTATUS(status) != 0)) {
 		std::string reason;
 		if (WIFSIGNALED(status))
 			reason = "signal " + std::to_string(WTERMSIG(status));
@@ -221,16 +223,15 @@ run_ptxpass_runner(const std::string &mode,
 			     read_file(diagnostics.get()));
 		return std::nullopt;
 	}
-	return read_file(result.get());
-}
-} // namespace
-
-std::optional<std::string> run_ptxpass_runner_for_test(
-	const std::string &mode, const std::filesystem::path &pass_library,
-	const std::string *stdin_payload, size_t output_bytes)
-{
-	return run_ptxpass_runner(mode, pass_library, stdin_payload,
-				  output_bytes);
+	auto output = read_file(result.get());
+	if (waited_pid < 0 && output.empty()) {
+		SPDLOG_ERROR(
+			"PTX pass runner {} for {} produced no result after its status was reaped: {}",
+			runner_path.c_str(), pass_library.c_str(),
+			read_file(diagnostics.get()));
+		return std::nullopt;
+	}
+	return output;
 }
 
 nv_attach_hook_state &nv_attach_get_hook_state()

--- a/attach/nv_attach_impl/nv_attach_impl.hpp
+++ b/attach/nv_attach_impl/nv_attach_impl.hpp
@@ -9,7 +9,6 @@
 #include <cstdint>
 #include <cuda_runtime.h>
 #include <cuda_runtime_api.h>
-#include <dlfcn.h>
 #include <filesystem>
 #include <map>
 #include <memory>
@@ -33,9 +32,6 @@ namespace bpftime
 {
 namespace attach
 {
-
-using print_config_fn = void (*)(int length, char *out);
-using process_input_fn = int (*)(const char *input, int length, char *output);
 
 std::string filter_compiled_ptx_for_ebpf_program(std::string input,
 						 std::string);
@@ -81,37 +77,17 @@ struct nv_attach_entry {
 						       // for pass
 	// Extra serialized parameters (JSON string) reserved for future use
 	std::optional<std::string> extras;
-	struct pass_cfg_with_exec_path *config;
+	const struct pass_cfg_with_library_path *config;
 };
 
-struct pass_cfg_with_exec_path {
-	std::filesystem::path executable_path;
+struct pass_cfg_with_library_path {
+	std::filesystem::path library_path;
 	ptxpass::pass_config::PassConfig pass_config;
-	print_config_fn print_config;
-	process_input_fn process_input;
 
-	void *handle;
-
-	pass_cfg_with_exec_path(std::filesystem::path path,
-				ptxpass::pass_config::PassConfig config,
-				print_config_fn print_config,
-				process_input_fn process_input, void *handle)
-		: executable_path(path), pass_config(config),
-		  print_config(print_config), process_input(process_input),
-		  handle(handle)
+	pass_cfg_with_library_path(std::filesystem::path path,
+				   ptxpass::pass_config::PassConfig config)
+		: library_path(path), pass_config(config)
 	{
-	}
-
-	pass_cfg_with_exec_path(const pass_cfg_with_exec_path &) = delete;
-	pass_cfg_with_exec_path &
-	operator=(const pass_cfg_with_exec_path &) = delete;
-	pass_cfg_with_exec_path(pass_cfg_with_exec_path &&) = default;
-	pass_cfg_with_exec_path &
-	operator=(pass_cfg_with_exec_path &&) = default;
-
-	~pass_cfg_with_exec_path()
-	{
-		dlclose(handle);
 	}
 };
 
@@ -245,7 +221,7 @@ class nv_attach_impl final : public base_attach_impl {
 		hooker_contexts;
 	std::map<int, nv_attach_entry> hook_entries;
 	// discovered pass definitions
-	std::vector<std::unique_ptr<pass_cfg_with_exec_path>>
+	std::vector<std::unique_ptr<pass_cfg_with_library_path>>
 		pass_configurations;
 	std::map<std::string, ptxpass::runtime_response::RuntimeResponse>
 		patch_cache;

--- a/attach/nv_attach_impl/nv_attach_impl.hpp
+++ b/attach/nv_attach_impl/nv_attach_impl.hpp
@@ -77,16 +77,16 @@ struct nv_attach_entry {
 						       // for pass
 	// Extra serialized parameters (JSON string) reserved for future use
 	std::optional<std::string> extras;
-	const struct pass_cfg_with_library_path *config;
+	const struct pass_cfg_with_exec_path *config;
 };
 
-struct pass_cfg_with_library_path {
-	std::filesystem::path library_path;
+struct pass_cfg_with_exec_path {
+	std::filesystem::path executable_path;
 	ptxpass::pass_config::PassConfig pass_config;
 
-	pass_cfg_with_library_path(std::filesystem::path path,
-				   ptxpass::pass_config::PassConfig config)
-		: library_path(path), pass_config(config)
+	pass_cfg_with_exec_path(std::filesystem::path path,
+				ptxpass::pass_config::PassConfig config)
+		: executable_path(path), pass_config(config)
 	{
 	}
 };
@@ -221,7 +221,7 @@ class nv_attach_impl final : public base_attach_impl {
 		hooker_contexts;
 	std::map<int, nv_attach_entry> hook_entries;
 	// discovered pass definitions
-	std::vector<std::unique_ptr<pass_cfg_with_library_path>>
+	std::vector<std::unique_ptr<pass_cfg_with_exec_path>>
 		pass_configurations;
 	std::map<std::string, ptxpass::runtime_response::RuntimeResponse>
 		patch_cache;

--- a/attach/nv_attach_impl/pass/ptxpass_runner.cpp
+++ b/attach/nv_attach_impl/pass/ptxpass_runner.cpp
@@ -1,0 +1,164 @@
+#include <cerrno>
+#include <charconv>
+#include <cstring>
+#include <dlfcn.h>
+#include <cstdio>
+#include <iostream>
+#include <iterator>
+#include <limits>
+#include <memory>
+#include <string>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <vector>
+
+using print_config_fn = void (*)(int length, char *out);
+using process_input_fn = int (*)(const char *input, int length, char *output);
+
+namespace
+{
+constexpr size_t kDefaultConfigOutputBytes = 256U << 10;
+constexpr size_t kDefaultProcessOutputBytes = 1U << 20;
+constexpr size_t kMaxOutputBytes = 64U << 20;
+
+void usage(const char *argv0)
+{
+	std::cerr
+		<< "Usage: " << argv0
+		<< " (--config|--process) <pass-library> [--output-bytes N]\n";
+}
+
+bool parse_size(const char *text, size_t &out)
+{
+	const char *end = text + std::strlen(text);
+	auto [ptr, ec] = std::from_chars(text, end, out);
+	return ec == std::errc() && ptr == end;
+}
+
+std::string read_stdin()
+{
+	return std::string(std::istreambuf_iterator<char>(std::cin),
+			   std::istreambuf_iterator<char>());
+}
+
+size_t nul_terminated_length(const std::vector<char> &buffer)
+{
+	const void *nul = std::memchr(buffer.data(), '\0', buffer.size());
+	if (nul == nullptr)
+		return buffer.size();
+	return static_cast<const char *>(nul) - buffer.data();
+}
+
+void close_inherited_fds()
+{
+#if defined(SYS_close_range)
+	if (syscall(SYS_close_range, STDERR_FILENO + 1, ~0U, 0) == 0)
+		return;
+#endif
+	long max_fd = sysconf(_SC_OPEN_MAX);
+	if (max_fd < 0 || max_fd > std::numeric_limits<int>::max())
+		max_fd = 1024;
+	for (int fd = STDERR_FILENO + 1; fd < max_fd; fd++)
+		close(fd);
+}
+} // namespace
+
+int main(int argc, char **argv)
+{
+	if (argc < 3) {
+		usage(argv[0]);
+		return 64;
+	}
+
+	const std::string mode = argv[1];
+	const char *library_path = argv[2];
+	if (mode != "--config" && mode != "--process") {
+		usage(argv[0]);
+		return 64;
+	}
+	size_t output_bytes = kDefaultProcessOutputBytes;
+	if (mode == "--config")
+		output_bytes = kDefaultConfigOutputBytes;
+	if (argc != 3 &&
+	    (argc != 5 || std::strcmp(argv[3], "--output-bytes") != 0)) {
+		usage(argv[0]);
+		return 64;
+	}
+	if (argc == 5 &&
+	    (!parse_size(argv[4], output_bytes) || output_bytes == 0 ||
+	     output_bytes > kMaxOutputBytes)) {
+		std::cerr << "Invalid --output-bytes value\n";
+		return 64;
+	}
+	close_inherited_fds();
+
+	fflush(stdout);
+	int saved_stdout = dup(STDOUT_FILENO);
+	if (saved_stdout == -1 || dup2(STDERR_FILENO, STDOUT_FILENO) == -1) {
+		std::cerr << "Unable to redirect pass stdout: "
+			  << std::strerror(errno) << "\n";
+		if (saved_stdout != -1)
+			close(saved_stdout);
+		return 70;
+	}
+	auto restore_stdout = [&]() -> bool {
+		std::cout.flush();
+		std::clog.flush();
+		std::cerr.flush();
+		fflush(stdout);
+		if (dup2(saved_stdout, STDOUT_FILENO) == -1) {
+			std::cerr << "Unable to restore stdout: "
+				  << std::strerror(errno) << "\n";
+			close(saved_stdout);
+			saved_stdout = -1;
+			return false;
+		}
+		close(saved_stdout);
+		saved_stdout = -1;
+		return true;
+	};
+
+	std::unique_ptr<void, int (*)(void *)> handle(
+		dlopen(library_path, RTLD_NOW | RTLD_LOCAL), dlclose);
+	if (!handle) {
+		std::cerr << "Unable to load PTX pass " << library_path << ": "
+			  << dlerror() << "\n";
+		return 66;
+	}
+
+	std::vector<char> output(output_bytes, '\0');
+	const int output_len = static_cast<int>(output.size());
+
+	if (mode == "--config") {
+		auto print_config = reinterpret_cast<print_config_fn>(
+			dlsym(handle.get(), "print_config"));
+		if (!print_config) {
+			std::cerr << "Symbol print_config not found in "
+				  << library_path << "\n";
+			return 66;
+		}
+		print_config(output_len, output.data());
+		handle.reset();
+		if (!restore_stdout())
+			return 70;
+		std::cout.write(output.data(), nul_terminated_length(output));
+		return 0;
+	}
+
+	auto process_input = reinterpret_cast<process_input_fn>(
+		dlsym(handle.get(), "process_input"));
+	if (!process_input) {
+		std::cerr << "Symbol process_input not found in "
+			  << library_path << "\n";
+		return 66;
+	}
+	std::string input = read_stdin();
+	int rc = process_input(input.c_str(), output_len, output.data());
+	handle.reset();
+	if (!restore_stdout())
+		return 70;
+	if (rc != 0)
+		return rc;
+	std::cout.write(output.data(), nul_terminated_length(output));
+	return 0;
+}

--- a/attach/nv_attach_impl/pass/ptxpass_runner.cpp
+++ b/attach/nv_attach_impl/pass/ptxpass_runner.cpp
@@ -5,7 +5,6 @@
 #include <iostream>
 #include <iterator>
 #include <limits>
-#include <memory>
 #include <string>
 #include <sys/syscall.h>
 #include <unistd.h>
@@ -18,33 +17,6 @@ namespace
 {
 constexpr size_t kMaxOutputBytes = 64U << 20;
 constexpr int kResultFd = STDERR_FILENO + 1;
-
-void usage(const char *argv0)
-{
-	std::cerr << "Usage: " << argv0
-		  << " (--config|--process) <pass-library> <output-bytes>\n";
-}
-
-bool parse_size(const char *text, size_t &out)
-{
-	const char *end = text + std::strlen(text);
-	auto [ptr, ec] = std::from_chars(text, end, out);
-	return ec == std::errc() && ptr == end;
-}
-
-std::string read_stdin()
-{
-	return std::string(std::istreambuf_iterator<char>(std::cin),
-			   std::istreambuf_iterator<char>());
-}
-
-size_t nul_terminated_length(const std::vector<char> &buffer)
-{
-	const void *nul = std::memchr(buffer.data(), '\0', buffer.size());
-	if (nul == nullptr)
-		return buffer.size();
-	return static_cast<const char *>(nul) - buffer.data();
-}
 
 void close_inherited_fds()
 {
@@ -79,27 +51,26 @@ bool write_all(int fd, const char *data, size_t length)
 
 int main(int argc, char **argv)
 {
-	if (argc != 4) {
-		usage(argv[0]);
+	if (argc != 4 || (std::strcmp(argv[1], "--config") != 0 &&
+			  std::strcmp(argv[1], "--process") != 0)) {
+		std::cerr
+			<< "Usage: " << argv[0]
+			<< " (--config|--process) <pass-library> <output-bytes>\n";
 		return 64;
 	}
-
-	const std::string mode = argv[1];
 	const char *library_path = argv[2];
-	if (mode != "--config" && mode != "--process") {
-		usage(argv[0]);
-		return 64;
-	}
 	size_t output_bytes = 0;
-	if (!parse_size(argv[3], output_bytes) || output_bytes == 0 ||
-	    output_bytes > kMaxOutputBytes) {
+	const char *size_end = argv[3] + std::strlen(argv[3]);
+	auto [size_ptr, size_error] =
+		std::from_chars(argv[3], size_end, output_bytes);
+	if (size_error != std::errc() || size_ptr != size_end ||
+	    output_bytes == 0 || output_bytes > kMaxOutputBytes) {
 		std::cerr << "Invalid output size\n";
 		return 64;
 	}
 	close_inherited_fds();
 
-	std::unique_ptr<void, int (*)(void *)> handle(
-		dlopen(library_path, RTLD_NOW | RTLD_LOCAL), dlclose);
+	void *handle = dlopen(library_path, RTLD_NOW | RTLD_LOCAL);
 	if (!handle) {
 		std::cerr << "Unable to load PTX pass " << library_path << ": "
 			  << dlerror() << "\n";
@@ -110,9 +81,9 @@ int main(int argc, char **argv)
 	const int output_len = static_cast<int>(output.size());
 	int rc = 0;
 
-	if (mode == "--config") {
+	if (std::strcmp(argv[1], "--config") == 0) {
 		auto print_config = reinterpret_cast<print_config_fn>(
-			dlsym(handle.get(), "print_config"));
+			dlsym(handle, "print_config"));
 		if (!print_config) {
 			std::cerr << "Symbol print_config not found in "
 				  << library_path << "\n";
@@ -121,20 +92,21 @@ int main(int argc, char **argv)
 		print_config(output_len, output.data());
 	} else {
 		auto process_input = reinterpret_cast<process_input_fn>(
-			dlsym(handle.get(), "process_input"));
+			dlsym(handle, "process_input"));
 		if (!process_input) {
 			std::cerr << "Symbol process_input not found in "
 				  << library_path << "\n";
 			return 66;
 		}
-		std::string input = read_stdin();
+		std::string input{ std::istreambuf_iterator<char>(std::cin),
+				   std::istreambuf_iterator<char>() };
 		rc = process_input(input.c_str(), output_len, output.data());
 	}
-	handle.reset();
+	dlclose(handle);
 	if (rc != 0)
 		return rc;
 	if (!write_all(kResultFd, output.data(),
-		       nul_terminated_length(output))) {
+		       strnlen(output.data(), output.size()))) {
 		std::cerr << "Unable to write PTX pass output: "
 			  << std::strerror(errno) << "\n";
 		return 70;

--- a/attach/nv_attach_impl/pass/ptxpass_runner.cpp
+++ b/attach/nv_attach_impl/pass/ptxpass_runner.cpp
@@ -61,6 +61,23 @@ void close_inherited_fds()
 	for (int fd = STDERR_FILENO + 1; fd < max_fd; fd++)
 		close(fd);
 }
+
+bool write_all(int fd, const char *data, size_t length)
+{
+	while (length > 0) {
+		ssize_t written = write(fd, data, length);
+		if (written <= 0) {
+			if (written < 0 && errno == EINTR)
+				continue;
+			if (written == 0)
+				errno = EIO;
+			return false;
+		}
+		data += written;
+		length -= static_cast<size_t>(written);
+	}
+	return true;
+}
 } // namespace
 
 int main(int argc, char **argv)
@@ -101,23 +118,6 @@ int main(int argc, char **argv)
 			close(saved_stdout);
 		return 70;
 	}
-	auto restore_stdout = [&]() -> bool {
-		std::cout.flush();
-		std::clog.flush();
-		std::cerr.flush();
-		fflush(stdout);
-		if (dup2(saved_stdout, STDOUT_FILENO) == -1) {
-			std::cerr << "Unable to restore stdout: "
-				  << std::strerror(errno) << "\n";
-			close(saved_stdout);
-			saved_stdout = -1;
-			return false;
-		}
-		close(saved_stdout);
-		saved_stdout = -1;
-		return true;
-	};
-
 	std::unique_ptr<void, int (*)(void *)> handle(
 		dlopen(library_path, RTLD_NOW | RTLD_LOCAL), dlclose);
 	if (!handle) {
@@ -128,6 +128,7 @@ int main(int argc, char **argv)
 
 	std::vector<char> output(output_bytes, '\0');
 	const int output_len = static_cast<int>(output.size());
+	int rc = 0;
 
 	if (mode == "--config") {
 		auto print_config = reinterpret_cast<print_config_fn>(
@@ -138,27 +139,31 @@ int main(int argc, char **argv)
 			return 66;
 		}
 		print_config(output_len, output.data());
-		handle.reset();
-		if (!restore_stdout())
-			return 70;
-		std::cout.write(output.data(), nul_terminated_length(output));
-		return 0;
+	} else {
+		auto process_input = reinterpret_cast<process_input_fn>(
+			dlsym(handle.get(), "process_input"));
+		if (!process_input) {
+			std::cerr << "Symbol process_input not found in "
+				  << library_path << "\n";
+			return 66;
+		}
+		std::string input = read_stdin();
+		rc = process_input(input.c_str(), output_len, output.data());
 	}
-
-	auto process_input = reinterpret_cast<process_input_fn>(
-		dlsym(handle.get(), "process_input"));
-	if (!process_input) {
-		std::cerr << "Symbol process_input not found in "
-			  << library_path << "\n";
-		return 66;
-	}
-	std::string input = read_stdin();
-	int rc = process_input(input.c_str(), output_len, output.data());
 	handle.reset();
-	if (!restore_stdout())
-		return 70;
 	if (rc != 0)
 		return rc;
-	std::cout.write(output.data(), nul_terminated_length(output));
-	return 0;
+	std::cout.flush();
+	std::clog.flush();
+	std::cerr.flush();
+	fflush(stdout);
+	if (!write_all(saved_stdout, output.data(),
+		       nul_terminated_length(output))) {
+		std::cerr << "Unable to write PTX pass output: "
+			  << std::strerror(errno) << "\n";
+		close(saved_stdout);
+		return 70;
+	}
+	close(saved_stdout);
+	_exit(0);
 }

--- a/attach/nv_attach_impl/pass/ptxpass_runner.cpp
+++ b/attach/nv_attach_impl/pass/ptxpass_runner.cpp
@@ -2,7 +2,6 @@
 #include <charconv>
 #include <cstring>
 #include <dlfcn.h>
-#include <cstdio>
 #include <iostream>
 #include <iterator>
 #include <limits>
@@ -17,15 +16,13 @@ using process_input_fn = int (*)(const char *input, int length, char *output);
 
 namespace
 {
-constexpr size_t kDefaultConfigOutputBytes = 256U << 10;
-constexpr size_t kDefaultProcessOutputBytes = 1U << 20;
 constexpr size_t kMaxOutputBytes = 64U << 20;
+constexpr int kResultFd = STDERR_FILENO + 1;
 
 void usage(const char *argv0)
 {
-	std::cerr
-		<< "Usage: " << argv0
-		<< " (--config|--process) <pass-library> [--output-bytes N]\n";
+	std::cerr << "Usage: " << argv0
+		  << " (--config|--process) <pass-library> <output-bytes>\n";
 }
 
 bool parse_size(const char *text, size_t &out)
@@ -52,13 +49,13 @@ size_t nul_terminated_length(const std::vector<char> &buffer)
 void close_inherited_fds()
 {
 #if defined(SYS_close_range)
-	if (syscall(SYS_close_range, STDERR_FILENO + 1, ~0U, 0) == 0)
+	if (syscall(SYS_close_range, kResultFd + 1, ~0U, 0) == 0)
 		return;
 #endif
 	long max_fd = sysconf(_SC_OPEN_MAX);
 	if (max_fd < 0 || max_fd > std::numeric_limits<int>::max())
 		max_fd = 1024;
-	for (int fd = STDERR_FILENO + 1; fd < max_fd; fd++)
+	for (int fd = kResultFd + 1; fd < max_fd; fd++)
 		close(fd);
 }
 
@@ -82,7 +79,7 @@ bool write_all(int fd, const char *data, size_t length)
 
 int main(int argc, char **argv)
 {
-	if (argc < 3) {
+	if (argc != 4) {
 		usage(argv[0]);
 		return 64;
 	}
@@ -93,31 +90,14 @@ int main(int argc, char **argv)
 		usage(argv[0]);
 		return 64;
 	}
-	size_t output_bytes = kDefaultProcessOutputBytes;
-	if (mode == "--config")
-		output_bytes = kDefaultConfigOutputBytes;
-	if (argc != 3 &&
-	    (argc != 5 || std::strcmp(argv[3], "--output-bytes") != 0)) {
-		usage(argv[0]);
-		return 64;
-	}
-	if (argc == 5 &&
-	    (!parse_size(argv[4], output_bytes) || output_bytes == 0 ||
-	     output_bytes > kMaxOutputBytes)) {
-		std::cerr << "Invalid --output-bytes value\n";
+	size_t output_bytes = 0;
+	if (!parse_size(argv[3], output_bytes) || output_bytes == 0 ||
+	    output_bytes > kMaxOutputBytes) {
+		std::cerr << "Invalid output size\n";
 		return 64;
 	}
 	close_inherited_fds();
 
-	fflush(stdout);
-	int saved_stdout = dup(STDOUT_FILENO);
-	if (saved_stdout == -1 || dup2(STDERR_FILENO, STDOUT_FILENO) == -1) {
-		std::cerr << "Unable to redirect pass stdout: "
-			  << std::strerror(errno) << "\n";
-		if (saved_stdout != -1)
-			close(saved_stdout);
-		return 70;
-	}
 	std::unique_ptr<void, int (*)(void *)> handle(
 		dlopen(library_path, RTLD_NOW | RTLD_LOCAL), dlclose);
 	if (!handle) {
@@ -153,17 +133,12 @@ int main(int argc, char **argv)
 	handle.reset();
 	if (rc != 0)
 		return rc;
-	std::cout.flush();
-	std::clog.flush();
-	std::cerr.flush();
-	fflush(stdout);
-	if (!write_all(saved_stdout, output.data(),
+	if (!write_all(kResultFd, output.data(),
 		       nul_terminated_length(output))) {
 		std::cerr << "Unable to write PTX pass output: "
 			  << std::strerror(errno) << "\n";
-		close(saved_stdout);
 		return 70;
 	}
-	close(saved_stdout);
+	close(kResultFd);
 	_exit(0);
 }

--- a/attach/nv_attach_impl/pass/ptxpass_runner.cpp
+++ b/attach/nv_attach_impl/pass/ptxpass_runner.cpp
@@ -80,24 +80,19 @@ int main(int argc, char **argv)
 	std::vector<char> output(output_bytes, '\0');
 	const int output_len = static_cast<int>(output.size());
 	int rc = 0;
+	auto print_config = reinterpret_cast<print_config_fn>(
+		dlsym(handle, "print_config"));
+	auto process_input = reinterpret_cast<process_input_fn>(
+		dlsym(handle, "process_input"));
+	if (!print_config || !process_input) {
+		std::cerr << "Required PTX pass symbols not found in "
+			  << library_path << "\n";
+		return 66;
+	}
 
 	if (std::strcmp(argv[1], "--config") == 0) {
-		auto print_config = reinterpret_cast<print_config_fn>(
-			dlsym(handle, "print_config"));
-		if (!print_config) {
-			std::cerr << "Symbol print_config not found in "
-				  << library_path << "\n";
-			return 66;
-		}
 		print_config(output_len, output.data());
 	} else {
-		auto process_input = reinterpret_cast<process_input_fn>(
-			dlsym(handle, "process_input"));
-		if (!process_input) {
-			std::cerr << "Symbol process_input not found in "
-				  << library_path << "\n";
-			return 66;
-		}
 		std::string input{ std::istreambuf_iterator<char>(std::cin),
 				   std::istreambuf_iterator<char>() };
 		rc = process_input(input.c_str(), output_len, output.data());

--- a/attach/nv_attach_impl/pass/ptxpass_runner_test_pass.cpp
+++ b/attach/nv_attach_impl/pass/ptxpass_runner_test_pass.cpp
@@ -2,6 +2,7 @@
 
 __attribute__((constructor)) static void on_load()
 {
+	setvbuf(stdout, nullptr, _IONBF, 0);
 	puts("constructor noise");
 }
 

--- a/attach/nv_attach_impl/pass/ptxpass_runner_test_pass.cpp
+++ b/attach/nv_attach_impl/pass/ptxpass_runner_test_pass.cpp
@@ -16,9 +16,11 @@ extern "C" void print_config(int length, char *output)
 	snprintf(output, length, R"({"mode":"config"})");
 }
 
+#ifndef PTXPASS_CONFIG_ONLY
 extern "C" int process_input(const char *input, int length, char *output)
 {
 	puts("process noise");
 	snprintf(output, length, R"({"input":"%s"})", input);
 	return 0;
 }
+#endif

--- a/attach/nv_attach_impl/pass/ptxpass_runner_test_pass.cpp
+++ b/attach/nv_attach_impl/pass/ptxpass_runner_test_pass.cpp
@@ -1,0 +1,24 @@
+#include <cstdio>
+
+__attribute__((constructor)) static void on_load()
+{
+	puts("constructor noise");
+}
+
+__attribute__((destructor)) static void on_unload()
+{
+	puts("destructor noise");
+}
+
+extern "C" void print_config(int length, char *output)
+{
+	puts("config noise");
+	snprintf(output, length, R"({"mode":"config"})");
+}
+
+extern "C" int process_input(const char *input, int length, char *output)
+{
+	puts("process noise");
+	snprintf(output, length, R"({"input":"%s"})", input);
+	return 0;
+}

--- a/attach/nv_attach_impl/test/CMakeLists.txt
+++ b/attach/nv_attach_impl/test/CMakeLists.txt
@@ -27,13 +27,16 @@ if(${ENABLE_EBPF_VERIFIER} AND NOT TARGET Catch2)
 endif()
 
 add_dependencies(bpftime_nv_attach_tests Catch2 bpftime_nv_attach_impl ptxpass_core spdlog::spdlog)
+add_dependencies(bpftime_nv_attach_tests ptxpass_runner_test_pass)
+file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/ptxpass_runner_test_config.hpp"
+    CONTENT "#pragma once\n#define PTXPASS_RUNNER_TEST_PASS R\"($<TARGET_FILE:ptxpass_runner_test_pass>)\"\n")
 if(${TEST_LCOV})
     target_link_options(bpftime_nv_attach_tests PRIVATE -lgcov)
     target_link_libraries(bpftime_nv_attach_tests PRIVATE Catch2::Catch2WithMain bpftime_nv_attach_impl ptxpass_core spdlog::spdlog gcov cuda)
 else()
     target_link_libraries(bpftime_nv_attach_tests PRIVATE Catch2::Catch2WithMain bpftime_nv_attach_impl ptxpass_core spdlog::spdlog cuda)
 endif()
-target_include_directories(bpftime_nv_attach_tests PRIVATE ${CMAKE_SOURCE_DIR}/runtime/ ${NV_ATTACH_IMPL_INCLUDE} ${CMAKE_SOURCE_DIR}/attach/nv_attach_impl/pass/ptxpass_core/include ${Catch2_INCLUDE} ${SPDLOG_INCLUDE})
+target_include_directories(bpftime_nv_attach_tests PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_SOURCE_DIR}/runtime/ ${NV_ATTACH_IMPL_INCLUDE} ${CMAKE_SOURCE_DIR}/attach/nv_attach_impl/pass/ptxpass_core/include ${Catch2_INCLUDE} ${SPDLOG_INCLUDE})
 
 add_test(NAME bpftime_nv_attach_tests COMMAND bpftime_nv_attach_tests)
 

--- a/attach/nv_attach_impl/test/CMakeLists.txt
+++ b/attach/nv_attach_impl/test/CMakeLists.txt
@@ -42,5 +42,10 @@ endif()
 target_include_directories(bpftime_nv_attach_tests PRIVATE ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_SOURCE_DIR}/runtime/ ${NV_ATTACH_IMPL_INCLUDE} ${CMAKE_SOURCE_DIR}/attach/nv_attach_impl/pass/ptxpass_core/include ${Catch2_INCLUDE} ${SPDLOG_INCLUDE})
 
 add_test(NAME bpftime_nv_attach_tests COMMAND bpftime_nv_attach_tests)
+if(BPFTIME_ENABLE_UNIT_TESTING)
+    add_test(NAME ptxpass-runner-ignored-sigchld
+        COMMAND sh -c "trap '' CHLD; \"$1\" '[ptxpass_runner]'"
+        _ $<TARGET_FILE:bpftime_nv_attach_tests>)
+endif()
 
 set_property(TARGET bpftime_nv_attach_tests PROPERTY CXX_STANDARD 20)

--- a/attach/nv_attach_impl/test/CMakeLists.txt
+++ b/attach/nv_attach_impl/test/CMakeLists.txt
@@ -27,9 +27,12 @@ if(${ENABLE_EBPF_VERIFIER} AND NOT TARGET Catch2)
 endif()
 
 add_dependencies(bpftime_nv_attach_tests Catch2 bpftime_nv_attach_impl ptxpass_core spdlog::spdlog)
-add_dependencies(bpftime_nv_attach_tests ptxpass_runner_test_pass)
-file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/ptxpass_runner_test_config.hpp"
-    CONTENT "#pragma once\n#define PTXPASS_RUNNER_TEST_PASS R\"($<TARGET_FILE:ptxpass_runner_test_pass>)\"\n")
+if(BPFTIME_ENABLE_UNIT_TESTING)
+    add_dependencies(bpftime_nv_attach_tests ptxpass_runner_test_pass ptxpass_runner_config_only_test_pass)
+    target_compile_definitions(bpftime_nv_attach_tests PRIVATE BPFTIME_TEST_PTXPASS_RUNNER)
+    file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/ptxpass_runner_test_config.hpp"
+        CONTENT "#pragma once\n#define PTXPASS_RUNNER_TEST_PASS R\"($<TARGET_FILE:ptxpass_runner_test_pass>)\"\n")
+endif()
 if(${TEST_LCOV})
     target_link_options(bpftime_nv_attach_tests PRIVATE -lgcov)
     target_link_libraries(bpftime_nv_attach_tests PRIVATE Catch2::Catch2WithMain bpftime_nv_attach_impl ptxpass_core spdlog::spdlog gcov cuda)

--- a/attach/nv_attach_impl/test/test_ptxpass.cpp
+++ b/attach/nv_attach_impl/test/test_ptxpass.cpp
@@ -310,7 +310,8 @@ TEST_CASE("compile_ebpf_to_ptx_from_words compiles eBPF to PTX",
 	REQUIRE(ptx.find("ret") != std::string::npos);
 }
 
-TEST_CASE("log_transform_stats emits stats through spdlog", "[ptxpass_core]")
+TEST_CASE("log_transform_stats emits stats through spdlog",
+	  "[ptxpass_core]")
 {
 	std::ostringstream oss;
 	auto old_logger = spdlog::default_logger();

--- a/attach/nv_attach_impl/test/test_ptxpass.cpp
+++ b/attach/nv_attach_impl/test/test_ptxpass.cpp
@@ -1,14 +1,27 @@
 #include "catch2/catch_test_macros.hpp"
 #include "ptxpass/core.hpp"
+#include "ptxpass_runner_test_config.hpp"
+#include <array>
+#include <fcntl.h>
+#include <filesystem>
 #include <memory>
 #include <fstream>
 #include <iostream>
+#include <optional>
 #include <spdlog/logger.h>
 #include <spdlog/sinks/ostream_sink.h>
 #include <spdlog/spdlog.h>
 #include <sstream>
 #include <string>
+#include <unistd.h>
 #include <vector>
+
+namespace bpftime::attach
+{
+std::optional<std::string>
+run_ptxpass_runner_for_test(const std::string &, const std::filesystem::path &,
+			    const std::string *, size_t);
+}
 
 using namespace ptxpass;
 
@@ -293,8 +306,7 @@ TEST_CASE("compile_ebpf_to_ptx_from_words compiles eBPF to PTX",
 	REQUIRE(ptx.find("ret") != std::string::npos);
 }
 
-TEST_CASE("log_transform_stats emits stats through spdlog",
-	  "[ptxpass_core]")
+TEST_CASE("log_transform_stats emits stats through spdlog", "[ptxpass_core]")
 {
 	std::ostringstream oss;
 	auto old_logger = spdlog::default_logger();
@@ -411,4 +423,44 @@ TEST_CASE("compile_ebpf_to_ptx_from_words handles exit instruction",
 		pos += 7;
 	}
 	REQUIRE(target_count <= 1);
+}
+
+TEST_CASE("PTX pass runner client handles closed standard descriptors",
+	  "[ptxpass_runner]")
+{
+	std::optional<std::string> config;
+	std::optional<std::string> process;
+	{
+		struct standard_fd_guard {
+			std::array<int, 4> saved{};
+			standard_fd_guard()
+			{
+				for (int fd = 0; fd < 4; fd++) {
+					saved[fd] =
+						fcntl(fd, F_DUPFD_CLOEXEC, 4);
+					close(fd);
+				}
+			}
+			~standard_fd_guard()
+			{
+				for (int fd = 0; fd < 4; fd++) {
+					if (saved[fd] >= 0) {
+						dup2(saved[fd], fd);
+						close(saved[fd]);
+					}
+				}
+			}
+		};
+		standard_fd_guard guard;
+
+		const std::filesystem::path pass = PTXPASS_RUNNER_TEST_PASS;
+		config = bpftime::attach::run_ptxpass_runner_for_test(
+			"--config", pass, nullptr, 1024);
+		const std::string input = "input";
+		process = bpftime::attach::run_ptxpass_runner_for_test(
+			"--process", pass, &input, 1024);
+	}
+
+	REQUIRE(config == R"({"mode":"config"})");
+	REQUIRE(process == R"({"input":"input"})");
 }

--- a/attach/nv_attach_impl/test/test_ptxpass.cpp
+++ b/attach/nv_attach_impl/test/test_ptxpass.cpp
@@ -1,6 +1,8 @@
 #include "catch2/catch_test_macros.hpp"
 #include "ptxpass/core.hpp"
+#ifdef BPFTIME_TEST_PTXPASS_RUNNER
 #include "ptxpass_runner_test_config.hpp"
+#endif
 #include <array>
 #include <fcntl.h>
 #include <filesystem>
@@ -16,12 +18,14 @@
 #include <unistd.h>
 #include <vector>
 
+#ifdef BPFTIME_TEST_PTXPASS_RUNNER
 namespace bpftime::attach
 {
 std::optional<std::string>
 run_ptxpass_runner_for_test(const std::string &, const std::filesystem::path &,
 			    const std::string *, size_t);
 }
+#endif
 
 using namespace ptxpass;
 
@@ -425,6 +429,7 @@ TEST_CASE("compile_ebpf_to_ptx_from_words handles exit instruction",
 	REQUIRE(target_count <= 1);
 }
 
+#ifdef BPFTIME_TEST_PTXPASS_RUNNER
 TEST_CASE("PTX pass runner client handles closed standard descriptors",
 	  "[ptxpass_runner]")
 {
@@ -464,3 +469,4 @@ TEST_CASE("PTX pass runner client handles closed standard descriptors",
 	REQUIRE(config == R"({"mode":"config"})");
 	REQUIRE(process == R"({"input":"input"})");
 }
+#endif

--- a/attach/nv_attach_impl/test/test_ptxpass.cpp
+++ b/attach/nv_attach_impl/test/test_ptxpass.cpp
@@ -21,9 +21,9 @@
 #ifdef BPFTIME_TEST_PTXPASS_RUNNER
 namespace bpftime::attach
 {
-std::optional<std::string>
-run_ptxpass_runner_for_test(const std::string &, const std::filesystem::path &,
-			    const std::string *, size_t);
+std::optional<std::string> run_ptxpass_runner(const std::string &,
+					      const std::filesystem::path &,
+					      const std::string *, size_t);
 }
 #endif
 
@@ -460,11 +460,11 @@ TEST_CASE("PTX pass runner client handles closed standard descriptors",
 		standard_fd_guard guard;
 
 		const std::filesystem::path pass = PTXPASS_RUNNER_TEST_PASS;
-		config = bpftime::attach::run_ptxpass_runner_for_test(
-			"--config", pass, nullptr, 1024);
+		config = bpftime::attach::run_ptxpass_runner("--config", pass,
+							     nullptr, 1024);
 		const std::string input = "input";
-		process = bpftime::attach::run_ptxpass_runner_for_test(
-			"--process", pass, &input, 1024);
+		process = bpftime::attach::run_ptxpass_runner("--process", pass,
+							      &input, 1024);
 	}
 
 	REQUIRE(config == R"({"mode":"config"})");


### PR DESCRIPTION
Replaces #583 with a current-master implementation.

## Why

PTX pass DSOs currently run inside an already CUDA-initialized target process. Loading arbitrary pass code there couples pass crashes, global state, loader behavior, and preload hooks to the target; forking after CUDA initialization is also unsafe.

## Change

- add a one-shot `bpftime_ptxpass_runner` and invoke it with `posix_spawn`
- keep pass DSOs out of the CUDA or injected parent
- use stdin for input, stdout/stderr for diagnostics, and dedicated FD 3 for results
- duplicate spawn source FDs above 3 before remapping, so closed standard FDs cannot collide with protocol descriptors
- remove inherited `LD_PRELOAD`/`LD_AUDIT` and close inherited FDs before `dlopen`
- tolerate an externally reaped child only when FD 3 contains a completed result
- keep adaptive process output at 1 to 64 MiB and existing config, pass selection, caching, and ordering
- treat malformed config output like other pass failures
- restore the runner executable bit after artifact download before GPU example jobs

## Minimal-diff audit

Exact diff: 9 files, +445/-114.

No generic IPC framework, service, CLI/config surface, public header API, or build matrix is added. The artifact correction is limited to validating the runner path, restoring its mode, and asserting the result.

## Validation

Exact HEAD: `2d06c05e90bb16eee6bfeb25c9e23a5782a5cb76`

- testing-on `bpftime_nv_attach_tests` build
- complete directory CTest suite: 3/3 passed
- focused runner regression: 2 assertions in 1 case passed
- testing-off `bpftime_nv_attach_tests` build
- parsed `.github/workflows/test-gpu-examples.yml`
- `git diff --check`
- exact-head dedicated review: PASS
- exact-head independent external read-only review: PASS

## CI and merge status

The prerequisite base repair has merged and this branch was synchronized. In run 30986750301, four GPU example jobs reached the new runner but `posix_spawn` failed with Permission denied after artifact download stripped its executable bit. The exact head now validates the runner artifact, restores its mode, and asserts it is executable. The integrated rerun completed all 120 jobs successfully; PR checks are terminal at 86 passed, 2 skipped, 0 failed or pending.

#619 should merge first because both PRs touch the PTX test CMake file. This PR is Ready (not Draft) and remains unmerged pending maintainer approval.
