### PR TITLE
ci: cover remaining runtime options

### DIFF
--- a/.github/workflows/test-runtime.yml
+++ b/.github/workflows/test-runtime.yml
@@ -128,27 +128,24 @@ jobs:
           ./build/runtime/unit-test/bpftime_runtime_tests
       - name: Test runtime environment options (Ubuntu)
         if: matrix.container == 'ubuntu-2204'
-        shell: bash
+        env:
+          BPFTIME_LOG_OUTPUT: console
         run: |
-          set -euo pipefail
+          set -eu
           SERVER="$PWD/build/runtime/syscall-server/libbpftime-syscall-server.so"
           HELPER="$PWD/build/runtime/unit-test/bpftime-runtime-options-test-helper"
 
-          if BPFTIME_LOG_OUTPUT=console \
-             BPFTIME_RUN_WITH_KERNEL=true \
+          if BPFTIME_RUN_WITH_KERNEL=true \
              LD_PRELOAD="$SERVER" \
-             "$HELPER" > runtime-options-without-bypass.log 2>&1; then
+             "$HELPER"; then
             echo "Invalid BPF program loaded without verifier bypass"
             exit 1
           fi
 
-          BPFTIME_LOG_OUTPUT=console \
           BPFTIME_RUN_WITH_KERNEL=true \
           BPFTIME_NOT_LOAD_PATTERN='bypass_me' \
           LD_PRELOAD="$SERVER" \
-            "$HELPER" 2>&1 | tee runtime-options.log
-          grep -F "Using kernel eBPF runtime and maps" runtime-options.log
-          grep -F "By pass kernel verifier for program bypass_me" runtime-options.log
+            "$HELPER"
       - name: Build runtime libs for example (openEuler)
         if: matrix.container == 'openeuler-2403sp2'
         run: |

--- a/.github/workflows/test-runtime.yml
+++ b/.github/workflows/test-runtime.yml
@@ -124,15 +124,27 @@ jobs:
           ./build/runtime/unit-test/bpftime_runtime_tests
       - name: Test runtime environment options (Ubuntu)
         if: matrix.container == 'ubuntu-2204'
+        shell: bash
         run: |
           set -euo pipefail
+          SERVER="$PWD/build/runtime/syscall-server/libbpftime-syscall-server.so"
+          HELPER="$PWD/build/runtime/unit-test/bpftime-runtime-options-test-helper"
+
+          if BPFTIME_LOG_OUTPUT=console \
+             BPFTIME_RUN_WITH_KERNEL=true \
+             LD_PRELOAD="$SERVER" \
+             "$HELPER" > runtime-options-without-bypass.log 2>&1; then
+            echo "Invalid BPF program loaded without verifier bypass"
+            exit 1
+          fi
+
           BPFTIME_LOG_OUTPUT=console \
           BPFTIME_RUN_WITH_KERNEL=true \
-          BPFTIME_NOT_LOAD_PATTERN='.*' \
-          LD_PRELOAD="$PWD/build/runtime/syscall-server/libbpftime-syscall-server.so" \
-            /bin/cat /dev/null 2>&1 | tee runtime-options.log
+          BPFTIME_NOT_LOAD_PATTERN='bypass_me' \
+          LD_PRELOAD="$SERVER" \
+            "$HELPER" 2>&1 | tee runtime-options.log
           grep -F "Using kernel eBPF runtime and maps" runtime-options.log
-          grep -F "By pass kernel verifier pattern: .*" runtime-options.log
+          grep -F "By pass kernel verifier for program bypass_me" runtime-options.log
       - name: Build static runtime archive (Ubuntu)
         if: matrix.container == 'ubuntu-2204'
         run: |

--- a/.github/workflows/test-runtime.yml
+++ b/.github/workflows/test-runtime.yml
@@ -122,6 +122,31 @@ jobs:
         run: |
           export BPFTIME_VM_NAME=llvm
           ./build/runtime/unit-test/bpftime_runtime_tests
+      - name: Test runtime environment options (Ubuntu)
+        if: matrix.container == 'ubuntu-2204'
+        run: |
+          set -euo pipefail
+          BPFTIME_LOG_OUTPUT=console \
+          BPFTIME_RUN_WITH_KERNEL=true \
+          BPFTIME_NOT_LOAD_PATTERN='.*' \
+          LD_PRELOAD="$PWD/build/runtime/syscall-server/libbpftime-syscall-server.so" \
+            /bin/cat /dev/null 2>&1 | tee runtime-options.log
+          grep -F "Using kernel eBPF runtime and maps" runtime-options.log
+          grep -F "By pass kernel verifier pattern: .*" runtime-options.log
+      - name: Build static runtime archive (Ubuntu)
+        if: matrix.container == 'ubuntu-2204'
+        run: |
+          set -e
+          LLVM_CONFIG=$(command -v llvm-config-18 || command -v llvm-config-17 || command -v llvm-config-16 || command -v llvm-config-15 || command -v llvm-config)
+          cmake -S . -B build-static \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DLLVM_DIR="$($LLVM_CONFIG --cmakedir)" \
+            -DBPFTIME_BUILD_STATIC_LIB=ON \
+            -DBPFTIME_ENABLE_CUDA_ATTACH=OFF \
+            -DBUILD_BPFTIME_DAEMON=OFF \
+            -DBPFTIME_ENABLE_UNIT_TESTING=OFF
+          cmake --build build-static --target bpftime_static_target -j$(nproc)
+          test -s build-static/libbpftime.a
       - name: Build runtime libs for example (openEuler)
         if: matrix.container == 'openeuler-2403sp2'
         run: |

--- a/.github/workflows/test-runtime.yml
+++ b/.github/workflows/test-runtime.yml
@@ -134,6 +134,8 @@ jobs:
           set -eu
           SERVER="$PWD/build/runtime/syscall-server/libbpftime-syscall-server.so"
           HELPER="$PWD/build/runtime/unit-test/bpftime-runtime-options-test-helper"
+          GCOV_PREFIX=$(mktemp -d)
+          export GCOV_PREFIX GCOV_PREFIX_STRIP=0
 
           if BPFTIME_RUN_WITH_KERNEL=true \
              LD_PRELOAD="$SERVER" \

--- a/.github/workflows/test-runtime.yml
+++ b/.github/workflows/test-runtime.yml
@@ -116,38 +116,16 @@ jobs:
             cmake -DTEST_LCOV=ON -DBPFTIME_LLVM_JIT=YES -DBPFTIME_ENABLE_UNIT_TESTING=YES -DBPFTIME_ENABLE_CUDA_ATTACH=OFF -DBUILD_BPFTIME_DAEMON=OFF -DBPFTIME_BUILD_STATIC_LIB=ON -DENABLE_PROBE_WRITE_CHECK=1 -DENABLE_PROBE_READ_CHECK=1 -DCMAKE_BUILD_TYPE=Debug -B build
           fi
           if [ -n "$LLVM_LIBDIR" ]; then export LD_LIBRARY_PATH="$LLVM_LIBDIR:$LD_LIBRARY_PATH"; fi
-          cmake --build build --config Debug --target bpftime_runtime_tests -j$(nproc)
           if [ "${{ matrix.container }}" = 'ubuntu-2204' ]; then
             cmake --build build --config Debug --target bpftime_static_target -j$(nproc)
             test -s build/libbpftime.a
           fi
+          cmake --build build --config Debug --target bpftime_runtime_tests -j$(nproc)
       - name: Test Runtime (Ubuntu/Fedora)
         if: matrix.container != 'openeuler-2403sp2'
         run: |
           export BPFTIME_VM_NAME=llvm
           ./build/runtime/unit-test/bpftime_runtime_tests
-      - name: Test runtime environment options (Ubuntu)
-        if: matrix.container == 'ubuntu-2204'
-        env:
-          BPFTIME_LOG_OUTPUT: console
-        run: |
-          set -eu
-          SERVER="$PWD/build/runtime/syscall-server/libbpftime-syscall-server.so"
-          HELPER="$PWD/build/runtime/unit-test/bpftime-runtime-options-test-helper"
-          GCOV_PREFIX=$(mktemp -d)
-          export GCOV_PREFIX GCOV_PREFIX_STRIP=0
-
-          if BPFTIME_RUN_WITH_KERNEL=true \
-             LD_PRELOAD="$SERVER" \
-             "$HELPER"; then
-            echo "Invalid BPF program loaded without verifier bypass"
-            exit 1
-          fi
-
-          BPFTIME_RUN_WITH_KERNEL=true \
-          BPFTIME_NOT_LOAD_PATTERN='bypass_me' \
-          LD_PRELOAD="$SERVER" \
-            "$HELPER"
       - name: Build runtime libs for example (openEuler)
         if: matrix.container == 'openeuler-2403sp2'
         run: |
@@ -251,6 +229,27 @@ jobs:
           include-hidden-files: false
           path: |
             ./coverage-runtime.info
+
+      - name: Test runtime environment options (Ubuntu)
+        if: matrix.container == 'ubuntu-2204'
+        env:
+          BPFTIME_LOG_OUTPUT: console
+        run: |
+          set -eu
+          SERVER="$PWD/build/runtime/syscall-server/libbpftime-syscall-server.so"
+          HELPER="$PWD/build/runtime/unit-test/bpftime-runtime-options-test-helper"
+
+          if BPFTIME_RUN_WITH_KERNEL=true \
+             LD_PRELOAD="$SERVER" \
+             "$HELPER"; then
+            echo "Invalid BPF program loaded without verifier bypass"
+            exit 1
+          fi
+
+          BPFTIME_RUN_WITH_KERNEL=true \
+          BPFTIME_NOT_LOAD_PATTERN='bypass_me' \
+          LD_PRELOAD="$SERVER" \
+            "$HELPER"
 
       - name: build runtime with mpk enable
         if: matrix.container != 'openeuler-2403sp2'

--- a/.github/workflows/test-runtime.yml
+++ b/.github/workflows/test-runtime.yml
@@ -111,12 +111,16 @@ jobs:
           LLVM_CMAKE_DIR=$([ -n "$LLVM_CONFIG" ] && "$LLVM_CONFIG" --cmakedir 2>/dev/null || true)
           LLVM_LIBDIR=$([ -n "$LLVM_CONFIG" ] && "$LLVM_CONFIG" --libdir 2>/dev/null || true)
           if [ -n "$LLVM_CMAKE_DIR" ]; then
-            cmake -DTEST_LCOV=ON -DBPFTIME_LLVM_JIT=YES -DBPFTIME_ENABLE_UNIT_TESTING=YES -DBPFTIME_ENABLE_CUDA_ATTACH=OFF -DBUILD_BPFTIME_DAEMON=OFF -DENABLE_PROBE_WRITE_CHECK=1 -DENABLE_PROBE_READ_CHECK=1 -DCMAKE_BUILD_TYPE=Debug -DLLVM_DIR="$LLVM_CMAKE_DIR" -B build
+            cmake -DTEST_LCOV=ON -DBPFTIME_LLVM_JIT=YES -DBPFTIME_ENABLE_UNIT_TESTING=YES -DBPFTIME_ENABLE_CUDA_ATTACH=OFF -DBUILD_BPFTIME_DAEMON=OFF -DBPFTIME_BUILD_STATIC_LIB=ON -DENABLE_PROBE_WRITE_CHECK=1 -DENABLE_PROBE_READ_CHECK=1 -DCMAKE_BUILD_TYPE=Debug -DLLVM_DIR="$LLVM_CMAKE_DIR" -B build
           else
-            cmake -DTEST_LCOV=ON -DBPFTIME_LLVM_JIT=YES -DBPFTIME_ENABLE_UNIT_TESTING=YES -DBPFTIME_ENABLE_CUDA_ATTACH=OFF -DBUILD_BPFTIME_DAEMON=OFF -DENABLE_PROBE_WRITE_CHECK=1 -DENABLE_PROBE_READ_CHECK=1 -DCMAKE_BUILD_TYPE=Debug -B build
+            cmake -DTEST_LCOV=ON -DBPFTIME_LLVM_JIT=YES -DBPFTIME_ENABLE_UNIT_TESTING=YES -DBPFTIME_ENABLE_CUDA_ATTACH=OFF -DBUILD_BPFTIME_DAEMON=OFF -DBPFTIME_BUILD_STATIC_LIB=ON -DENABLE_PROBE_WRITE_CHECK=1 -DENABLE_PROBE_READ_CHECK=1 -DCMAKE_BUILD_TYPE=Debug -B build
           fi
           if [ -n "$LLVM_LIBDIR" ]; then export LD_LIBRARY_PATH="$LLVM_LIBDIR:$LD_LIBRARY_PATH"; fi
           cmake --build build --config Debug --target bpftime_runtime_tests -j$(nproc)
+          if [ "${{ matrix.container }}" = 'ubuntu-2204' ]; then
+            cmake --build build --config Debug --target bpftime_static_target -j$(nproc)
+            test -s build/libbpftime.a
+          fi
       - name: Test Runtime (Ubuntu/Fedora)
         if: matrix.container != 'openeuler-2403sp2'
         run: |
@@ -145,20 +149,6 @@ jobs:
             "$HELPER" 2>&1 | tee runtime-options.log
           grep -F "Using kernel eBPF runtime and maps" runtime-options.log
           grep -F "By pass kernel verifier for program bypass_me" runtime-options.log
-      - name: Build static runtime archive (Ubuntu)
-        if: matrix.container == 'ubuntu-2204'
-        run: |
-          set -e
-          LLVM_CONFIG=$(command -v llvm-config-18 || command -v llvm-config-17 || command -v llvm-config-16 || command -v llvm-config-15 || command -v llvm-config)
-          cmake -S . -B build-static \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DLLVM_DIR="$($LLVM_CONFIG --cmakedir)" \
-            -DBPFTIME_BUILD_STATIC_LIB=ON \
-            -DBPFTIME_ENABLE_CUDA_ATTACH=OFF \
-            -DBUILD_BPFTIME_DAEMON=OFF \
-            -DBPFTIME_ENABLE_UNIT_TESTING=OFF
-          cmake --build build-static --target bpftime_static_target -j$(nproc)
-          test -s build-static/libbpftime.a
       - name: Build runtime libs for example (openEuler)
         if: matrix.container == 'openeuler-2403sp2'
         run: |

--- a/runtime/unit-test/CMakeLists.txt
+++ b/runtime/unit-test/CMakeLists.txt
@@ -55,9 +55,13 @@ add_executable(bpftime_runtime_tests ${TEST_SOURCES})
 if(UNIX AND NOT APPLE)
     add_executable(bpftime-shm-allocation-test-helper
         assets/shm_allocation_test_helper.c)
+    add_executable(bpftime-runtime-options-test-helper
+        assets/runtime_options_test_helper.c)
     set_property(TARGET bpftime-shm-allocation-test-helper PROPERTY C_STANDARD 99)
+    set_property(TARGET bpftime-runtime-options-test-helper PROPERTY C_STANDARD 99)
     add_dependencies(bpftime_runtime_tests
         bpftime-syscall-server
+        bpftime-runtime-options-test-helper
         bpftime-shm-allocation-test-helper)
     file(GENERATE
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/shm_allocation_test_paths.hpp"

--- a/runtime/unit-test/assets/runtime_options_test_helper.c
+++ b/runtime/unit-test/assets/runtime_options_test_helper.c
@@ -1,0 +1,22 @@
+#include <linux/bpf.h>
+#include <stdint.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+int main(void)
+{
+	const char license[] = "GPL";
+	struct bpf_insn insns[1] = {};
+	union bpf_attr attr = {
+		.prog_type = BPF_PROG_TYPE_SOCKET_FILTER,
+		.insn_cnt = 1,
+		.insns = (uint64_t)(uintptr_t)insns,
+		.license = (uint64_t)(uintptr_t)license,
+		.prog_name = "bypass_me",
+	};
+
+	int fd = syscall(__NR_bpf, BPF_PROG_LOAD, &attr, sizeof(attr));
+	if (fd >= 0)
+		close(fd);
+	return fd < 0;
+}

--- a/runtime/unit-test/test_config.cpp
+++ b/runtime/unit-test/test_config.cpp
@@ -2,6 +2,7 @@
 #include <bpftime_config.hpp>
 #include "./common_def.hpp"
 #include <boost/interprocess/interprocess_fwd.hpp>
+#include <optional>
 using namespace bpftime;
 using namespace boost::interprocess;
 static const char *SHM_NAME = "_BPFTIME_CONFIG_TEST";
@@ -20,4 +21,23 @@ TEST_CASE("Test bpftime agent_config")
 	REQUIRE(cfg.get_logger_output_path() == test_string);
 	cfg.set_logger_output_path(test_string_2.c_str());
 	REQUIRE(cfg.get_logger_output_path() == test_string_2);
+}
+
+TEST_CASE("Allow external maps from the environment")
+{
+	const char *old_value = getenv("BPFTIME_ALLOW_EXTERNAL_MAPS");
+	const auto saved_value = old_value == nullptr ?
+					 std::nullopt :
+					 std::optional<std::string>(old_value);
+
+	REQUIRE(setenv("BPFTIME_ALLOW_EXTERNAL_MAPS", "1", 1) == 0);
+	const auto cfg = construct_agent_config_from_env();
+	const int restore_result =
+		saved_value.has_value() ?
+			setenv("BPFTIME_ALLOW_EXTERNAL_MAPS",
+			       saved_value->c_str(), 1) :
+			unsetenv("BPFTIME_ALLOW_EXTERNAL_MAPS");
+
+	REQUIRE(restore_result == 0);
+	REQUIRE(cfg.allow_non_buildin_map_types);
 }

--- a/runtime/unit-test/test_config.cpp
+++ b/runtime/unit-test/test_config.cpp
@@ -29,7 +29,7 @@ TEST_CASE("Allow external maps from the environment")
 	const std::string saved_value = was_set ? old_value : "";
 
 	REQUIRE(setenv("BPFTIME_ALLOW_EXTERNAL_MAPS", "1", 1) == 0);
-	const auto cfg = construct_agent_config_from_env();
+	const auto cfg = construct_runtime_config_from_env();
 	const int restore_result =
 		was_set ? setenv("BPFTIME_ALLOW_EXTERNAL_MAPS",
 				 saved_value.c_str(), 1) :

--- a/runtime/unit-test/test_config.cpp
+++ b/runtime/unit-test/test_config.cpp
@@ -2,7 +2,6 @@
 #include <bpftime_config.hpp>
 #include "./common_def.hpp"
 #include <boost/interprocess/interprocess_fwd.hpp>
-#include <optional>
 using namespace bpftime;
 using namespace boost::interprocess;
 static const char *SHM_NAME = "_BPFTIME_CONFIG_TEST";
@@ -26,17 +25,15 @@ TEST_CASE("Test bpftime agent_config")
 TEST_CASE("Allow external maps from the environment")
 {
 	const char *old_value = getenv("BPFTIME_ALLOW_EXTERNAL_MAPS");
-	const auto saved_value = old_value == nullptr ?
-					 std::nullopt :
-					 std::optional<std::string>(old_value);
+	const bool was_set = old_value != nullptr;
+	const std::string saved_value = was_set ? old_value : "";
 
 	REQUIRE(setenv("BPFTIME_ALLOW_EXTERNAL_MAPS", "1", 1) == 0);
 	const auto cfg = construct_agent_config_from_env();
 	const int restore_result =
-		saved_value.has_value() ?
-			setenv("BPFTIME_ALLOW_EXTERNAL_MAPS",
-			       saved_value->c_str(), 1) :
-			unsetenv("BPFTIME_ALLOW_EXTERNAL_MAPS");
+		was_set ? setenv("BPFTIME_ALLOW_EXTERNAL_MAPS",
+				 saved_value.c_str(), 1) :
+			  unsetenv("BPFTIME_ALLOW_EXTERNAL_MAPS");
 
 	REQUIRE(restore_result == 0);
 	REQUIRE(cfg.allow_non_buildin_map_types);


### PR DESCRIPTION
## Summary

- exercise `BPFTIME_RUN_WITH_KERNEL` and `BPFTIME_NOT_LOAD_PATTERN` with a real invalid BPF load
- verify `BPFTIME_ALLOW_EXTERNAL_MAPS` through the runtime config parser
- build and validate the `BPFTIME_BUILD_STATIC_LIB` archive
- keep runtime coverage data coherent while running both validations

Part of #332; #625 covers the remaining no-libbpf build option. This is the current-master replacement for #338 and intentionally excludes `BPFTIME_BUILD_WITH_LIBBPF`.

## Minimal scope

Exact HEAD: `e812414717b13c750baf1d03eada477b9c38c6a6`

- 4 files, +70/-2; production code: 0 lines
- no new production behavior, public API, default, dependency, framework, documentation, or abstraction
- the dedicated syscall helper is required because the two options must be exercised in a fresh `LD_PRELOAD` process
- the static archive is built before the runtime test target so the final coverage-instrumented executable is linked against the final runtime objects
- the helper-process smoke runs after runtime coverage capture/upload; the following MPK build already removes the build tree

## Validation

- prior Ubuntu CI confirmed the invalid BPF load fails in kernel mode without the bypass pattern and succeeds with the matching pattern
- exact-head `BPFTIME_ALLOW_EXTERNAL_MAPS` parser test: 3 assertions / 1 test case passed
- exact-head `bpftime_static_target` and `bpftime_runtime_tests` build in the intended order; `libbpftime.a` is non-empty
- exact-head `gcov-13` processes `bpf_helper.cpp.gcda` without the prior stamp mismatch
- exact-head `Build and test runtime` CI: Ubuntu, Fedora, and openEuler all passed; Ubuntu coverage and both environment-option smoke paths completed successfully
- complete local runtime suite previously reached 8,644,307 assertions; 76/78 cases passed, with the two failures caused by existing host/kernel limitations outside this change
- workflow YAML parse and `git diff --check`: PASS
- exact-head dedicated review: PASS
- exact-head independent external read-only review: PASS
- fresh exact-head Copilot review requested

## Current status

Exact-head CI is terminal: 86 checks passed, 2 were intentionally skipped, and none failed or remain pending. This PR is Ready (not Draft) and remains unmerged pending maintainer approval.
