### PR TITLE
fix(build): support LLVM JIT without libbpf

### DIFF
--- a/.github/workflows/build-gcc13.yml
+++ b/.github/workflows/build-gcc13.yml
@@ -87,8 +87,10 @@ jobs:
             -DBPFTIME_BUILD_WITH_LIBBPF=OFF \
             -DBPFTIME_ENABLE_UNIT_TESTING=OFF
           cmake --build build-no-libbpf --target install -j$(nproc)
-          readelf -Ws build-no-libbpf/runtime/agent/libbpftime-agent.so | grep -q register_llvm_vm_factory
-          readelf -Ws build-no-libbpf/runtime/agent/libbpftime-agent.so | grep -q create_ubpf_vm_instance
+          readelf -Ws build-no-libbpf/runtime/agent/libbpftime-agent.so | grep register_llvm_vm_factory
+          readelf -Ws build-no-libbpf/runtime/agent/libbpftime-agent.so | grep create_ubpf_vm_instance
+          readelf -Ws build-no-libbpf/runtime/syscall-server/libbpftime-syscall-server.so | grep register_llvm_vm_factory
+          readelf -Ws build-no-libbpf/runtime/syscall-server/libbpftime-syscall-server.so | grep create_ubpf_vm_instance
 
       - name: Configure daemon build and tests
         env:

--- a/.github/workflows/build-gcc13.yml
+++ b/.github/workflows/build-gcc13.yml
@@ -77,6 +77,20 @@ jobs:
       - name: Build
         run: cmake --build build -j$(nproc)
 
+      - name: Build without libbpf
+        env:
+          CC: gcc-13
+          CXX: g++-13
+        run: |
+          cmake -S . -B build-no-libbpf \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX=$PWD/build-no-libbpf/install \
+            -DBPFTIME_BUILD_WITH_LIBBPF=OFF \
+            -DBPFTIME_ENABLE_UNIT_TESTING=OFF
+          cmake --build build-no-libbpf --target install -j$(nproc)
+          readelf -Ws build-no-libbpf/runtime/agent/libbpftime-agent.so | grep -q register_llvm_vm_factory
+          readelf -Ws build-no-libbpf/runtime/agent/libbpftime-agent.so | grep -q create_ubpf_vm_instance
+
       - name: Configure daemon build and tests
         env:
           CC: gcc-13

--- a/.github/workflows/build-gcc13.yml
+++ b/.github/workflows/build-gcc13.yml
@@ -84,7 +84,6 @@ jobs:
         run: |
           cmake -S . -B build-no-libbpf \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCMAKE_INSTALL_PREFIX=$PWD/build-no-libbpf/install \
             -DBPFTIME_BUILD_WITH_LIBBPF=OFF \
             -DBPFTIME_ENABLE_UNIT_TESTING=OFF
           cmake --build build-no-libbpf --target install -j$(nproc)

--- a/runtime/agent/CMakeLists.txt
+++ b/runtime/agent/CMakeLists.txt
@@ -29,7 +29,6 @@ endif()
 
 if(${BPFTIME_LLVM_JIT})
   add_dependencies(bpftime-agent bpftime_llvm_vm llvmbpf_vm)
-  target_link_options(bpftime-agent PUBLIC "-Wl,--whole-archive" "$<TARGET_FILE:bpftime_llvm_vm>" "-Wl,--no-whole-archive")
   target_link_libraries(bpftime-agent PUBLIC bpftime_llvm_vm)
   # Statically embed the compat_llvm constructor TU to guarantee VM factory registration in LD_PRELOAD context
   target_sources(bpftime-agent PRIVATE $<TARGET_OBJECTS:bpftime_llvm_vm_obj>)

--- a/runtime/src/bpf_map/userspace/bloom_filter.cpp
+++ b/runtime/src/bpf_map/userspace/bloom_filter.cpp
@@ -1,4 +1,5 @@
 #include <bpf_map/userspace/bloom_filter.hpp>
+#include "linux/bpf.h"
 #include <spdlog/spdlog.h>
 #include <cerrno>
 #include <cstring>

--- a/runtime/src/bpf_map/userspace/bloom_filter.hpp
+++ b/runtime/src/bpf_map/userspace/bloom_filter.hpp
@@ -24,7 +24,6 @@
 #include <boost/interprocess/sync/interprocess_mutex.hpp>
 #include <boost/interprocess/containers/vector.hpp>
 #include <boost/interprocess/allocators/allocator.hpp>
-#include <bpf/bpf.h>
 #include <cstdint>
 
 namespace bpftime

--- a/runtime/src/bpf_map/userspace/prog_array.cpp
+++ b/runtime/src/bpf_map/userspace/prog_array.cpp
@@ -5,9 +5,7 @@
  */
 
 #if __linux__
-#include "bpf/bpf.h"
 #include "linux/bpf.h"
-#include <bpf/libbpf.h>
 #include <gnu/lib-names.h>
 #include <asm/unistd.h>
 #elif __APPLE__

--- a/runtime/src/bpf_map/userspace/queue.cpp
+++ b/runtime/src/bpf_map/userspace/queue.cpp
@@ -1,4 +1,5 @@
 #include <bpf_map/userspace/queue.hpp>
+#include "linux/bpf.h"
 #include <spdlog/spdlog.h>
 #include <cerrno>
 #include <cstring>

--- a/runtime/src/bpf_map/userspace/queue.hpp
+++ b/runtime/src/bpf_map/userspace/queue.hpp
@@ -20,8 +20,6 @@
 #include <boost/interprocess/managed_shared_memory.hpp>
 #include <boost/interprocess/containers/vector.hpp>
 #include <boost/interprocess/allocators/allocator.hpp>
-// Include bpf.h for BPF flags like BPF_ANY, BPF_EXIST, etc.
-#include <bpf/bpf.h>
 
 // Forward declaration
 namespace bpftime

--- a/runtime/src/bpf_map/userspace/stack.cpp
+++ b/runtime/src/bpf_map/userspace/stack.cpp
@@ -1,4 +1,5 @@
 #include <bpf_map/userspace/stack.hpp>
+#include "linux/bpf.h"
 #include <spdlog/spdlog.h>
 #include <cerrno>
 #include <cstring>

--- a/runtime/src/bpf_map/userspace/stack.hpp
+++ b/runtime/src/bpf_map/userspace/stack.hpp
@@ -25,8 +25,6 @@
 #include <boost/interprocess/sync/interprocess_mutex.hpp>
 #include <boost/interprocess/containers/vector.hpp>
 #include <boost/interprocess/allocators/allocator.hpp>
-// Include bpf.h for BPF flags like BPF_ANY, BPF_EXIST, etc.
-#include <bpf/bpf.h>
 
 // Forward declaration
 namespace bpftime

--- a/runtime/syscall-server/CMakeLists.txt
+++ b/runtime/syscall-server/CMakeLists.txt
@@ -33,21 +33,17 @@ target_link_libraries(bpftime-syscall-server PUBLIC
 
 add_dependencies(bpftime-syscall-server spdlog::spdlog)
 
-if(${BPFTIME_BUILD_WITH_LIBBPF})
-
 target_include_directories(bpftime-syscall-server
     PUBLIC
     "../include"
     "../../vm"
-    "../../third_party/libbpf/include"
     "../../third_party/libbpf/include/uapi"
     ${SPDLOG_INCLUDE}
 )
-else()
-target_include_directories(bpftime-syscall-server
-    PUBLIC
-    "../../vm"
-    ${SPDLOG_INCLUDE}
+
+if(${BPFTIME_BUILD_WITH_LIBBPF})
+target_include_directories(bpftime-syscall-server PUBLIC
+    "../../third_party/libbpf/include"
 )
 endif()
 

--- a/runtime/syscall-server/CMakeLists.txt
+++ b/runtime/syscall-server/CMakeLists.txt
@@ -20,8 +20,8 @@ endif()
 
 if(${BPFTIME_LLVM_JIT})
   add_dependencies(bpftime-syscall-server bpftime_llvm_vm llvmbpf_vm)
-  target_link_options(bpftime-syscall-server PUBLIC "-Wl,--whole-archive" "$<TARGET_FILE:bpftime_llvm_vm>" "-Wl,--no-whole-archive")
   target_link_libraries(bpftime-syscall-server PUBLIC bpftime_llvm_vm)
+  target_sources(bpftime-syscall-server PRIVATE $<TARGET_OBJECTS:bpftime_llvm_vm_obj>)
 endif()
 
 target_link_libraries(bpftime-syscall-server PUBLIC

--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -72,7 +72,7 @@ namespace {
 [[noreturn]] void
 exit_for_startup_allocation_failure(const std::exception &error)
 {
-	auto config = bpftime::construct_agent_config_from_env();
+	auto config = bpftime::construct_runtime_config_from_env();
 	SPDLOG_CRITICAL(
 		"Unable to initialize bpftime shared memory ({} MiB, {} fd slots): {}",
 		config.shm_memory_size, config.max_fd_count, error.what());

--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -24,6 +24,7 @@
 #if __linux__
 #include "linux/perf_event.h"
 #include <linux/bpf.h>
+#include <asm/unistd.h>
 #include <sys/epoll.h>
 #ifdef BPFTIME_BUILD_WITH_LIBBPF
 #include <bpf/bpf.h>
@@ -300,7 +301,7 @@ int syscall_context::create_kernel_bpf_map(int map_fd, int bpftime_map_type)
 	bpf_map_info info = {};
 	uint32_t info_len = sizeof(info);
 	int res = get_bpf_obj_info_by_fd(map_fd, &info, &info_len,
-				 orig_syscall_fn);
+					 orig_syscall_fn);
 	if (res < 0) {
 		SPDLOG_ERROR("Failed to get map info for fd {}", map_fd);
 		return -1;
@@ -381,9 +382,10 @@ int syscall_context::create_kernel_bpf_prog_in_userspace(int cmd,
 			if (inst.src_reg == 1 || inst.src_reg == 2) {
 				bpf_map_info info = {};
 				uint32_t info_len = sizeof(info);
-				int res = get_bpf_obj_info_by_fd(
-					inst.imm, &info, &info_len,
-					orig_syscall_fn);
+				int res =
+					get_bpf_obj_info_by_fd(inst.imm, &info,
+							       &info_len,
+							       orig_syscall_fn);
 				if (res < 0) {
 					SPDLOG_ERROR(
 						"Failed to get map info for id {}",

--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -25,7 +25,9 @@
 #include "linux/perf_event.h"
 #include <linux/bpf.h>
 #include <sys/epoll.h>
+#ifdef BPFTIME_BUILD_WITH_LIBBPF
 #include <bpf/bpf.h>
+#endif
 #include <linux/perf_event.h>
 #include <linux/filter.h>
 #elif __APPLE__
@@ -72,13 +74,34 @@ namespace {
 [[noreturn]] void
 exit_for_startup_allocation_failure(const std::exception &error)
 {
-	auto config = bpftime::construct_agent_config_from_env();
+	auto config = bpftime::construct_runtime_config_from_env();
 	SPDLOG_CRITICAL(
 		"Unable to initialize bpftime shared memory ({} MiB, {} fd slots): {}",
 		config.shm_memory_size, config.max_fd_count, error.what());
 	SPDLOG_CRITICAL(
 		"Increase BPFTIME_SHM_MEMORY_MB or decrease BPFTIME_MAX_FD_COUNT");
 	std::exit(EXIT_FAILURE);
+}
+
+int get_bpf_obj_info_by_fd(int fd, void *info, uint32_t *info_len,
+			   long (*syscall_fn)(long, ...))
+{
+#ifdef BPFTIME_BUILD_WITH_LIBBPF
+	return bpf_obj_get_info_by_fd(fd, info, info_len);
+#elif defined(__linux__)
+	union bpf_attr attr = {};
+	attr.info.bpf_fd = fd;
+	attr.info.info_len = *info_len;
+	attr.info.info = reinterpret_cast<uintptr_t>(info);
+	int result = syscall_fn(__NR_bpf, BPF_OBJ_GET_INFO_BY_FD, &attr,
+				sizeof(attr.info));
+	if (result == 0)
+		*info_len = attr.info.info_len;
+	return result;
+#else
+	errno = ENOTSUP;
+	return -1;
+#endif
 }
 
 std::string format_verifier_program_dump(const uint64_t *instructions,
@@ -276,7 +299,8 @@ int syscall_context::create_kernel_bpf_map(int map_fd, int bpftime_map_type)
 {
 	bpf_map_info info = {};
 	uint32_t info_len = sizeof(info);
-	int res = bpf_obj_get_info_by_fd(map_fd, &info, &info_len);
+	int res = get_bpf_obj_info_by_fd(map_fd, &info, &info_len,
+				 orig_syscall_fn);
 	if (res < 0) {
 		SPDLOG_ERROR("Failed to get map info for fd {}", map_fd);
 		return -1;
@@ -357,8 +381,9 @@ int syscall_context::create_kernel_bpf_prog_in_userspace(int cmd,
 			if (inst.src_reg == 1 || inst.src_reg == 2) {
 				bpf_map_info info = {};
 				uint32_t info_len = sizeof(info);
-				int res = bpf_obj_get_info_by_fd(
-					inst.imm, &info, &info_len);
+				int res = get_bpf_obj_info_by_fd(
+					inst.imm, &info, &info_len,
+					orig_syscall_fn);
 				if (res < 0) {
 					SPDLOG_ERROR(
 						"Failed to get map info for id {}",

--- a/runtime/unit-test/maps/test_bloom_filter_map.cpp
+++ b/runtime/unit-test/maps/test_bloom_filter_map.cpp
@@ -3,6 +3,7 @@
 
 #include "bpf_map/userspace/bloom_filter.hpp"
 #include "../common_def.hpp"
+#include <linux/bpf.h>
 #include <boost/interprocess/managed_shared_memory.hpp>
 #include <vector>
 #include <cstring>

--- a/runtime/unit-test/maps/test_queue_map.cpp
+++ b/runtime/unit-test/maps/test_queue_map.cpp
@@ -5,6 +5,7 @@
 
 #include "bpf_map/userspace/queue.hpp" // Adjust path as needed
 #include "../common_def.hpp"
+#include <linux/bpf.h>
 #include <boost/interprocess/managed_shared_memory.hpp>
 #include <boost/interprocess/containers/string.hpp>
 #include <vector>

--- a/runtime/unit-test/maps/test_stack_map.cpp
+++ b/runtime/unit-test/maps/test_stack_map.cpp
@@ -3,6 +3,7 @@
 
 #include "bpf_map/userspace/stack.hpp" // Adjust path as needed
 #include "../common_def.hpp"
+#include <linux/bpf.h>
 #include <boost/interprocess/managed_shared_memory.hpp>
 #include <boost/interprocess/containers/string.hpp>
 #include <vector>

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_subdirectory(bpftimetool)
 add_subdirectory(cli)
-if(BPFTIME_LLVM_JIT)
+if(BPFTIME_LLVM_JIT AND BPFTIME_BUILD_WITH_LIBBPF)
   message(STATUS "Using llvm-jit")
   add_subdirectory(aot)
 endif()

--- a/vm/compat/llvm-vm/CMakeLists.txt
+++ b/vm/compat/llvm-vm/CMakeLists.txt
@@ -7,5 +7,8 @@ target_link_libraries(bpftime_llvm_vm PUBLIC bpftime_vm_compat spdlog::spdlog ll
 
 target_include_directories(bpftime_llvm_vm_obj PRIVATE ../../llvm-jit/include ${CMAKE_CURRENT_SOURCE_DIR} ${SPDLOG_INCLUDE} ../include)
 
-add_subdirectory(../../llvm-jit ${CMAKE_CURRENT_BINARY_DIR}/llvm-jit)
-
+if(BPFTIME_BUILD_WITH_LIBBPF)
+  add_subdirectory(../../llvm-jit ${CMAKE_CURRENT_BINARY_DIR}/llvm-jit)
+else()
+  add_subdirectory(../../llvm-jit ${CMAKE_CURRENT_BINARY_DIR}/llvm-jit EXCLUDE_FROM_ALL)
+endif()


### PR DESCRIPTION
Fixes #603.

This is a clean minimized replacement for #604. It is temporarily stacked on the one-line compile prerequisite #626; after #626 merges, this PR will be retargeted to `master`.

## What changed

- remove libbpf headers from userspace-map public headers and keep Linux UAPI includes local
- use the original BPF syscall for object-info queries when libbpf is disabled
- skip libbpf-dependent AOT and LLVM CLI targets in no-libbpf builds
- retain both LLVM and uBPF VM factories in the agent and syscall server
- add one no-libbpf CI smoke that builds and installs the dual-VM configuration and checks both artifacts
- keep libbpf-enabled behavior unchanged

## Scope

The reported no-libbpf build no longer enters the libbpf-dependent AOT target, so its missing `libbpf` dependency and hard-coded LLVM-20 path cannot break this configuration. This minimal PR intentionally does not change the separate libbpf-enabled AOT link configuration.

## Minimal-diff audit

- exact stacked diff: 16 files, +62/-23
- compared with #604, this removes the broad matrix, documentation expansion, CUDA #614 changes, formatting churn, and extra syscall-header declaration
- public-header edits are one-line dependency-ownership fixes
- CI adds one focused build/install step; no new workflow or matrix
- the final link fix directly embeds the existing single LLVM factory object and removes a leaking whole-archive option
- no removable block was found by the exact-head subagent or independent review

## Validation

Exact HEAD: 759cb55b8ea9211fb7b5f1b39f0a13ba590b61c8

- standard GCC 13 no-libbpf Release dual-VM agent and syscall-server builds passed
- reporter's stripped MinSizeRel, LLVM-only, LTO, no-libbpf agent and syscall-server builds passed
- agent and syscall server both retain the expected LLVM/uBPF factories and have no `libbpf` dynamic dependency
- four CI symbol assertions return 0 under `set -o pipefail`
- libbpf-enabled touched translation units compile
- queue, stack, and bloom-filter tests passed 32,710 assertions in 18 cases
- workflow YAML, changed-range clang-format, and `git diff --check` passed
- exact-head subagent review: PASS
- exact-head independent read-only review: PASS
- Copilot exact-head review requested; no unresolved thread is currently present

## Draft status

This PR remains Draft while #626 is open. After #626 merges, it must be retargeted/rebased onto current `master`; the changed exact SHA will receive fresh local validation, subagent review, independent review, Copilot audit, and terminal-green CI before Ready.
