### PR TITLE
fix(runtime): use renamed startup config helper

### DIFF
--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -72,7 +72,7 @@ namespace {
 [[noreturn]] void
 exit_for_startup_allocation_failure(const std::exception &error)
 {
-	auto config = bpftime::construct_agent_config_from_env();
+	auto config = bpftime::construct_runtime_config_from_env();
 	SPDLOG_CRITICAL(
 		"Unable to initialize bpftime shared memory ({} MiB, {} fd slots): {}",
 		config.shm_memory_size, config.max_fd_count, error.what());


### PR DESCRIPTION
## Why

`construct_agent_config_from_env()` was renamed to `construct_runtime_config_from_env()`, but the syscall server startup-allocation error path still calls the removed name. This breaks compilation for any configuration that builds `bpftime-syscall-server`.

## Change

Update that single stale call. No behavior or configuration change.

## Validation

- Debug configure with libbpf enabled and LLVM disabled: pass
- `cmake --build build-compile --target bpftime-syscall-server -j2`: pass
- `git diff --check`: pass

This one-line prerequisite was split from #625 to keep one root cause per PR. Exact-head subagent and independent reviews pass, all current-head CI is terminal green, and GitHub Copilot reviews, inline comments, and review threads were checked with no findings present. The PR is Ready and awaiting maintainer approval and merge.
