### PR TITLE
feat(cuda): scope patched modules to active contexts

### DIFF
--- a/.github/workflows/test-gpu-examples.yml
+++ b/.github/workflows/test-gpu-examples.yml
@@ -231,6 +231,7 @@ jobs:
           - path: atomizer
             executable: ./atomizer
             victim: ./vec_add
+            client_env: BPFTIME_EXPECT_PATCHED=1
             expected_str: "Exited _Z9vectorAdd"
             name: atomizer
             server_timeout: 15
@@ -783,7 +784,7 @@ jobs:
             pushd "$EXAMPLE_DIR" >/dev/null
             set +e
             # Don't preload into the shell itself; only preload into the target binary.
-            timeout -s SIGKILL ${CLIENT_TIMEOUT}s env BPFTIME_LOG_OUTPUT=console bash -lc "LD_PRELOAD=\"$AGENT_SO\" exec $VICTIM_REL" > "$ROOT_DIR/client.log" 2>&1
+            timeout -s SIGKILL ${CLIENT_TIMEOUT}s env ${{ matrix.examples.client_env || '' }} BPFTIME_LOG_OUTPUT=console bash -lc "LD_PRELOAD=\"$AGENT_SO\" exec $VICTIM_REL" > "$ROOT_DIR/client.log" 2>&1
             CLIENT_RC=$?
             set -e
             popd >/dev/null

--- a/.github/workflows/test-gpu-examples.yml
+++ b/.github/workflows/test-gpu-examples.yml
@@ -796,6 +796,11 @@ jobs:
             EXAMPLE_NAME="${{ matrix.examples.name }}"
             FOUND=1
             case "$EXAMPLE_NAME" in
+              atomizer)
+                if grep -Fq "$EXPECTED" server.log client.log && grep -Fq "Validated all visible GPUs" client.log; then
+                  FOUND=0
+                fi
+                ;;
               directly_run_on_gpu)
                 # For GEMM, expect a non-zero fixed-point value after bpftimetool ran.
                 if grep -Eq "GEMM C\\[0\\]=[1-9]" server.log; then

--- a/attach/nv_attach_impl/nv_attach_fatbin_record.cpp
+++ b/attach/nv_attach_impl/nv_attach_fatbin_record.cpp
@@ -61,6 +61,8 @@ ptx_in_module::~ptx_in_module()
 			SPDLOG_ERROR(
 				"Unable to switch context before unloading module");
 	}
+	if (switch_context && !pushed)
+		return;
 	CUDA_DRIVER_CHECK_NO_EXCEPTION(cuModuleUnload(this->module_ptr),
 				       "Unable to unload module");
 	if (pushed) {
@@ -112,20 +114,27 @@ fatbin_record::find_variable_info(nv_attach_impl &impl,
 	if (cuCtxGetCurrent(&context) != CUDA_SUCCESS || context == nullptr)
 		return std::nullopt;
 	std::lock_guard<std::mutex> guard(load_mutex);
+	std::optional<variable_info> result;
 	for (const auto &ptx : ptxs_by_context.at(context)) {
 		CUdeviceptr ptr = 0;
 		size_t size = 0;
 		auto err = cuModuleGetGlobal(&ptr, &size, ptx->module_ptr,
 					     name.c_str());
-		if (err == CUDA_SUCCESS)
-			return variable_info{ name, ptr, size, ptx.get() };
+		if (err == CUDA_SUCCESS) {
+			if (result) {
+				SPDLOG_WARN("Ambiguous patched global {}", name);
+				return std::nullopt;
+			}
+			result = variable_info{ name, ptr, size, ptx.get() };
+			continue;
+		}
 		if (err != CUDA_ERROR_NOT_FOUND) {
 			SPDLOG_ERROR("Unable to lookup symbol {}: {}", name,
 				     (int)err);
 			return std::nullopt;
 		}
 	}
-	return std::nullopt;
+	return result;
 }
 
 std::optional<kernel_info>
@@ -152,19 +161,26 @@ fatbin_record::find_function_info(nv_attach_impl &impl,
 	if (cuCtxGetCurrent(&context) != CUDA_SUCCESS || context == nullptr)
 		return std::nullopt;
 	std::lock_guard<std::mutex> guard(load_mutex);
+	std::optional<kernel_info> result;
 	for (const auto &ptx : ptxs_by_context.at(context)) {
 		CUfunction function = nullptr;
 		auto err = cuModuleGetFunction(&function, ptx->module_ptr,
 					       name.c_str());
-		if (err == CUDA_SUCCESS)
-			return kernel_info{ name, function, ptx.get() };
+		if (err == CUDA_SUCCESS) {
+			if (result) {
+				SPDLOG_WARN("Ambiguous patched kernel {}", name);
+				return std::nullopt;
+			}
+			result = kernel_info{ name, function, ptx.get() };
+			continue;
+		}
 		if (err != CUDA_ERROR_NOT_FOUND) {
 			SPDLOG_ERROR("Unable to lookup function {}: {}", name,
 				     (int)err);
 			return std::nullopt;
 		}
 	}
-	return std::nullopt;
+	return result;
 }
 
 std::map<std::string, std::vector<uint8_t>> fatbin_record::compile_ptxs(
@@ -283,8 +299,8 @@ void fatbin_record::try_loading_ptxs(class nv_attach_impl &impl)
 	for (const auto &[name, ptx_and_trampoline_flag] : patched_ptx) {
 		bool added_trampoline = std::get<1>(ptx_and_trampoline_flag);
 		const auto &compiled_elf = compiled_ptx.at(name);
-		module_key key{ context, sha256(compiled_elf.data(),
-					       compiled_elf.size()) };
+		module_key key{ context, this, sha256(compiled_elf.data(),
+						     compiled_elf.size()) };
 		std::shared_ptr<ptx_in_module> cached;
 		{
 			std::lock_guard<std::mutex> guard(impl.module_cache_mutex);

--- a/attach/nv_attach_impl/nv_attach_fatbin_record.cpp
+++ b/attach/nv_attach_impl/nv_attach_fatbin_record.cpp
@@ -12,6 +12,7 @@
 #include <cstdio>
 #include <dlfcn.h>
 #include <iterator>
+#include <set>
 #include <stdexcept>
 #include <ptx_pass_config.h>
 #include "ptx_compiler/ptx_compiler.hpp"
@@ -264,21 +265,15 @@ void fatbin_record::try_loading_ptxs(class nv_attach_impl &impl)
 	auto compiled_ptx = compile_ptxs(impl, patched_ptx);
 
 	std::vector<std::shared_ptr<ptx_in_module>> context_ptxs;
-	std::map<std::string, std::shared_ptr<ptx_in_module>> loaded_modules;
+	std::set<std::string> loaded_modules;
 	for (const auto &[name, ptx_and_trampoline_flag] : patched_ptx) {
 		bool added_trampoline = std::get<1>(ptx_and_trampoline_flag);
 		const auto &compiled_elf = compiled_ptx.at(name);
 		const auto key =
 			sha256(compiled_elf.data(), compiled_elf.size());
-		std::shared_ptr<ptx_in_module> cached;
-		if (auto itr = loaded_modules.find(key);
-		    itr != loaded_modules.end())
-			cached = itr->second;
-		if (cached) {
+		if (loaded_modules.contains(key)) {
 			SPDLOG_INFO("Module {} found in cache", name);
-			if (std::find(context_ptxs.begin(), context_ptxs.end(),
-				      cached) == context_ptxs.end())
-				context_ptxs.push_back(std::move(cached));
+			continue;
 		} else {
 			CUmodule module;
 			SPDLOG_INFO("Loading module: {}, not found in cache",
@@ -340,7 +335,7 @@ void fatbin_record::try_loading_ptxs(class nv_attach_impl &impl)
 					"Unable to copy constData pointer to device");
 				SPDLOG_INFO("Trampoline data copied");
 			}
-			loaded_modules.emplace(key, ptr);
+			loaded_modules.emplace(key);
 			context_ptxs.push_back(std::move(ptr));
 			SPDLOG_INFO("Loaded module: {}", name);
 		}

--- a/attach/nv_attach_impl/nv_attach_fatbin_record.cpp
+++ b/attach/nv_attach_impl/nv_attach_fatbin_record.cpp
@@ -114,27 +114,20 @@ fatbin_record::find_variable_info(nv_attach_impl &impl,
 	if (cuCtxGetCurrent(&context) != CUDA_SUCCESS || context == nullptr)
 		return std::nullopt;
 	std::lock_guard<std::mutex> guard(load_mutex);
-	std::optional<variable_info> result;
 	for (const auto &ptx : ptxs_by_context.at(context)) {
 		CUdeviceptr ptr = 0;
 		size_t size = 0;
 		auto err = cuModuleGetGlobal(&ptr, &size, ptx->module_ptr,
 					     name.c_str());
-		if (err == CUDA_SUCCESS) {
-			if (result) {
-				SPDLOG_WARN("Ambiguous patched global {}", name);
-				return std::nullopt;
-			}
-			result = variable_info{ name, ptr, size, ptx.get() };
-			continue;
-		}
+		if (err == CUDA_SUCCESS)
+			return variable_info{ name, ptr, size, ptx.get() };
 		if (err != CUDA_ERROR_NOT_FOUND) {
 			SPDLOG_ERROR("Unable to lookup symbol {}: {}", name,
 				     (int)err);
 			return std::nullopt;
 		}
 	}
-	return result;
+	return std::nullopt;
 }
 
 std::optional<kernel_info>
@@ -161,26 +154,19 @@ fatbin_record::find_function_info(nv_attach_impl &impl,
 	if (cuCtxGetCurrent(&context) != CUDA_SUCCESS || context == nullptr)
 		return std::nullopt;
 	std::lock_guard<std::mutex> guard(load_mutex);
-	std::optional<kernel_info> result;
 	for (const auto &ptx : ptxs_by_context.at(context)) {
 		CUfunction function = nullptr;
 		auto err = cuModuleGetFunction(&function, ptx->module_ptr,
 					       name.c_str());
-		if (err == CUDA_SUCCESS) {
-			if (result) {
-				SPDLOG_WARN("Ambiguous patched kernel {}", name);
-				return std::nullopt;
-			}
-			result = kernel_info{ name, function, ptx.get() };
-			continue;
-		}
+		if (err == CUDA_SUCCESS)
+			return kernel_info{ name, function, ptx.get() };
 		if (err != CUDA_ERROR_NOT_FOUND) {
 			SPDLOG_ERROR("Unable to lookup function {}: {}", name,
 				     (int)err);
 			return std::nullopt;
 		}
 	}
-	return result;
+	return std::nullopt;
 }
 
 std::map<std::string, std::vector<uint8_t>> fatbin_record::compile_ptxs(
@@ -310,7 +296,9 @@ void fatbin_record::try_loading_ptxs(class nv_attach_impl &impl)
 		}
 		if (cached) {
 			SPDLOG_INFO("Module {} found in cache", name);
-			context_ptxs.push_back(std::move(cached));
+			if (std::find(context_ptxs.begin(), context_ptxs.end(),
+				      cached) == context_ptxs.end())
+				context_ptxs.push_back(std::move(cached));
 		} else {
 			CUmodule module;
 			SPDLOG_INFO("Loading module: {}, not found in cache",

--- a/attach/nv_attach_impl/nv_attach_fatbin_record.cpp
+++ b/attach/nv_attach_impl/nv_attach_fatbin_record.cpp
@@ -15,6 +15,8 @@
 #include <stdexcept>
 #include <ptx_pass_config.h>
 #include "ptx_compiler/ptx_compiler.hpp"
+#include <algorithm>
+#include <exception>
 #include <utility>
 #define CUDA_DRIVER_CHECK_NO_EXCEPTION(expr, message)                          \
 	do {                                                                   \
@@ -47,57 +49,122 @@ fatbin_record::~fatbin_record()
 }
 ptx_in_module::~ptx_in_module()
 {
+	CUcontext current = nullptr;
+	const bool switch_context =
+		context != nullptr &&
+		(cuCtxGetCurrent(&current) != CUDA_SUCCESS || current != context);
+	bool pushed = false;
+	if (switch_context) {
+		if (cuCtxPushCurrent(context) == CUDA_SUCCESS)
+			pushed = true;
+		else
+			SPDLOG_ERROR(
+				"Unable to switch context before unloading module");
+	}
 	CUDA_DRIVER_CHECK_NO_EXCEPTION(cuModuleUnload(this->module_ptr),
 				       "Unable to unload module");
+	if (pushed) {
+		CUcontext popped = nullptr;
+		CUDA_DRIVER_CHECK_NO_EXCEPTION(
+			cuCtxPopCurrent(&popped),
+			"Unable to restore CUDA context after unloading module");
+	}
 }
 
 bool fatbin_record::find_and_fill_variable_info(void *ptr,
 						const char *symbol_name)
 {
-	for (const auto &ptx : ptxs) {
-		CUdeviceptr dptr;
-		size_t size;
-		auto err = cuModuleGetGlobal(&dptr, &size, ptx->module_ptr,
-					     symbol_name);
-		if (err == CUDA_SUCCESS) {
-			variable_addr_to_symbol[ptr] =
-				variable_info{ .symbol_name =
-						       std::string(symbol_name),
-					       .ptr = dptr,
-					       .size = size,
-					       .ptx = ptx.get() };
-			return true;
-		} else if (err == CUDA_ERROR_NOT_FOUND) {
-			continue;
-		} else {
-			SPDLOG_ERROR("Unable to lookup symbol: {}", (int)err);
-			return false;
-		}
-	}
-	return false;
+	if (ptr == nullptr || symbol_name == nullptr)
+		return false;
+	variable_addr_to_symbol[ptr] = symbol_name;
+	return true;
 }
 bool fatbin_record::find_and_fill_function_info(void *ptr,
 						const char *symbol_name)
 {
-	for (const auto &ptx : ptxs) {
-		CUfunction func;
-		auto err = cuModuleGetFunction(&func, ptx->module_ptr,
-					       symbol_name);
-		if (err == CUDA_SUCCESS) {
-			function_addr_to_symbol[ptr] =
-				kernel_info{ .symbol_name =
-						     std::string(symbol_name),
-					     .func = func,
-					     .ptx = ptx.get() };
-			return true;
-		} else if (err == CUDA_ERROR_NOT_FOUND) {
-			continue;
-		} else {
-			SPDLOG_ERROR("Unable to lookup function: {}", (int)err);
-			return false;
+	if (ptr == nullptr || symbol_name == nullptr)
+		return false;
+	function_addr_to_symbol[ptr] = symbol_name;
+	return true;
+}
+
+std::optional<variable_info>
+fatbin_record::find_variable_info(nv_attach_impl &impl, void *ptr)
+{
+	auto itr = variable_addr_to_symbol.find(ptr);
+	if (itr == variable_addr_to_symbol.end())
+		return std::nullopt;
+	return find_variable_info(impl, itr->second);
+}
+
+std::optional<variable_info>
+fatbin_record::find_variable_info(nv_attach_impl &impl,
+				  const std::string &name)
+{
+	try {
+		try_loading_ptxs(impl);
+	} catch (const std::exception &ex) {
+		SPDLOG_ERROR("Unable to load PTX while resolving {}: {}", name,
+			     ex.what());
+		return std::nullopt;
+	}
+	CUcontext context = nullptr;
+	if (cuCtxGetCurrent(&context) != CUDA_SUCCESS || context == nullptr)
+		return std::nullopt;
+	std::lock_guard<std::mutex> guard(load_mutex);
+	for (const auto &ptx : ptxs_by_context.at(context)) {
+		CUdeviceptr ptr = 0;
+		size_t size = 0;
+		auto err = cuModuleGetGlobal(&ptr, &size, ptx->module_ptr,
+					     name.c_str());
+		if (err == CUDA_SUCCESS)
+			return variable_info{ name, ptr, size, ptx.get() };
+		if (err != CUDA_ERROR_NOT_FOUND) {
+			SPDLOG_ERROR("Unable to lookup symbol {}: {}", name,
+				     (int)err);
+			return std::nullopt;
 		}
 	}
-	return false;
+	return std::nullopt;
+}
+
+std::optional<kernel_info>
+fatbin_record::find_function_info(nv_attach_impl &impl, void *ptr)
+{
+	auto itr = function_addr_to_symbol.find(ptr);
+	if (itr == function_addr_to_symbol.end())
+		return std::nullopt;
+	return find_function_info(impl, itr->second);
+}
+
+std::optional<kernel_info>
+fatbin_record::find_function_info(nv_attach_impl &impl,
+				  const std::string &name)
+{
+	try {
+		try_loading_ptxs(impl);
+	} catch (const std::exception &ex) {
+		SPDLOG_ERROR("Unable to load PTX while resolving {}: {}", name,
+			     ex.what());
+		return std::nullopt;
+	}
+	CUcontext context = nullptr;
+	if (cuCtxGetCurrent(&context) != CUDA_SUCCESS || context == nullptr)
+		return std::nullopt;
+	std::lock_guard<std::mutex> guard(load_mutex);
+	for (const auto &ptx : ptxs_by_context.at(context)) {
+		CUfunction function = nullptr;
+		auto err = cuModuleGetFunction(&function, ptx->module_ptr,
+					       name.c_str());
+		if (err == CUDA_SUCCESS)
+			return kernel_info{ name, function, ptx.get() };
+		if (err != CUDA_ERROR_NOT_FOUND) {
+			SPDLOG_ERROR("Unable to lookup function {}: {}", name,
+				     (int)err);
+			return std::nullopt;
+		}
+	}
+	return std::nullopt;
 }
 
 std::map<std::string, std::vector<uint8_t>> fatbin_record::compile_ptxs(
@@ -114,82 +181,90 @@ std::map<std::string, std::vector<uint8_t>> fatbin_record::compile_ptxs(
 
 	std::map<std::string, std::vector<uint8_t>> compiled_ptx;
 	const auto &handler = impl.ptx_compiler;
-	boost::asio::thread_pool pool(std::thread::hardware_concurrency());
+	boost::asio::thread_pool pool(
+		std::max(1u, std::thread::hardware_concurrency()));
 	std::mutex map_lock;
+	std::exception_ptr error;
 	for (const auto &[name, ptx_and_trampoline_flag] : patched_ptx) {
 		const auto &ptx = std::get<0>(ptx_and_trampoline_flag);
 
-			boost::asio::post(
-				pool,
-				[&handler, ptx, name, &compiled_ptx, &map_lock, this,
-				 sm_arch]() -> void {
-					const auto ptx_fixed =
-						rewrite_ptx_target(ptx, sm_arch);
-					auto sha256_string =
-						sha256(ptx_fixed.data(), ptx_fixed.size());
-					if (auto itr =
-						    this->ptx_pool->find(sha256_string);
-					    itr != this->ptx_pool->end()) {
-						SPDLOG_INFO(
-						"PTX {} ({}) found in cache",
-						name, sha256_string);
-					std::lock_guard<std::mutex> _guard(
-						map_lock);
-					compiled_ptx[name] = itr->second;
-				} else {
+		boost::asio::post(pool, [&, ptx, name, sm_arch]() {
+			try {
+				const auto ptx_fixed =
+					rewrite_ptx_target(ptx, sm_arch);
+				const auto sha256_string = sha256(
+					ptx_fixed.data(), ptx_fixed.size());
+				std::vector<uint8_t> compiled_program;
+				{
+					std::lock_guard<std::mutex> guard(
+						impl.ptx_cache_mutex);
+					if (auto itr = ptx_pool->find(sha256_string);
+					    itr != ptx_pool->end())
+						compiled_program = itr->second;
+				}
+				if (compiled_program.empty()) {
 					SPDLOG_INFO(
 						"Start compiling {}, not found in cache",
 						name);
-					auto compiler = handler.create();
-					if (!compiler) {
+					std::unique_ptr<nv_attach_impl_ptx_compiler,
+							decltype(handler.destroy)>
+						compiler(handler.create(),
+							 handler.destroy);
+					if (!compiler)
 						throw std::runtime_error(
 							"Unable to create nv_attach_impl_ptx_compiler");
-					}
-						std::string gpu_name =
-							"--gpu-name=" + sm_arch;
-							const char *compile_options[] = {
-								gpu_name.c_str(), "--verbose",
-								"-O3"
-							};
-						if (auto err = handler.compile(
-							    compiler, ptx_fixed.c_str(),
-							    compile_options,
-							    std::size(compile_options));
-						    err != 0) {
-							SPDLOG_ERROR(
-								"Unable to compile: {}, error = {}",
-							err,
-							handler.get_error_log(
-								compiler));
+					std::string gpu_name = "--gpu-name=" + sm_arch;
+					const char *compile_options[] = {
+						gpu_name.c_str(), "--verbose", "-O3"
+					};
+					if (auto err = handler.compile(
+						    compiler.get(), ptx_fixed.c_str(),
+						    compile_options,
+						    std::size(compile_options));
+					    err != 0) {
+						SPDLOG_ERROR(
+							"Unable to compile: {}, error = {}",
+							err, handler.get_error_log(
+								     compiler.get()));
 						throw std::runtime_error(
 							"Unable to compile");
 					}
-					SPDLOG_DEBUG(
-						"Info: {}",
-						handler.get_info_log(compiler));
 					uint8_t *data;
 					size_t size;
 					handler.get_compiled_program(
-						compiler, &data, &size);
-					std::vector<uint8_t> compiled_program(
-						data, data + size);
-					handler.destroy(compiler);
-					std::lock_guard<std::mutex> _guard(
-						map_lock);
-					compiled_ptx[name] = compiled_program;
-					this->ptx_pool->insert(std::make_pair(
-						sha256_string,
-						compiled_program));
-					SPDLOG_INFO("Compile of {} done", name);
+						compiler.get(), &data, &size);
+					compiled_program.assign(data, data + size);
+					std::lock_guard<std::mutex> guard(
+						impl.ptx_cache_mutex);
+					const auto [itr, inserted] = ptx_pool->emplace(
+						sha256_string, compiled_program);
+					if (!inserted)
+						compiled_program = itr->second;
+				} else {
+					SPDLOG_INFO("PTX {} ({}) found in cache", name,
+						    sha256_string);
 				}
-			});
+				std::lock_guard<std::mutex> guard(map_lock);
+				compiled_ptx[name] = std::move(compiled_program);
+			} catch (...) {
+				std::lock_guard<std::mutex> guard(map_lock);
+				if (!error)
+					error = std::current_exception();
+			}
+		});
 	}
 	pool.join();
+	if (error)
+		std::rethrow_exception(error);
 	return compiled_ptx;
 }
 void fatbin_record::try_loading_ptxs(class nv_attach_impl &impl)
 {
-	if (ptx_loaded)
+	CUcontext context = nullptr;
+	if (cuCtxGetCurrent(&context) != CUDA_SUCCESS || context == nullptr)
+		throw std::runtime_error("No current CUDA context");
+	std::lock_guard<std::mutex> load_guard(load_mutex);
+	if (ptxs_by_context.contains(context))
 		return;
 	if (impl.shared_mem_ptr == 0) {
 		throw std::runtime_error(
@@ -197,20 +272,29 @@ void fatbin_record::try_loading_ptxs(class nv_attach_impl &impl)
 	}
 	SPDLOG_INFO("Loading & patching current fatbin..");
 
-	auto patched_ptx = *impl.hack_fatbin(original_ptx);
+	auto patched_ptx_result = impl.hack_fatbin(original_ptx);
+	if (!patched_ptx_result)
+		throw std::runtime_error("Unable to patch fatbin PTX");
+	auto &patched_ptx = *patched_ptx_result;
 
 	auto compiled_ptx = compile_ptxs(impl, patched_ptx);
 
+	std::vector<std::shared_ptr<ptx_in_module>> context_ptxs;
 	for (const auto &[name, ptx_and_trampoline_flag] : patched_ptx) {
-		const auto &ptx = std::get<0>(ptx_and_trampoline_flag);
 		bool added_trampoline = std::get<1>(ptx_and_trampoline_flag);
 		const auto &compiled_elf = compiled_ptx.at(name);
-		auto sha256_string =
-			sha256(compiled_elf.data(), compiled_elf.size());
-		if (auto itr = module_pool->find(sha256_string);
-		    itr != module_pool->end()) {
+		module_key key{ context, sha256(compiled_elf.data(),
+					       compiled_elf.size()) };
+		std::shared_ptr<ptx_in_module> cached;
+		{
+			std::lock_guard<std::mutex> guard(impl.module_cache_mutex);
+			if (auto itr = module_pool->find(key);
+			    itr != module_pool->end())
+				cached = itr->second;
+		}
+		if (cached) {
 			SPDLOG_INFO("Module {} found in cache", name);
-			ptxs.push_back(itr->second);
+			context_ptxs.push_back(std::move(cached));
 		} else {
 			CUmodule module;
 			SPDLOG_INFO("Loading module: {}, not found in cache",
@@ -237,6 +321,8 @@ void fatbin_record::try_loading_ptxs(class nv_attach_impl &impl)
 				throw std::runtime_error(
 					"Unable to compile module");
 			}
+			auto ptr =
+				std::make_shared<ptx_in_module>(module, context);
 			if (added_trampoline) {
 				CUdeviceptr const_data_ptr, map_basic_info_ptr;
 				size_t const_data_size, map_basic_info_size;
@@ -270,13 +356,19 @@ void fatbin_record::try_loading_ptxs(class nv_attach_impl &impl)
 					"Unable to copy constData pointer to device");
 				SPDLOG_INFO("Trampoline data copied");
 			}
-			auto ptr = std::make_shared<ptx_in_module>(module);
-			module_pool->insert(std::make_pair(sha256_string, ptr));
-			ptxs.push_back(ptr);
+			{
+				std::lock_guard<std::mutex> guard(
+					impl.module_cache_mutex);
+				const auto [itr, inserted] =
+					module_pool->emplace(key, ptr);
+				if (!inserted)
+					ptr = itr->second;
+			}
+			context_ptxs.push_back(std::move(ptr));
 			SPDLOG_INFO("Loaded module: {}", name);
 		}
 	}
-	ptx_loaded = true;
+	ptxs_by_context.emplace(context, std::move(context_ptxs));
 }
 
 } // namespace bpftime::attach

--- a/attach/nv_attach_impl/nv_attach_fatbin_record.cpp
+++ b/attach/nv_attach_impl/nv_attach_fatbin_record.cpp
@@ -73,23 +73,6 @@ ptx_in_module::~ptx_in_module()
 	}
 }
 
-bool fatbin_record::find_and_fill_variable_info(void *ptr,
-						const char *symbol_name)
-{
-	if (ptr == nullptr || symbol_name == nullptr)
-		return false;
-	variable_addr_to_symbol[ptr] = symbol_name;
-	return true;
-}
-bool fatbin_record::find_and_fill_function_info(void *ptr,
-						const char *symbol_name)
-{
-	if (ptr == nullptr || symbol_name == nullptr)
-		return false;
-	function_addr_to_symbol[ptr] = symbol_name;
-	return true;
-}
-
 std::optional<variable_info>
 fatbin_record::find_variable_info(nv_attach_impl &impl, void *ptr)
 {
@@ -120,7 +103,7 @@ fatbin_record::find_variable_info(nv_attach_impl &impl,
 		auto err = cuModuleGetGlobal(&ptr, &size, ptx->module_ptr,
 					     name.c_str());
 		if (err == CUDA_SUCCESS)
-			return variable_info{ name, ptr, size, ptx.get() };
+			return variable_info{ name, ptr, size };
 		if (err != CUDA_ERROR_NOT_FOUND) {
 			SPDLOG_ERROR("Unable to lookup symbol {}: {}", name,
 				     (int)err);
@@ -130,7 +113,7 @@ fatbin_record::find_variable_info(nv_attach_impl &impl,
 	return std::nullopt;
 }
 
-std::optional<kernel_info>
+std::optional<CUfunction>
 fatbin_record::find_function_info(nv_attach_impl &impl, void *ptr)
 {
 	auto itr = function_addr_to_symbol.find(ptr);
@@ -139,9 +122,8 @@ fatbin_record::find_function_info(nv_attach_impl &impl, void *ptr)
 	return find_function_info(impl, itr->second);
 }
 
-std::optional<kernel_info>
-fatbin_record::find_function_info(nv_attach_impl &impl,
-				  const std::string &name)
+std::optional<CUfunction>
+fatbin_record::find_function_info(nv_attach_impl &impl, const std::string &name)
 {
 	try {
 		try_loading_ptxs(impl);
@@ -159,7 +141,7 @@ fatbin_record::find_function_info(nv_attach_impl &impl,
 		auto err = cuModuleGetFunction(&function, ptx->module_ptr,
 					       name.c_str());
 		if (err == CUDA_SUCCESS)
-			return kernel_info{ name, function, ptx.get() };
+			return function;
 		if (err != CUDA_ERROR_NOT_FOUND) {
 			SPDLOG_ERROR("Unable to lookup function {}: {}", name,
 				     (int)err);
@@ -282,18 +264,16 @@ void fatbin_record::try_loading_ptxs(class nv_attach_impl &impl)
 	auto compiled_ptx = compile_ptxs(impl, patched_ptx);
 
 	std::vector<std::shared_ptr<ptx_in_module>> context_ptxs;
+	std::map<std::string, std::shared_ptr<ptx_in_module>> loaded_modules;
 	for (const auto &[name, ptx_and_trampoline_flag] : patched_ptx) {
 		bool added_trampoline = std::get<1>(ptx_and_trampoline_flag);
 		const auto &compiled_elf = compiled_ptx.at(name);
-		module_key key{ context, this, sha256(compiled_elf.data(),
-						     compiled_elf.size()) };
+		const auto key =
+			sha256(compiled_elf.data(), compiled_elf.size());
 		std::shared_ptr<ptx_in_module> cached;
-		{
-			std::lock_guard<std::mutex> guard(impl.module_cache_mutex);
-			if (auto itr = module_pool->find(key);
-			    itr != module_pool->end())
-				cached = itr->second;
-		}
+		if (auto itr = loaded_modules.find(key);
+		    itr != loaded_modules.end())
+			cached = itr->second;
 		if (cached) {
 			SPDLOG_INFO("Module {} found in cache", name);
 			if (std::find(context_ptxs.begin(), context_ptxs.end(),
@@ -360,14 +340,7 @@ void fatbin_record::try_loading_ptxs(class nv_attach_impl &impl)
 					"Unable to copy constData pointer to device");
 				SPDLOG_INFO("Trampoline data copied");
 			}
-			{
-				std::lock_guard<std::mutex> guard(
-					impl.module_cache_mutex);
-				const auto [itr, inserted] =
-					module_pool->emplace(key, ptr);
-				if (!inserted)
-					ptr = itr->second;
-			}
+			loaded_modules.emplace(key, ptr);
 			context_ptxs.push_back(std::move(ptr));
 			SPDLOG_INFO("Loaded module: {}", name);
 		}

--- a/attach/nv_attach_impl/nv_attach_fatbin_record.hpp
+++ b/attach/nv_attach_impl/nv_attach_fatbin_record.hpp
@@ -28,6 +28,10 @@ struct variable_info {
 };
 struct fatbin_record {
 	std::shared_ptr<std::map<std::string, std::vector<uint8_t>>> ptx_pool;
+	// Zero for records observed through CUDA registration hooks. Non-zero
+	// late-bootstrap generations let reruns supersede, but safely retain,
+	// modules that may still have in-flight launches.
+	std::size_t late_bootstrap_generation = 0;
 	std::map<void *, std::string> variable_addr_to_symbol;
 	std::map<void *, std::string> function_addr_to_symbol;
 	std::map<std::string, std::string> original_ptx;

--- a/attach/nv_attach_impl/nv_attach_fatbin_record.hpp
+++ b/attach/nv_attach_impl/nv_attach_fatbin_record.hpp
@@ -4,6 +4,8 @@
 #include "cuda.h"
 #include <map>
 #include <memory>
+#include <mutex>
+#include <optional>
 #include <string>
 #include <vector>
 namespace bpftime
@@ -12,7 +14,9 @@ namespace attach
 {
 struct ptx_in_module {
 	CUmodule module_ptr;
-	ptx_in_module(CUmodule module_ptr) : module_ptr(module_ptr)
+	CUcontext context;
+	ptx_in_module(CUmodule module_ptr, CUcontext context)
+		: module_ptr(module_ptr), context(context)
 	{
 	}
 	virtual ~ptx_in_module();
@@ -30,21 +34,31 @@ struct kernel_info {
 	ptx_in_module *ptx;
 };
 struct fatbin_record {
-	std::shared_ptr<std::map<std::string, std::shared_ptr<ptx_in_module>>>
+	using module_key = std::pair<CUcontext, std::string>;
+	std::shared_ptr<std::map<module_key, std::shared_ptr<ptx_in_module>>>
 		module_pool;
 	std::shared_ptr<std::map<std::string, std::vector<uint8_t>>> ptx_pool;
-	std::vector<std::shared_ptr<ptx_in_module>> ptxs;
-	std::map<void *, variable_info> variable_addr_to_symbol;
-	std::map<void *, kernel_info> function_addr_to_symbol;
+	std::map<void *, std::string> variable_addr_to_symbol;
+	std::map<void *, std::string> function_addr_to_symbol;
 	std::map<std::string, std::string> original_ptx;
 	bool all_ptx_not_modified = true;
-	bool ptx_loaded = false;
 	void try_loading_ptxs(class nv_attach_impl &);
 	virtual ~fatbin_record();
 	bool find_and_fill_variable_info(void *ptr, const char *symbol_name);
 	bool find_and_fill_function_info(void *ptr, const char *symbol_name);
+	std::optional<variable_info>
+	find_variable_info(class nv_attach_impl &, void *ptr);
+	std::optional<variable_info>
+	find_variable_info(class nv_attach_impl &, const std::string &name);
+	std::optional<kernel_info>
+	find_function_info(class nv_attach_impl &, void *ptr);
+	std::optional<kernel_info>
+	find_function_info(class nv_attach_impl &, const std::string &name);
 
     private:
+	std::map<CUcontext, std::vector<std::shared_ptr<ptx_in_module>>>
+		ptxs_by_context;
+	std::mutex load_mutex;
 	std::map<std::string, std::vector<uint8_t>>
 	compile_ptxs(class nv_attach_impl &impl,std::map<std::string, std::tuple<std::string, bool>>);
 };

--- a/attach/nv_attach_impl/nv_attach_fatbin_record.hpp
+++ b/attach/nv_attach_impl/nv_attach_fatbin_record.hpp
@@ -7,7 +7,6 @@
 #include <mutex>
 #include <optional>
 #include <string>
-#include <tuple>
 #include <vector>
 namespace bpftime
 {
@@ -26,19 +25,8 @@ struct variable_info {
 	std::string symbol_name;
 	CUdeviceptr ptr;
 	size_t size;
-	ptx_in_module *ptx;
-};
-
-struct kernel_info {
-	std::string symbol_name;
-	CUfunction func;
-	ptx_in_module *ptx;
 };
 struct fatbin_record {
-	using module_key =
-		std::tuple<CUcontext, const fatbin_record *, std::string>;
-	std::shared_ptr<std::map<module_key, std::shared_ptr<ptx_in_module>>>
-		module_pool;
 	std::shared_ptr<std::map<std::string, std::vector<uint8_t>>> ptx_pool;
 	std::map<void *, std::string> variable_addr_to_symbol;
 	std::map<void *, std::string> function_addr_to_symbol;
@@ -46,16 +34,14 @@ struct fatbin_record {
 	bool all_ptx_not_modified = true;
 	void try_loading_ptxs(class nv_attach_impl &);
 	virtual ~fatbin_record();
-	bool find_and_fill_variable_info(void *ptr, const char *symbol_name);
-	bool find_and_fill_function_info(void *ptr, const char *symbol_name);
 	std::optional<variable_info>
 	find_variable_info(class nv_attach_impl &, void *ptr);
 	std::optional<variable_info>
 	find_variable_info(class nv_attach_impl &, const std::string &name);
-	std::optional<kernel_info>
-	find_function_info(class nv_attach_impl &, void *ptr);
-	std::optional<kernel_info>
-	find_function_info(class nv_attach_impl &, const std::string &name);
+	std::optional<CUfunction> find_function_info(class nv_attach_impl &,
+						     void *ptr);
+	std::optional<CUfunction> find_function_info(class nv_attach_impl &,
+						     const std::string &name);
 
     private:
 	std::map<CUcontext, std::vector<std::shared_ptr<ptx_in_module>>>

--- a/attach/nv_attach_impl/nv_attach_fatbin_record.hpp
+++ b/attach/nv_attach_impl/nv_attach_fatbin_record.hpp
@@ -7,6 +7,7 @@
 #include <mutex>
 #include <optional>
 #include <string>
+#include <tuple>
 #include <vector>
 namespace bpftime
 {
@@ -34,7 +35,8 @@ struct kernel_info {
 	ptx_in_module *ptx;
 };
 struct fatbin_record {
-	using module_key = std::pair<CUcontext, std::string>;
+	using module_key =
+		std::tuple<CUcontext, const fatbin_record *, std::string>;
 	std::shared_ptr<std::map<module_key, std::shared_ptr<ptx_in_module>>>
 		module_pool;
 	std::shared_ptr<std::map<std::string, std::vector<uint8_t>>> ptx_pool;

--- a/attach/nv_attach_impl/nv_attach_impl.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl.cpp
@@ -1023,14 +1023,17 @@ nv_attach_impl::hack_fatbin(std::map<std::string, std::string> all_ptx)
 											int>::
 											max() :
 										(int)buf_bytes;
-								int err =
-									hook_entry
-										.config
-										->process_input(
+								int err;
+								{
+									std::lock_guard<std::mutex>
+										pass_guard(
+											patch_cache_mutex);
+									err = hook_entry.config->process_input(
 											input_json
 												.c_str(),
 											len,
 											buf.data());
+								}
 								if (err !=
 								    ptxpass::ExitCode::
 									    Success) {

--- a/attach/nv_attach_impl/nv_attach_impl.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl.cpp
@@ -130,6 +130,7 @@ extern GType cuda_runtime_function_hooker_get_type();
 
 int nv_attach_impl::detach_by_id(int id)
 {
+	std::unique_lock<std::shared_mutex> state_guard(patched_state_mutex);
 	bool last_entry = false;
 	{
 		std::lock_guard<std::mutex> guard(hook_entries_mutex);
@@ -140,10 +141,9 @@ int nv_attach_impl::detach_by_id(int id)
 		}
 		hook_entries.erase(itr);
 		last_entry = hook_entries.empty();
-		if (last_entry)
-			enabled.store(false, std::memory_order_release);
 	}
 	if (last_entry) {
+		enabled.store(false, std::memory_order_release);
 		SPDLOG_INFO(
 			"nv_attach_impl: last entry detached; disabling CUDA launch replacement");
 		// Wait for in-flight patched kernels to complete before the
@@ -198,6 +198,8 @@ int nv_attach_impl::create_attach_with_ebpf_callback(
 		}
 	}
 	if (matched) {
+		std::unique_lock<std::shared_mutex> state_guard(
+			patched_state_mutex);
 		auto id = this->allocate_id();
 		nv_attach_entry entry;
 		entry.instuctions = data.instructions;
@@ -1336,6 +1338,7 @@ void nv_attach_impl::mirror_cuda_memcpy_to_symbol(
 	const void *symbol, const void *src, size_t count, size_t offset,
 	cudaMemcpyKind kind, cudaStream_t stream, bool async)
 {
+	auto state_guard = lock_patched_state();
 	if (!is_enabled())
 		return;
 	bootstrap_existing_fatbins_once();

--- a/attach/nv_attach_impl/nv_attach_impl.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl.cpp
@@ -30,6 +30,7 @@
 #include <cstdint>
 #include <cuda.h>
 #include <cuda_runtime.h>
+#include <fatbinary_section.h>
 #include <dlfcn.h>
 #include <filesystem>
 #include <iterator>
@@ -266,10 +267,6 @@ CUresult cuda_driver_function__cuGraphKernelNodeSetParams_v1(
 	CUgraphNode hNode, const CUDA_KERNEL_NODE_PARAMS_v1 *nodeParams);
 CUresult cuda_driver_function__cuGraphKernelNodeSetParams_v2(
 	CUgraphNode hNode, const CUDA_KERNEL_NODE_PARAMS_v2 *nodeParams);
-CUresult cuda_driver_function__cuGraphLaunch(CUgraphExec graph_exec,
-					     CUstream stream);
-CUresult cuda_driver_function__cuGraphLaunch_ptsz(CUgraphExec graph_exec,
-						  CUstream stream);
 cudaError_t cuda_runtime_function__cudaMemcpyFromSymbol(
 	void *dst, const void *symbol, size_t count, size_t offset = 0,
 	cudaMemcpyKind kind = cudaMemcpyDeviceToHost);
@@ -456,12 +453,6 @@ nv_attach_impl::nv_attach_impl()
 		"cuGraphKernelNodeSetParams_v2",
 		(gpointer)&cuda_driver_function__cuGraphKernelNodeSetParams_v2,
 		hook_state.orig_cu_graph_kernel_node_set_params_v2);
-	replace_hook_once("cuGraphLaunch",
-			  (gpointer)&cuda_driver_function__cuGraphLaunch,
-			  hook_state.orig_cu_graph_launch);
-	replace_hook_once("cuGraphLaunch_ptsz",
-			  (gpointer)&cuda_driver_function__cuGraphLaunch_ptsz,
-			  hook_state.orig_cu_graph_launch_ptsz);
 	replace_hook_once(
 		"cudaMemcpyFromSymbol",
 		(gpointer)&cuda_runtime_function__cudaMemcpyFromSymbol,
@@ -624,15 +615,45 @@ std::optional<CUfunction> nv_attach_impl::find_patched_kernel_function(
 		    itr != patched_kernel_by_context.end())
 			return itr->second;
 	}
+	std::lock_guard<std::mutex> records_guard(late_bootstrap_mutex);
+	std::optional<CUfunction> resolved;
 	for (const auto &record : fatbin_records) {
 		if (auto info = record->find_function_info(*this, kernel_name);
 		    info) {
-			record_patched_kernel_function(kernel_name, info->func);
-			record_original_cufunction_name(info->func, kernel_name);
-			return info->func;
+			if (resolved) {
+				SPDLOG_WARN(
+					"Ambiguous late-attach kernel {}; using original launch",
+					kernel_name);
+				return std::nullopt;
+			}
+			resolved = info->func;
 		}
 	}
-	return std::nullopt;
+	if (!resolved)
+		return std::nullopt;
+	record_patched_kernel_function(kernel_name, *resolved);
+	record_original_cufunction_name(*resolved, kernel_name);
+	return resolved;
+}
+
+std::optional<variable_info>
+nv_attach_impl::find_patched_global(const std::string &symbol_name)
+{
+	std::lock_guard<std::mutex> records_guard(late_bootstrap_mutex);
+	std::optional<variable_info> resolved;
+	for (const auto &record : fatbin_records) {
+		auto info = record->find_variable_info(*this, symbol_name);
+		if (!info)
+			continue;
+		if (resolved) {
+			SPDLOG_WARN(
+				"Ambiguous late-attach global {}; skipping mirror",
+				symbol_name);
+			return std::nullopt;
+		}
+		resolved = std::move(info);
+	}
+	return resolved;
 }
 
 void nv_attach_impl::record_original_cufunction_name(
@@ -1330,19 +1351,13 @@ void nv_attach_impl::mirror_cuda_memcpy_to_symbol(
 			}
 		}
 		if (!resolved_var) {
-			for (const auto &rec_uptr : fatbin_records) {
-				auto *rec = rec_uptr.get();
-				if (rec == nullptr)
-					continue;
-				resolved_var = rec->find_variable_info(*this, *name);
-				if (resolved_var) {
-					std::lock_guard<std::mutex> guard(
-						patched_global_cache_mutex);
-					patched_global_by_context[{ context, *name }] =
-						{ resolved_var->ptr,
-						  resolved_var->size };
-					break;
-				}
+			resolved_var = find_patched_global(*name);
+			if (resolved_var) {
+				std::lock_guard<std::mutex> guard(
+					patched_global_cache_mutex);
+				patched_global_by_context[{ context, *name }] = {
+					resolved_var->ptr, resolved_var->size
+				};
 			}
 		}
 	}
@@ -1797,31 +1812,48 @@ void nv_attach_impl::bootstrap_existing_fatbins()
 	std::size_t ingested = 0;
 
 	for (const auto &mod : modules) {
+		bool has_regular_wrapper = false;
+		if (auto sec = elf_introspect::find_section_in_memory(
+			    mod, ".nvFatBinSegment");
+		    sec) {
+			auto [addr, size] = *sec;
+			for (const auto *wrapper :
+			     elf_introspect::scan_fatbin_wrappers(addr, size)) {
+				if (wrapper != nullptr &&
+				    wrapper->version == FATBINC_VERSION) {
+					has_regular_wrapper = true;
+					break;
+				}
+			}
+		}
 		// CUDA binaries may expose fatbin bytes either directly in
 		// `.nv_fatbin` (raw fatbin header 0xBA55ED50...) or as a list
 		// of wrappers inside `.nvFatBinSegment` (magic 'FbC1').
-		if (auto sec = elf_introspect::find_section_in_memory(
-			    mod, ".nv_fatbin");
-		    sec) {
-			auto [sec_addr, sec_size] = *sec;
-			(void)sec_size;
-			if (auto bytes = read_fatbin_bytes_from_ptr(sec_addr);
-			    bytes) {
-				auto extracted_ptx =
-					extract_ptxs(std::move(*bytes));
-				if (!extracted_ptx.empty()) {
-					auto rec =
-						std::make_unique<fatbin_record>();
-					rec->original_ptx =
-						std::move(extracted_ptx);
-					rec->module_pool = module_pool;
-					rec->ptx_pool = ptx_pool;
-					fatbin_records.emplace_back(
-						std::move(rec));
-					ingested++;
-					SPDLOG_INFO(
-						"nv_attach_impl: ingested fatbin from .nv_fatbin in {}",
-						mod.path.c_str());
+		if (!has_regular_wrapper) {
+			if (auto sec = elf_introspect::find_section_in_memory(
+				    mod, ".nv_fatbin");
+			    sec) {
+				auto [sec_addr, sec_size] = *sec;
+				(void)sec_size;
+				if (auto bytes = read_fatbin_bytes_from_ptr(
+					    sec_addr);
+				    bytes) {
+					auto extracted_ptx =
+						extract_ptxs(std::move(*bytes));
+					if (!extracted_ptx.empty()) {
+						auto rec = std::make_unique<
+							fatbin_record>();
+						rec->original_ptx = std::move(
+							extracted_ptx);
+						rec->module_pool = module_pool;
+						rec->ptx_pool = ptx_pool;
+						fatbin_records.emplace_back(
+							std::move(rec));
+						ingested++;
+						SPDLOG_INFO(
+							"nv_attach_impl: ingested fatbin from .nv_fatbin in {}",
+							mod.path.c_str());
+					}
 				}
 			}
 		}
@@ -1838,7 +1870,7 @@ void nv_attach_impl::bootstrap_existing_fatbins()
 					wrappers.size(), mod.path.c_str());
 			}
 			for (const auto *w : wrappers) {
-				if (w == nullptr)
+				if (w == nullptr || w->version != FATBINC_VERSION)
 					continue;
 				auto bytes = read_fatbin_bytes_from_wrapper(*w);
 				if (!bytes)

--- a/attach/nv_attach_impl/nv_attach_impl.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl.cpp
@@ -130,16 +130,22 @@ extern GType cuda_runtime_function_hooker_get_type();
 
 int nv_attach_impl::detach_by_id(int id)
 {
-	auto itr = hook_entries.find(id);
-	if (itr == hook_entries.end()) {
-		SPDLOG_WARN("nv_attach_impl: detach unknown id {}", id);
-		return -ENOENT;
+	bool last_entry = false;
+	{
+		std::lock_guard<std::mutex> guard(hook_entries_mutex);
+		auto itr = hook_entries.find(id);
+		if (itr == hook_entries.end()) {
+			SPDLOG_WARN("nv_attach_impl: detach unknown id {}", id);
+			return -ENOENT;
+		}
+		hook_entries.erase(itr);
+		last_entry = hook_entries.empty();
+		if (last_entry)
+			enabled.store(false, std::memory_order_release);
 	}
-	hook_entries.erase(itr);
-	if (hook_entries.empty()) {
+	if (last_entry) {
 		SPDLOG_INFO(
 			"nv_attach_impl: last entry detached; disabling CUDA launch replacement");
-		enabled.store(false, std::memory_order_release);
 		// Wait for in-flight patched kernels to complete before the
 		// loader exits and tears down CUDA IPC buffers.
 		wait_for_patched_launch_events(std::chrono::seconds(2));
@@ -192,7 +198,6 @@ int nv_attach_impl::create_attach_with_ebpf_callback(
 		}
 	}
 	if (matched) {
-		enabled.store(true, std::memory_order_release);
 		auto id = this->allocate_id();
 		nv_attach_entry entry;
 		entry.instuctions = data.instructions;
@@ -200,7 +205,11 @@ int nv_attach_impl::create_attach_with_ebpf_callback(
 		entry.program_name = data.program_name;
 		entry.config = matched;
 
-		hook_entries[id] = std::move(entry);
+		{
+			std::lock_guard<std::mutex> guard(hook_entries_mutex);
+			hook_entries[id] = std::move(entry);
+			enabled.store(true, std::memory_order_release);
+		}
 		// Late bootstrap may have already patched/loaded modules for earlier
 		// hooks (e.g. kprobe). If a new hook is added afterwards (e.g.
 		// kretprobe), we must rerun bootstrap so the new pass is applied to
@@ -937,12 +946,18 @@ nv_attach_impl::hack_fatbin(std::map<std::string, std::string> all_ptx)
 		std::max(1u, std::thread::hardware_concurrency()));
 	std::map<std::string, std::tuple<std::string, bool>> ptx_out;
 	std::mutex map_mutex;
+	std::vector<nv_attach_entry> entries;
+	{
+		std::lock_guard<std::mutex> guard(hook_entries_mutex);
+		for (const auto &[_, entry] : hook_entries)
+			entries.push_back(entry);
+	}
 	for (auto &[file_name, original_ptx] : all_ptx) {
-		boost::asio::post(pool, [this, original_ptx, file_name, &map_mutex, &ptx_out]() -> void {
+		boost::asio::post(pool, [this, original_ptx, file_name, &map_mutex, &ptx_out, &entries]() -> void {
 			auto current_ptx = original_ptx;
 			SPDLOG_INFO("Patching PTX: {}", file_name);
 			bool should_add_trampoline = false;
-			for (const auto &[_, hook_entry] : this->hook_entries) {
+			for (const auto &hook_entry : entries) {
 				const auto &kernels = hook_entry.kernels;
 				for (const auto &kernel : kernels) {
 					std::vector<uint64_t> ebpf_inst_words;
@@ -1121,6 +1136,7 @@ namespace bpftime::attach
 
 int nv_attach_impl::find_attach_entry_by_program_name(const char *name) const
 {
+	std::lock_guard<std::mutex> guard(hook_entries_mutex);
 	for (const auto &entry : this->hook_entries) {
 		if (entry.second.program_name == name)
 			return entry.first;
@@ -1163,14 +1179,16 @@ int nv_attach_impl::run_attach_entry_on_gpu(int attach_id, int run_count,
 		return -1;
 	}
 	std::vector<ebpf_inst> insts;
-	if (auto itr = hook_entries.find(attach_id);
-	    itr != hook_entries.end()) {
+	{
+		std::lock_guard<std::mutex> guard(hook_entries_mutex);
+		auto itr = hook_entries.find(attach_id);
+		if (itr == hook_entries.end()) {
+			SPDLOG_ERROR("Invalid attach id {}", attach_id);
+			return -1;
+		}
 		// In new flow, directly_run is not supported and should be
 		// represented by a dedicated pass
 		insts = itr->second.instuctions;
-	} else {
-		SPDLOG_ERROR("Invalid attach id {}", attach_id);
-		return -1;
 	}
 	SPDLOG_INFO("Running program on GPU");
 
@@ -1923,9 +1941,6 @@ void nv_attach_impl::bootstrap_existing_fatbins_once()
 		return;
 	if (!map_basic_info.has_value() || map_basic_info->empty())
 		return;
-	if (hook_entries.empty())
-		return;
-
 	std::lock_guard<std::mutex> guard(late_bootstrap_mutex);
 	if (late_bootstrap_done.load(std::memory_order_acquire))
 		return;

--- a/attach/nv_attach_impl/nv_attach_impl.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl.cpp
@@ -634,7 +634,7 @@ std::optional<CUfunction> nv_attach_impl::find_patched_kernel_function(
 	}
 	std::lock_guard<std::mutex> records_guard(late_bootstrap_mutex);
 	std::optional<CUfunction> resolved;
-	for (const auto &record : fatbin_records) {
+	for (auto *record : active_fatbin_records()) {
 		if (auto info = record->find_function_info(*this, kernel_name);
 		    info) {
 			if (resolved) {
@@ -658,7 +658,7 @@ nv_attach_impl::find_patched_global(const std::string &symbol_name)
 {
 	std::lock_guard<std::mutex> records_guard(late_bootstrap_mutex);
 	std::optional<variable_info> resolved;
-	for (const auto &record : fatbin_records) {
+	for (auto *record : active_fatbin_records()) {
 		auto info = record->find_variable_info(*this, symbol_name);
 		if (!info)
 			continue;
@@ -669,6 +669,17 @@ nv_attach_impl::find_patched_global(const std::string &symbol_name)
 			return std::nullopt;
 		}
 		resolved = std::move(info);
+	}
+	if (resolved) {
+		CUcontext context = nullptr;
+		if (cuCtxGetCurrent(&context) == CUDA_SUCCESS &&
+		    context != nullptr) {
+			std::lock_guard<std::mutex> guard(
+				patched_global_cache_mutex);
+			patched_global_by_context[{ context, symbol_name }] = {
+				resolved->ptr, resolved->size
+			};
+		}
 	}
 	return resolved;
 }
@@ -1383,13 +1394,6 @@ void nv_attach_impl::mirror_cuda_memcpy_to_symbol(
 		}
 		if (!resolved_var) {
 			resolved_var = find_patched_global(*name);
-			if (resolved_var) {
-				std::lock_guard<std::mutex> guard(
-					patched_global_cache_mutex);
-				patched_global_by_context[{ context, *name }] = {
-					resolved_var->ptr, resolved_var->size
-				};
-			}
 		}
 	}
 
@@ -1601,6 +1605,7 @@ void nv_attach_impl::clear_patched_state_for_next_session()
 	{
 		std::lock_guard<std::mutex> guard(late_bootstrap_mutex);
 		old_records.swap(fatbin_records);
+		late_bootstrap_generation = 0;
 		current_fatbin = nullptr;
 		symbol_address_to_fatbin.clear();
 		{
@@ -1829,13 +1834,68 @@ read_fatbin_bytes_from_wrapper(const __fatBinC_Wrapper_t &wrapper)
 {
 	return read_fatbin_bytes_from_ptr(wrapper.data);
 }
+
+static std::string
+fingerprint_ptx_set(const std::map<std::string, std::string> &ptxs)
+{
+	std::vector<std::string> digests;
+	digests.reserve(ptxs.size());
+	for (const auto &[file_name, ptx] : ptxs) {
+		(void)file_name;
+		digests.emplace_back(sha256(ptx.data(), ptx.size()));
+	}
+	std::sort(digests.begin(), digests.end());
+	std::string combined;
+	combined.reserve(digests.size() * 64);
+	for (const auto &digest : digests)
+		combined += digest;
+	return sha256(combined.data(), combined.size());
+}
 } // namespace
+
+std::vector<fatbin_record *> nv_attach_impl::active_fatbin_records()
+{
+	std::map<std::string, std::size_t> bootstrap_fingerprints;
+	if (late_bootstrap_generation != 0) {
+		for (const auto &record : fatbin_records) {
+			if (record->late_bootstrap_generation ==
+			    late_bootstrap_generation) {
+				bootstrap_fingerprints[fingerprint_ptx_set(
+					record->original_ptx)]++;
+			}
+		}
+	}
+
+	std::vector<fatbin_record *> active;
+	active.reserve(fatbin_records.size());
+	for (const auto &record : fatbin_records) {
+		if (record->late_bootstrap_generation != 0 &&
+		    record->late_bootstrap_generation !=
+			    late_bootstrap_generation) {
+			continue;
+		}
+		if (record->late_bootstrap_generation == 0) {
+			auto fingerprint =
+				fingerprint_ptx_set(record->original_ptx);
+			if (auto it = bootstrap_fingerprints.find(fingerprint);
+			    it != bootstrap_fingerprints.end() &&
+			    it->second != 0) {
+				it->second--;
+				continue;
+			}
+		}
+		active.emplace_back(record.get());
+	}
+	return active;
+}
 
 void nv_attach_impl::bootstrap_existing_fatbins()
 {
 	SPDLOG_INFO("nv_attach_impl: late attach bootstrap scanning fatbins..");
 	auto modules = elf_introspect::list_loaded_modules();
 	std::size_t ingested = 0;
+	const std::size_t generation = late_bootstrap_generation + 1;
+	std::vector<std::unique_ptr<fatbin_record>> new_records;
 
 	for (const auto &mod : modules) {
 		bool has_regular_wrapper = false;
@@ -1869,10 +1929,12 @@ void nv_attach_impl::bootstrap_existing_fatbins()
 					if (!extracted_ptx.empty()) {
 						auto rec = std::make_unique<
 							fatbin_record>();
+						rec->late_bootstrap_generation =
+							generation;
 						rec->original_ptx = std::move(
 							extracted_ptx);
 						rec->ptx_pool = ptx_pool;
-						fatbin_records.emplace_back(
+						new_records.emplace_back(
 							std::move(rec));
 						ingested++;
 						SPDLOG_INFO(
@@ -1906,9 +1968,10 @@ void nv_attach_impl::bootstrap_existing_fatbins()
 					continue;
 
 				auto rec = std::make_unique<fatbin_record>();
+				rec->late_bootstrap_generation = generation;
 				rec->original_ptx = std::move(extracted_ptx);
 				rec->ptx_pool = ptx_pool;
-				fatbin_records.emplace_back(std::move(rec));
+				new_records.emplace_back(std::move(rec));
 				ingested++;
 			}
 		}
@@ -1921,13 +1984,31 @@ void nv_attach_impl::bootstrap_existing_fatbins()
 		auto extracted_ptx = extract_ptxs({});
 		if (!extracted_ptx.empty()) {
 			auto rec = std::make_unique<fatbin_record>();
+			rec->late_bootstrap_generation = generation;
 			rec->original_ptx = std::move(extracted_ptx);
 			rec->ptx_pool = ptx_pool;
-			fatbin_records.emplace_back(std::move(rec));
+			new_records.emplace_back(std::move(rec));
 			ingested++;
 			SPDLOG_INFO(
 				"nv_attach_impl: ingested fatbin via external PTX directory fallback");
 		}
+	}
+	if (ingested != 0) {
+		fatbin_records.reserve(fatbin_records.size() +
+				       new_records.size());
+		for (auto &record : new_records)
+			fatbin_records.emplace_back(std::move(record));
+		{
+			std::lock_guard<std::mutex> guard(
+				cuda_symbol_map_mutex);
+			patched_kernel_by_context.clear();
+		}
+		{
+			std::lock_guard<std::mutex> guard(
+				patched_global_cache_mutex);
+			patched_global_by_context.clear();
+		}
+		late_bootstrap_generation = generation;
 	}
 
 	SPDLOG_INFO(

--- a/attach/nv_attach_impl/nv_attach_impl.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl.cpp
@@ -266,6 +266,10 @@ CUresult cuda_driver_function__cuGraphKernelNodeSetParams_v1(
 	CUgraphNode hNode, const CUDA_KERNEL_NODE_PARAMS_v1 *nodeParams);
 CUresult cuda_driver_function__cuGraphKernelNodeSetParams_v2(
 	CUgraphNode hNode, const CUDA_KERNEL_NODE_PARAMS_v2 *nodeParams);
+CUresult cuda_driver_function__cuGraphLaunch(CUgraphExec graph_exec,
+					     CUstream stream);
+CUresult cuda_driver_function__cuGraphLaunch_ptsz(CUgraphExec graph_exec,
+						  CUstream stream);
 cudaError_t cuda_runtime_function__cudaMemcpyFromSymbol(
 	void *dst, const void *symbol, size_t count, size_t offset = 0,
 	cudaMemcpyKind kind = cudaMemcpyDeviceToHost);
@@ -452,6 +456,12 @@ nv_attach_impl::nv_attach_impl()
 		"cuGraphKernelNodeSetParams_v2",
 		(gpointer)&cuda_driver_function__cuGraphKernelNodeSetParams_v2,
 		hook_state.orig_cu_graph_kernel_node_set_params_v2);
+	replace_hook_once("cuGraphLaunch",
+			  (gpointer)&cuda_driver_function__cuGraphLaunch,
+			  hook_state.orig_cu_graph_launch);
+	replace_hook_once("cuGraphLaunch_ptsz",
+			  (gpointer)&cuda_driver_function__cuGraphLaunch_ptsz,
+			  hook_state.orig_cu_graph_launch_ptsz);
 	replace_hook_once(
 		"cudaMemcpyFromSymbol",
 		(gpointer)&cuda_runtime_function__cudaMemcpyFromSymbol,
@@ -1396,8 +1406,59 @@ void nv_attach_impl::record_patched_launch(cudaStream_t stream)
 	record_patched_launch_event(reinterpret_cast<CUstream>(stream));
 }
 
+namespace
+{
+class scoped_cuda_context final {
+    public:
+	explicit scoped_cuda_context(CUcontext context)
+	{
+		CUcontext current = nullptr;
+		if (context == nullptr ||
+		    cuCtxGetCurrent(&current) != CUDA_SUCCESS)
+			return;
+		if (current == context) {
+			active = true;
+			return;
+		}
+		if (cuCtxPushCurrent(context) == CUDA_SUCCESS) {
+			active = true;
+			pushed = true;
+		}
+	}
+
+	~scoped_cuda_context()
+	{
+		if (pushed) {
+			CUcontext popped = nullptr;
+			cuCtxPopCurrent(&popped);
+		}
+	}
+
+	explicit operator bool() const
+	{
+		return active;
+	}
+
+    private:
+	bool active = false;
+	bool pushed = false;
+};
+
+void destroy_cuda_event(CUcontext context, CUevent event)
+{
+	if (event == nullptr)
+		return;
+	scoped_cuda_context guard(context);
+	if (guard)
+		cuEventDestroy(event);
+}
+} // namespace
+
 void nv_attach_impl::record_patched_launch_event(CUstream stream)
 {
+	CUcontext context = nullptr;
+	if (cuCtxGetCurrent(&context) != CUDA_SUCCESS || context == nullptr)
+		return;
 	CUevent ev = nullptr;
 	if (cuEventCreate(&ev, CU_EVENT_DISABLE_TIMING) != CUDA_SUCCESS ||
 	    ev == nullptr) {
@@ -1409,13 +1470,14 @@ void nv_attach_impl::record_patched_launch_event(CUstream stream)
 	}
 	{
 		std::lock_guard<std::mutex> guard(launch_event_mutex);
-		auto it = pending_launch_events_by_stream.find(stream);
-		if (it != pending_launch_events_by_stream.end()) {
+		auto key = std::make_pair(context, stream);
+		auto it = pending_launch_events.find(key);
+		if (it != pending_launch_events.end()) {
 			if (it->second)
 				cuEventDestroy(it->second);
 			it->second = ev;
 		} else {
-			pending_launch_events_by_stream.emplace(stream, ev);
+			pending_launch_events.emplace(key, ev);
 		}
 	}
 }
@@ -1423,44 +1485,48 @@ void nv_attach_impl::record_patched_launch_event(CUstream stream)
 void nv_attach_impl::wait_for_patched_launch_events(
 	std::chrono::milliseconds timeout)
 {
-	// Best-effort ensure a context is current for driver event APIs.
-	{
-		CUcontext current = nullptr;
-		if (cuCtxGetCurrent(&current) != CUDA_SUCCESS ||
-		    current == nullptr) {
-			cuInit(0);
-			CUdevice dev = 0;
-			if (cuDeviceGet(&dev, 0) == CUDA_SUCCESS) {
-				cuDevicePrimaryCtxRetain(&current, dev);
-				if (current)
-					cuCtxSetCurrent(current);
-			}
-		}
-	}
-	auto deadline = std::chrono::steady_clock::now() + timeout;
-	for (;;) {
-		std::vector<std::pair<CUstream, CUevent>> batch;
+	using event_entry = std::pair<std::pair<CUcontext, CUstream>, CUevent>;
+	auto requeue = [this](const std::vector<event_entry> &events) {
+		std::vector<event_entry> superseded;
 		{
 			std::lock_guard<std::mutex> guard(launch_event_mutex);
-			batch.reserve(pending_launch_events_by_stream.size());
-			for (auto &kv : pending_launch_events_by_stream)
-				batch.emplace_back(kv.first, kv.second);
-			pending_launch_events_by_stream.clear();
+			for (const auto &entry : events) {
+				if (!pending_launch_events.emplace(entry).second)
+					superseded.push_back(entry);
+			}
+		}
+		for (const auto &entry : superseded)
+			destroy_cuda_event(entry.first.first, entry.second);
+	};
+	auto deadline = std::chrono::steady_clock::now() + timeout;
+	for (;;) {
+		std::vector<event_entry> batch;
+		{
+			std::lock_guard<std::mutex> guard(launch_event_mutex);
+			batch.reserve(pending_launch_events.size());
+			for (auto &entry : pending_launch_events)
+				batch.emplace_back(entry.first, entry.second);
+			pending_launch_events.clear();
 		}
 		if (batch.empty())
 			return;
-		std::vector<std::pair<CUstream, CUevent>> not_ready;
+		std::vector<event_entry> not_ready;
 		not_ready.reserve(batch.size());
-		for (auto &kv : batch) {
-			CUstream stream = kv.first;
-			CUevent ev = kv.second;
+		for (const auto &entry : batch) {
+			CUcontext context = entry.first.first;
+			CUevent ev = entry.second;
 			if (ev == nullptr)
 				continue;
+			scoped_cuda_context guard(context);
+			if (!guard) {
+				not_ready.push_back(entry);
+				continue;
+			}
 			CUresult st = cuEventQuery(ev);
 			if (st == CUDA_SUCCESS) {
 				cuEventDestroy(ev);
 			} else if (st == CUDA_ERROR_NOT_READY) {
-				not_ready.emplace_back(stream, ev);
+				not_ready.push_back(entry);
 			} else {
 				cuEventDestroy(ev);
 			}
@@ -1468,42 +1534,13 @@ void nv_attach_impl::wait_for_patched_launch_events(
 		if (not_ready.empty())
 			return;
 		if (std::chrono::steady_clock::now() >= deadline) {
-			std::lock_guard<std::mutex> guard(launch_event_mutex);
-			for (auto &kv : not_ready) {
-				// Keep the most recent event per stream.
-				auto it = pending_launch_events_by_stream.find(
-					kv.first);
-				if (it !=
-				    pending_launch_events_by_stream.end()) {
-					if (it->second)
-						cuEventDestroy(it->second);
-					it->second = kv.second;
-				} else {
-					pending_launch_events_by_stream.emplace(
-						kv.first, kv.second);
-				}
-			}
+			requeue(not_ready);
 			SPDLOG_WARN(
 				"nv_attach_impl: detach timeout waiting for {} patched kernel event(s)",
 				not_ready.size());
 			return;
 		}
-		{
-			std::lock_guard<std::mutex> guard(launch_event_mutex);
-			for (auto &kv : not_ready) {
-				auto it = pending_launch_events_by_stream.find(
-					kv.first);
-				if (it !=
-				    pending_launch_events_by_stream.end()) {
-					if (it->second)
-						cuEventDestroy(it->second);
-					it->second = kv.second;
-				} else {
-					pending_launch_events_by_stream.emplace(
-						kv.first, kv.second);
-				}
-			}
-		}
+		requeue(not_ready);
 		std::this_thread::sleep_for(std::chrono::milliseconds(5));
 	}
 }
@@ -1513,6 +1550,8 @@ void nv_attach_impl::clear_patched_state_for_next_session()
 	// Clear session-scoped state so a new trace session can bind to a new
 	// shm/maps layout without stale GPU pointers.
 	std::vector<std::unique_ptr<fatbin_record>> old_records;
+	std::vector<std::pair<std::pair<CUcontext, CUstream>, CUevent>>
+		old_launch_events;
 	{
 		std::lock_guard<std::mutex> guard(late_bootstrap_mutex);
 		old_records.swap(fatbin_records);
@@ -1544,13 +1583,14 @@ void nv_attach_impl::clear_patched_state_for_next_session()
 		}
 		{
 			std::lock_guard<std::mutex> g(launch_event_mutex);
-			for (auto &kv : pending_launch_events_by_stream) {
-				if (kv.second)
-					cuEventDestroy(kv.second);
-			}
-			pending_launch_events_by_stream.clear();
+			for (const auto &entry : pending_launch_events)
+				old_launch_events.emplace_back(entry.first,
+							       entry.second);
+			pending_launch_events.clear();
 		}
 	}
+	for (const auto &entry : old_launch_events)
+		destroy_cuda_event(entry.first.first, entry.second);
 	// Let old_records destruct (cuModuleUnload) outside locks.
 	old_records.clear();
 }
@@ -1568,7 +1608,7 @@ void nv_attach_impl::build_host_symbol_cache_once()
 
 		auto modules = elf_introspect::list_loaded_modules();
 		for (const auto &mod : modules) {
-			auto syms = elf_introspect::read_function_symbols(mod);
+			auto syms = elf_introspect::read_symbols(mod);
 			for (auto &sym : syms) {
 				if (sym.name.empty() || sym.start == 0)
 					continue;
@@ -1603,6 +1643,20 @@ nv_attach_impl::resolve_host_function_symbol(void *addr)
 			s.erase(0, strlen(kStubPrefix));
 			if (!s.empty() && s[0] != '_')
 				s.insert(s.begin(), '_');
+		}
+		// nvcc registers file-local device variables by their source
+		// name, while ELF exposes the host placeholder as
+		// `_ZL<len><name>`.
+		if (s.rfind("_ZL", 0) == 0) {
+			size_t pos = 3;
+			size_t name_length = 0;
+			while (pos < s.size() && s[pos] >= '0' &&
+			       s[pos] <= '9') {
+				name_length = name_length * 10 + (s[pos] - '0');
+				pos++;
+			}
+			if (name_length != 0 && pos + name_length == s.size())
+				return s.substr(pos, name_length);
 		}
 		return s;
 	};

--- a/attach/nv_attach_impl/nv_attach_impl.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl.cpp
@@ -307,9 +307,6 @@ nv_attach_impl::nv_attach_impl()
 				     dlerror());
 		}
 	}
-	this->module_pool = std::make_shared<
-		std::map<fatbin_record::module_key,
-			 std::shared_ptr<ptx_in_module>>>();
 	this->ptx_pool =
 		std::make_shared<std::map<std::string, std::vector<uint8_t>>>();
 
@@ -646,7 +643,7 @@ std::optional<CUfunction> nv_attach_impl::find_patched_kernel_function(
 					kernel_name);
 				return std::nullopt;
 			}
-			resolved = info->func;
+			resolved = *info;
 		}
 	}
 	if (!resolved)
@@ -1381,7 +1378,6 @@ void nv_attach_impl::mirror_cuda_memcpy_to_symbol(
 					.symbol_name = *name,
 					.ptr = it->second.first,
 					.size = it->second.second,
-					.ptx = nullptr,
 				};
 			}
 		}
@@ -1620,11 +1616,6 @@ void nv_attach_impl::clear_patched_state_for_next_session()
 			std::lock_guard<std::mutex> g(
 				patched_global_cache_mutex);
 			patched_global_by_context.clear();
-		}
-		{
-			std::lock_guard<std::mutex> g(module_cache_mutex);
-			if (module_pool)
-				module_pool->clear();
 		}
 		{
 			std::lock_guard<std::mutex> g(ptx_cache_mutex);
@@ -1880,7 +1871,6 @@ void nv_attach_impl::bootstrap_existing_fatbins()
 							fatbin_record>();
 						rec->original_ptx = std::move(
 							extracted_ptx);
-						rec->module_pool = module_pool;
 						rec->ptx_pool = ptx_pool;
 						fatbin_records.emplace_back(
 							std::move(rec));
@@ -1917,7 +1907,6 @@ void nv_attach_impl::bootstrap_existing_fatbins()
 
 				auto rec = std::make_unique<fatbin_record>();
 				rec->original_ptx = std::move(extracted_ptx);
-				rec->module_pool = module_pool;
 				rec->ptx_pool = ptx_pool;
 				fatbin_records.emplace_back(std::move(rec));
 				ingested++;
@@ -1933,7 +1922,6 @@ void nv_attach_impl::bootstrap_existing_fatbins()
 		if (!extracted_ptx.empty()) {
 			auto rec = std::make_unique<fatbin_record>();
 			rec->original_ptx = std::move(extracted_ptx);
-			rec->module_pool = module_pool;
 			rec->ptx_pool = ptx_pool;
 			fatbin_records.emplace_back(std::move(rec));
 			ingested++;

--- a/attach/nv_attach_impl/nv_attach_impl.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl.cpp
@@ -130,7 +130,11 @@ extern GType cuda_runtime_function_hooker_get_type();
 
 int nv_attach_impl::detach_by_id(int id)
 {
+	std::lock_guard<std::mutex> writer_guard(patched_state_writer_mutex);
+	const bool was_enabled = is_enabled();
+	enabled.store(false, std::memory_order_release);
 	std::unique_lock<std::shared_mutex> state_guard(patched_state_mutex);
+	enabled.store(was_enabled, std::memory_order_release);
 	bool last_entry = false;
 	{
 		std::lock_guard<std::mutex> guard(hook_entries_mutex);
@@ -198,8 +202,13 @@ int nv_attach_impl::create_attach_with_ebpf_callback(
 		}
 	}
 	if (matched) {
+		std::lock_guard<std::mutex> writer_guard(
+			patched_state_writer_mutex);
+		const bool was_enabled = is_enabled();
+		enabled.store(false, std::memory_order_release);
 		std::unique_lock<std::shared_mutex> state_guard(
 			patched_state_mutex);
+		enabled.store(was_enabled, std::memory_order_release);
 		auto id = this->allocate_id();
 		nv_attach_entry entry;
 		entry.instuctions = data.instructions;
@@ -1338,6 +1347,8 @@ void nv_attach_impl::mirror_cuda_memcpy_to_symbol(
 	const void *symbol, const void *src, size_t count, size_t offset,
 	cudaMemcpyKind kind, cudaStream_t stream, bool async)
 {
+	if (!is_enabled())
+		return;
 	auto state_guard = lock_patched_state();
 	if (!is_enabled())
 		return;

--- a/attach/nv_attach_impl/nv_attach_impl.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl.cpp
@@ -11,6 +11,7 @@
 #include "nv_elf_introspect.hpp"
 // #include "spdlog/common.h"
 #include "spdlog/spdlog.h"
+#include <algorithm>
 #include <asm/unistd.h> // For architecture-specific syscall numbers
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/post.hpp>
@@ -35,8 +36,6 @@
 #include <map>
 #include <memory>
 #include <mutex>
-#include <set>
-#include <regex>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -288,7 +287,8 @@ nv_attach_impl::nv_attach_impl()
 		}
 	}
 	this->module_pool = std::make_shared<
-		std::map<std::string, std::shared_ptr<ptx_in_module>>>();
+		std::map<fatbin_record::module_key,
+			 std::shared_ptr<ptx_in_module>>>();
 	this->ptx_pool =
 		std::make_shared<std::map<std::string, std::vector<uint8_t>>>();
 
@@ -592,26 +592,37 @@ void nv_attach_impl::record_patched_kernel_function(
 {
 	if (kernel_name.empty() || function == nullptr)
 		return;
-	std::lock_guard<std::mutex> guard(cuda_symbol_map_mutex);
-	auto itr = patched_kernel_by_name.find(kernel_name);
-	if (itr == patched_kernel_by_name.end()) {
-		patched_kernel_by_name.emplace(kernel_name, function);
+	CUcontext context = nullptr;
+	if (cuCtxGetCurrent(&context) != CUDA_SUCCESS || context == nullptr)
 		return;
-	}
-	if (itr->second != function)
-		itr->second = function;
+	std::lock_guard<std::mutex> guard(cuda_symbol_map_mutex);
+	patched_kernel_by_context[{ context, kernel_name }] = function;
 }
 
 std::optional<CUfunction> nv_attach_impl::find_patched_kernel_function(
-	const std::string &kernel_name) const
+	const std::string &kernel_name)
 {
 	if (kernel_name.empty())
 		return std::nullopt;
-	std::lock_guard<std::mutex> guard(cuda_symbol_map_mutex);
-	auto itr = patched_kernel_by_name.find(kernel_name);
-	if (itr == patched_kernel_by_name.end())
+	CUcontext context = nullptr;
+	if (cuCtxGetCurrent(&context) != CUDA_SUCCESS || context == nullptr)
 		return std::nullopt;
-	return itr->second;
+	{
+		std::lock_guard<std::mutex> guard(cuda_symbol_map_mutex);
+		if (auto itr = patched_kernel_by_context.find(
+			    { context, kernel_name });
+		    itr != patched_kernel_by_context.end())
+			return itr->second;
+	}
+	for (const auto &record : fatbin_records) {
+		if (auto info = record->find_function_info(*this, kernel_name);
+		    info) {
+			record_patched_kernel_function(kernel_name, info->func);
+			record_original_cufunction_name(info->func, kernel_name);
+			return info->func;
+		}
+	}
+	return std::nullopt;
 }
 
 void nv_attach_impl::record_original_cufunction_name(
@@ -891,12 +902,12 @@ nv_attach_impl::hack_fatbin(std::map<std::string, std::string> all_ptx)
 	/**
 	Here we can patch the PTX.
 	*/
-	boost::asio::thread_pool pool(std::thread::hardware_concurrency());
+	boost::asio::thread_pool pool(
+		std::max(1u, std::thread::hardware_concurrency()));
 	std::map<std::string, std::tuple<std::string, bool>> ptx_out;
 	std::mutex map_mutex;
-	std::mutex cache_mutex;
 	for (auto &[file_name, original_ptx] : all_ptx) {
-		boost::asio::post(pool, [this, original_ptx, file_name, &map_mutex, &ptx_out, &cache_mutex]() -> void {
+		boost::asio::post(pool, [this, original_ptx, file_name, &map_mutex, &ptx_out]() -> void {
 			auto current_ptx = original_ptx;
 			SPDLOG_INFO("Patching PTX: {}", file_name);
 			bool should_add_trampoline = false;
@@ -938,17 +949,22 @@ nv_attach_impl::hack_fatbin(std::map<std::string, std::string> all_ptx)
 					ptxpass::runtime_response::RuntimeResponse
 						resp;
 
-					cache_mutex.lock();
-					if (auto itr = this->patch_cache.find(
-						    sha256_string);
-					    itr != this->patch_cache.end()) {
+					bool cache_hit = false;
+					{
+						std::lock_guard<std::mutex> guard(
+							patch_cache_mutex);
+						if (auto itr = patch_cache.find(
+							    sha256_string);
+						    itr != patch_cache.end()) {
+							resp = itr->second;
+							cache_hit = true;
+						}
+					}
+					if (cache_hit) {
 						SPDLOG_INFO(
 							"Patching request {} found in cache",
 							sha256_string);
-						resp = itr->second;
-						cache_mutex.unlock();
 					} else {
-						cache_mutex.unlock();
 						SPDLOG_INFO(
 							"Patching request {} not found in cache, patching..",
 							sha256_string);
@@ -1025,7 +1041,7 @@ nv_attach_impl::hack_fatbin(std::map<std::string, std::string> all_ptx)
 						}
 						std::lock_guard<std::mutex>
 							_cache_guard(
-								cache_mutex);
+								patch_cache_mutex);
 						patch_cache[sha256_string] =
 							resp;
 					}
@@ -1273,15 +1289,14 @@ void nv_attach_impl::mirror_cuda_memcpy_to_symbol(
 	bootstrap_existing_fatbins_once();
 
 	std::optional<variable_info> resolved_var;
+	CUcontext context = nullptr;
+	if (cuCtxGetCurrent(&context) != CUDA_SUCCESS || context == nullptr)
+		return;
 
 	if (auto record_itr = symbol_address_to_fatbin.find((void *)symbol);
 	    record_itr != symbol_address_to_fatbin.end()) {
 		auto &record = *record_itr->second;
-		auto var_itr =
-			record.variable_addr_to_symbol.find((void *)symbol);
-		if (var_itr != record.variable_addr_to_symbol.end()) {
-			resolved_var = var_itr->second;
-		}
+		resolved_var = record.find_variable_info(*this, (void *)symbol);
 	}
 
 	if (!resolved_var) {
@@ -1293,8 +1308,9 @@ void nv_attach_impl::mirror_cuda_memcpy_to_symbol(
 		{
 			std::lock_guard<std::mutex> guard(
 				patched_global_cache_mutex);
-			auto it = patched_global_by_name.find(*name);
-			if (it != patched_global_by_name.end()) {
+			auto it = patched_global_by_context.find(
+				{ context, *name });
+			if (it != patched_global_by_context.end()) {
 				resolved_var = variable_info{
 					.symbol_name = *name,
 					.ptr = it->second.first,
@@ -1308,33 +1324,15 @@ void nv_attach_impl::mirror_cuda_memcpy_to_symbol(
 				auto *rec = rec_uptr.get();
 				if (rec == nullptr)
 					continue;
-				for (const auto &ptx : rec->ptxs) {
-					CUdeviceptr dptr;
-					size_t sz;
-					auto err = cuModuleGetGlobal(
-						&dptr, &sz, ptx->module_ptr,
-						name->c_str());
-					if (err == CUDA_SUCCESS) {
-						{
-							std::lock_guard<
-								std::mutex>
-								guard(patched_global_cache_mutex);
-							patched_global_by_name[*name] =
-								std::make_pair(
-									dptr,
-									sz);
-						}
-						resolved_var = variable_info{
-							.symbol_name = *name,
-							.ptr = dptr,
-							.size = sz,
-							.ptx = nullptr,
-						};
-						break;
-					}
-				}
-				if (resolved_var)
+				resolved_var = rec->find_variable_info(*this, *name);
+				if (resolved_var) {
+					std::lock_guard<std::mutex> guard(
+						patched_global_cache_mutex);
+					patched_global_by_context[{ context, *name }] =
+						{ resolved_var->ptr,
+						  resolved_var->size };
 					break;
+				}
 			}
 		}
 	}
@@ -1520,21 +1518,30 @@ void nv_attach_impl::clear_patched_state_for_next_session()
 		old_records.swap(fatbin_records);
 		current_fatbin = nullptr;
 		symbol_address_to_fatbin.clear();
-		patch_cache.clear();
+		{
+			std::lock_guard<std::mutex> g(patch_cache_mutex);
+			patch_cache.clear();
+		}
 		{
 			std::lock_guard<std::mutex> g(cuda_symbol_map_mutex);
-			patched_kernel_by_name.clear();
+			patched_kernel_by_context.clear();
 			kernel_name_by_cufunction.clear();
 		}
 		{
 			std::lock_guard<std::mutex> g(
 				patched_global_cache_mutex);
-			patched_global_by_name.clear();
+			patched_global_by_context.clear();
 		}
-		if (module_pool)
-			module_pool->clear();
-		if (ptx_pool)
-			ptx_pool->clear();
+		{
+			std::lock_guard<std::mutex> g(module_cache_mutex);
+			if (module_pool)
+				module_pool->clear();
+		}
+		{
+			std::lock_guard<std::mutex> g(ptx_cache_mutex);
+			if (ptx_pool)
+				ptx_pool->clear();
+		}
 		{
 			std::lock_guard<std::mutex> g(launch_event_mutex);
 			for (auto &kv : pending_launch_events_by_stream) {
@@ -1551,37 +1558,6 @@ void nv_attach_impl::clear_patched_state_for_next_session()
 bool nv_attach_impl::is_enabled() const noexcept
 {
 	return enabled.load(std::memory_order_acquire);
-}
-
-std::vector<std::string> nv_attach_impl::collect_all_kernels_to_patch() const
-{
-	std::vector<std::string> kernels;
-	for (const auto &[_, entry] : hook_entries) {
-		for (const auto &k : entry.kernels) {
-			kernels.push_back(k);
-		}
-	}
-	std::sort(kernels.begin(), kernels.end());
-	kernels.erase(std::unique(kernels.begin(), kernels.end()),
-		      kernels.end());
-	return kernels;
-}
-
-static std::vector<std::string>
-collect_ptx_entry_functions(const std::map<std::string, std::string> &all_ptx)
-{
-	static const std::regex kernel_entry(
-		R"((?:\.visible\s+)?\.entry\s+([A-Za-z_.$][A-Za-z0-9_.$]*)\s*\()");
-	std::set<std::string> entries;
-	for (const auto &[_, ptx] : all_ptx) {
-		for (std::sregex_iterator it(ptx.begin(), ptx.end(),
-					     kernel_entry),
-		     end;
-		     it != end; ++it) {
-			entries.insert((*it)[1].str());
-		}
-	}
-	return std::vector<std::string>(entries.begin(), entries.end());
 }
 
 void nv_attach_impl::build_host_symbol_cache_once()
@@ -1654,39 +1630,6 @@ nv_attach_impl::resolve_host_function_symbol(void *addr)
 			return std::nullopt;
 	}
 	return normalize_cuda_stub(it->name);
-}
-
-void nv_attach_impl::prefill_patched_kernel_functions_from_loaded_fatbins()
-{
-	if (fatbin_records.empty())
-		return;
-
-	for (const auto &rec_uptr : fatbin_records) {
-		auto *rec = rec_uptr.get();
-		if (rec == nullptr)
-			continue;
-		auto kernels = collect_ptx_entry_functions(rec->original_ptx);
-		if (kernels.empty())
-			kernels = collect_all_kernels_to_patch();
-		if (kernels.empty())
-			continue;
-		for (const auto &ptx : rec->ptxs) {
-			for (const auto &kernel : kernels) {
-				CUfunction func = nullptr;
-				auto err = cuModuleGetFunction(
-					&func, ptx->module_ptr, kernel.c_str());
-				if (err == CUDA_SUCCESS && func != nullptr) {
-					record_patched_kernel_function(kernel,
-								       func);
-					record_original_cufunction_name(func,
-									kernel);
-					SPDLOG_DEBUG(
-						"Prefilled patched CUDA kernel {}",
-						kernel);
-				}
-			}
-		}
-	}
 }
 
 namespace
@@ -1819,7 +1762,6 @@ void nv_attach_impl::bootstrap_existing_fatbins()
 						std::move(extracted_ptx);
 					rec->module_pool = module_pool;
 					rec->ptx_pool = ptx_pool;
-					rec->try_loading_ptxs(*this);
 					fatbin_records.emplace_back(
 						std::move(rec));
 					ingested++;
@@ -1856,7 +1798,6 @@ void nv_attach_impl::bootstrap_existing_fatbins()
 				rec->original_ptx = std::move(extracted_ptx);
 				rec->module_pool = module_pool;
 				rec->ptx_pool = ptx_pool;
-				rec->try_loading_ptxs(*this);
 				fatbin_records.emplace_back(std::move(rec));
 				ingested++;
 			}
@@ -1873,7 +1814,6 @@ void nv_attach_impl::bootstrap_existing_fatbins()
 			rec->original_ptx = std::move(extracted_ptx);
 			rec->module_pool = module_pool;
 			rec->ptx_pool = ptx_pool;
-			rec->try_loading_ptxs(*this);
 			fatbin_records.emplace_back(std::move(rec));
 			ingested++;
 			SPDLOG_INFO(
@@ -1884,7 +1824,6 @@ void nv_attach_impl::bootstrap_existing_fatbins()
 	SPDLOG_INFO(
 		"nv_attach_impl: late attach bootstrap ingested {} fatbin(s)",
 		ingested);
-	prefill_patched_kernel_functions_from_loaded_fatbins();
 }
 
 void nv_attach_impl::bootstrap_existing_fatbins_once()

--- a/attach/nv_attach_impl/nv_attach_impl.hpp
+++ b/attach/nv_attach_impl/nv_attach_impl.hpp
@@ -128,8 +128,6 @@ struct nv_attach_hook_state {
 	std::atomic<void *> orig_cu_graph_exec_kernel_node_set_params_v2{ nullptr };
 	std::atomic<void *> orig_cu_graph_kernel_node_set_params_v1{ nullptr };
 	std::atomic<void *> orig_cu_graph_kernel_node_set_params_v2{ nullptr };
-	std::atomic<void *> orig_cu_graph_launch{ nullptr };
-	std::atomic<void *> orig_cu_graph_launch_ptsz{ nullptr };
 	std::atomic<void *> orig_cuda_memcpy_from_symbol{ nullptr };
 	std::atomic<void *> orig_cuda_memcpy_from_symbol_async{ nullptr };
 
@@ -180,6 +178,8 @@ class nv_attach_impl final : public base_attach_impl {
 					    CUfunction function);
 	std::optional<CUfunction>
 	find_patched_kernel_function(const std::string &kernel_name);
+	std::optional<variable_info>
+	find_patched_global(const std::string &symbol_name);
 	// Notify nv_attach_impl that a patched kernel launch was enqueued on a
 	// stream. Used to coordinate detach with in-flight patched kernels so we
 	// don't tear down loader-owned CUDA IPC buffers prematurely.
@@ -208,7 +208,7 @@ class nv_attach_impl final : public base_attach_impl {
 	std::optional<std::vector<MapBasicInfo>> map_basic_info;
 	void *ptx_compiler_dl_handle = nullptr;
 	nv_attach_impl_ptx_compiler_handler ptx_compiler;
-	/// CUDA context + SHA256 of ELF -> PTX module
+	/// CUDA context + fatbin identity + SHA256 of ELF -> PTX module
 	std::shared_ptr<std::map<fatbin_record::module_key,
 				 std::shared_ptr<ptx_in_module>>>
 		module_pool;

--- a/attach/nv_attach_impl/nv_attach_impl.hpp
+++ b/attach/nv_attach_impl/nv_attach_impl.hpp
@@ -246,6 +246,7 @@ class nv_attach_impl final : public base_attach_impl {
 	void *frida_listener;
 	std::vector<std::unique_ptr<CUDARuntimeFunctionHookerContext>>
 		hooker_contexts;
+	mutable std::mutex hook_entries_mutex;
 	std::map<int, nv_attach_entry> hook_entries;
 	// discovered pass definitions
 	std::vector<std::unique_ptr<pass_cfg_with_exec_path>>

--- a/attach/nv_attach_impl/nv_attach_impl.hpp
+++ b/attach/nv_attach_impl/nv_attach_impl.hpp
@@ -128,6 +128,8 @@ struct nv_attach_hook_state {
 	std::atomic<void *> orig_cu_graph_exec_kernel_node_set_params_v2{ nullptr };
 	std::atomic<void *> orig_cu_graph_kernel_node_set_params_v1{ nullptr };
 	std::atomic<void *> orig_cu_graph_kernel_node_set_params_v2{ nullptr };
+	std::atomic<void *> orig_cu_graph_launch{ nullptr };
+	std::atomic<void *> orig_cu_graph_launch_ptsz{ nullptr };
 	std::atomic<void *> orig_cuda_memcpy_from_symbol{ nullptr };
 	std::atomic<void *> orig_cuda_memcpy_from_symbol_async{ nullptr };
 
@@ -281,7 +283,8 @@ class nv_attach_impl final : public base_attach_impl {
 			patched_global_by_context;
 
 		mutable std::mutex launch_event_mutex;
-		std::unordered_map<CUstream, CUevent> pending_launch_events_by_stream;
+		std::map<std::pair<CUcontext, CUstream>, CUevent>
+			pending_launch_events;
 	};
 
 std::string add_semicolon_for_variable_lines(std::string input);

--- a/attach/nv_attach_impl/nv_attach_impl.hpp
+++ b/attach/nv_attach_impl/nv_attach_impl.hpp
@@ -207,6 +207,7 @@ class nv_attach_impl final : public base_attach_impl {
 		return std::shared_lock(patched_state_mutex);
 	}
 	std::vector<std::unique_ptr<fatbin_record>> fatbin_records;
+	std::size_t late_bootstrap_generation = 0;
 	fatbin_record *current_fatbin = nullptr;
 	std::map<void *, fatbin_record *> symbol_address_to_fatbin;
 	uintptr_t shared_mem_ptr;
@@ -239,6 +240,7 @@ class nv_attach_impl final : public base_attach_impl {
 		void clear_patched_state_for_next_session();
 
 		void bootstrap_existing_fatbins();
+		std::vector<fatbin_record *> active_fatbin_records();
 		void reset_late_bootstrap_state_for_next_attach();
 		void build_host_symbol_cache_once();
 

--- a/attach/nv_attach_impl/nv_attach_impl.hpp
+++ b/attach/nv_attach_impl/nv_attach_impl.hpp
@@ -251,6 +251,7 @@ class nv_attach_impl final : public base_attach_impl {
 	void *frida_listener;
 	std::vector<std::unique_ptr<CUDARuntimeFunctionHookerContext>>
 		hooker_contexts;
+	mutable std::mutex patched_state_writer_mutex;
 	mutable std::shared_mutex patched_state_mutex;
 	mutable std::mutex hook_entries_mutex;
 	std::map<int, nv_attach_entry> hook_entries;

--- a/attach/nv_attach_impl/nv_attach_impl.hpp
+++ b/attach/nv_attach_impl/nv_attach_impl.hpp
@@ -177,7 +177,7 @@ class nv_attach_impl final : public base_attach_impl {
 	void record_patched_kernel_function(const std::string &kernel_name,
 					    CUfunction function);
 	std::optional<CUfunction>
-	find_patched_kernel_function(const std::string &kernel_name) const;
+	find_patched_kernel_function(const std::string &kernel_name);
 	// Notify nv_attach_impl that a patched kernel launch was enqueued on a
 	// stream. Used to coordinate detach with in-flight patched kernels so we
 	// don't tear down loader-owned CUDA IPC buffers prematurely.
@@ -206,11 +206,14 @@ class nv_attach_impl final : public base_attach_impl {
 	std::optional<std::vector<MapBasicInfo>> map_basic_info;
 	void *ptx_compiler_dl_handle = nullptr;
 	nv_attach_impl_ptx_compiler_handler ptx_compiler;
-	/// SHA256 of ELF -> PTX module
-	std::shared_ptr<std::map<std::string, std::shared_ptr<ptx_in_module>>>
+	/// CUDA context + SHA256 of ELF -> PTX module
+	std::shared_ptr<std::map<fatbin_record::module_key,
+				 std::shared_ptr<ptx_in_module>>>
 		module_pool;
 	/// SHA256 of PTX -> ELF
 	std::shared_ptr<std::map<std::string, std::vector<uint8_t>>> ptx_pool;
+	std::mutex module_cache_mutex;
+	std::mutex ptx_cache_mutex;
 
 	// Original function pointers for Frida replace hooks (trampolines)
 	// They are set by gum_interceptor_replace(...) and must be used to call
@@ -236,8 +239,6 @@ class nv_attach_impl final : public base_attach_impl {
 		void bootstrap_existing_fatbins();
 		void reset_late_bootstrap_state_for_next_attach();
 		void build_host_symbol_cache_once();
-		void prefill_patched_kernel_functions_from_loaded_fatbins();
-		std::vector<std::string> collect_all_kernels_to_patch() const;
 
 	void *frida_interceptor;
 	void *frida_listener;
@@ -249,8 +250,10 @@ class nv_attach_impl final : public base_attach_impl {
 		pass_configurations;
 	std::map<std::string, ptxpass::runtime_response::RuntimeResponse>
 		patch_cache;
+	std::mutex patch_cache_mutex;
 	mutable std::mutex cuda_symbol_map_mutex;
-	std::unordered_map<std::string, CUfunction> patched_kernel_by_name;
+	std::map<std::pair<CUcontext, std::string>, CUfunction>
+		patched_kernel_by_context;
 	std::unordered_map<CUfunction, std::string> kernel_name_by_cufunction;
 
 			std::atomic<bool> enabled{ true };
@@ -273,8 +276,9 @@ class nv_attach_impl final : public base_attach_impl {
 	std::vector<host_symbol_range> host_symbol_ranges;
 
 		mutable std::mutex patched_global_cache_mutex;
-		std::unordered_map<std::string, std::pair<CUdeviceptr, size_t>>
-			patched_global_by_name;
+		std::map<std::pair<CUcontext, std::string>,
+			 std::pair<CUdeviceptr, size_t>>
+			patched_global_by_context;
 
 		mutable std::mutex launch_event_mutex;
 		std::unordered_map<CUstream, CUevent> pending_launch_events_by_stream;

--- a/attach/nv_attach_impl/nv_attach_impl.hpp
+++ b/attach/nv_attach_impl/nv_attach_impl.hpp
@@ -18,6 +18,7 @@
 #include <cuda.h>
 #include <optional>
 #include <set>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 #include <sys/ptrace.h>
@@ -201,6 +202,10 @@ class nv_attach_impl final : public base_attach_impl {
 		std::optional<std::string> resolve_host_function_symbol(void *addr);
 	// Whether nv_attach is currently enabled (can be disabled by detach).
 	bool is_enabled() const noexcept;
+	std::shared_lock<std::shared_mutex> lock_patched_state() const
+	{
+		return std::shared_lock(patched_state_mutex);
+	}
 	std::vector<std::unique_ptr<fatbin_record>> fatbin_records;
 	fatbin_record *current_fatbin = nullptr;
 	std::map<void *, fatbin_record *> symbol_address_to_fatbin;
@@ -246,6 +251,7 @@ class nv_attach_impl final : public base_attach_impl {
 	void *frida_listener;
 	std::vector<std::unique_ptr<CUDARuntimeFunctionHookerContext>>
 		hooker_contexts;
+	mutable std::shared_mutex patched_state_mutex;
 	mutable std::mutex hook_entries_mutex;
 	std::map<int, nv_attach_entry> hook_entries;
 	// discovered pass definitions

--- a/attach/nv_attach_impl/nv_attach_impl.hpp
+++ b/attach/nv_attach_impl/nv_attach_impl.hpp
@@ -213,13 +213,8 @@ class nv_attach_impl final : public base_attach_impl {
 	std::optional<std::vector<MapBasicInfo>> map_basic_info;
 	void *ptx_compiler_dl_handle = nullptr;
 	nv_attach_impl_ptx_compiler_handler ptx_compiler;
-	/// CUDA context + fatbin identity + SHA256 of ELF -> PTX module
-	std::shared_ptr<std::map<fatbin_record::module_key,
-				 std::shared_ptr<ptx_in_module>>>
-		module_pool;
 	/// SHA256 of PTX -> ELF
 	std::shared_ptr<std::map<std::string, std::vector<uint8_t>>> ptx_pool;
-	std::mutex module_cache_mutex;
 	std::mutex ptx_cache_mutex;
 
 	// Original function pointers for Frida replace hooks (trampolines)

--- a/attach/nv_attach_impl/nv_attach_impl_frida_setup.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl_frida_setup.cpp
@@ -164,12 +164,14 @@ cuda_launch_kernel_common(nv_attach_impl *impl, void *original_fn_ptr,
 
 	if (auto itr1 = impl->symbol_address_to_fatbin.find((void *)func);
 	    itr1 != impl->symbol_address_to_fatbin.end()) {
-		const auto &fatbin = *itr1->second;
-		const auto &handle =
-			fatbin.function_addr_to_symbol.at((void *)func);
+		auto &fatbin = *itr1->second;
+		auto handle = fatbin.find_function_info(*impl, (void *)func);
+		if (!handle)
+			return original(func, grid_dim, block_dim, args,
+					shared_mem, stream);
 		SPDLOG_DEBUG("Launching kernel..");
 		if (auto err = cuLaunchKernel(
-			    handle.func, grid_dim.x, grid_dim.y, grid_dim.z,
+			    handle->func, grid_dim.x, grid_dim.y, grid_dim.z,
 			    block_dim.x, block_dim.y, block_dim.z, shared_mem,
 			    stream, args, nullptr);
 		    err != CUDA_SUCCESS) {
@@ -182,7 +184,7 @@ cuda_launch_kernel_common(nv_attach_impl *impl, void *original_fn_ptr,
 				     error_string ? error_string :
 						    "No description");
 			SPDLOG_ERROR("Error code: {}", (int)err);
-			log_cufunc_attrs(handle.func);
+			log_cufunc_attrs(handle->func);
 			// Preserve target semantics: fall back to the original
 			// runtime launch path if patched launch fails.
 			return original(func, grid_dim, block_dim, args,
@@ -292,9 +294,7 @@ static void example_listener_on_enter(GumInvocationListener *listener,
 	} else if (context->to_function ==
 		   AttachedToFunction::RegisterFunction) {
 		SPDLOG_DEBUG("Entering __cudaRegisterFunction..");
-		auto &impl = *context->impl;
 		auto current_fatbin = context->impl->current_fatbin;
-		current_fatbin->try_loading_ptxs(*context->impl);
 
 		auto func_addr =
 			gum_invocation_context_get_nth_argument(gum_ctx, 1);
@@ -310,13 +310,6 @@ static void example_listener_on_enter(GumInvocationListener *listener,
 		} else {
 			context->impl->symbol_address_to_fatbin[func_addr] =
 				current_fatbin;
-			if (auto itr = current_fatbin->function_addr_to_symbol
-					       .find(func_addr);
-			    itr !=
-			    current_fatbin->function_addr_to_symbol.end())
-				impl.record_patched_kernel_function(
-					std::string(symbol_name),
-					itr->second.func);
 			SPDLOG_DEBUG(
 				"Registered kernel function name {} addr {:x}",
 				symbol_name, (uintptr_t)func_addr);
@@ -326,7 +319,6 @@ static void example_listener_on_enter(GumInvocationListener *listener,
 		   AttachedToFunction::RegisterVariable) {
 		SPDLOG_DEBUG("Entering __cudaRegisterVar");
 		auto current_fatbin = context->impl->current_fatbin;
-		current_fatbin->try_loading_ptxs(*context->impl);
 		auto fatbin_handle =
 			gum_invocation_context_get_nth_argument(gum_ctx, 0);
 		auto var_addr =
@@ -780,91 +772,25 @@ static cudaError_t mirror_cuda_memcpy_from_symbol(
 	cuda_memcpy_from_symbol_fn_t original_sync,
 	cuda_memcpy_from_symbol_async_fn_t original_async)
 {
+	std::optional<variable_info> resolved_var;
 	auto record_itr = impl->symbol_address_to_fatbin.find((void *)symbol);
-	if (record_itr == impl->symbol_address_to_fatbin.end()) {
+	if (record_itr != impl->symbol_address_to_fatbin.end()) {
+		resolved_var = record_itr->second->find_variable_info(
+			*impl, (void *)symbol);
+	} else {
 		impl->bootstrap_existing_fatbins_once();
-
-		// Late attach fallback: resolve host symbol name and read from
-		// a patched module global if present.
 		if (auto name =
 			    impl->resolve_host_function_symbol((void *)symbol);
 		    name) {
 			for (const auto &rec_uptr : impl->fatbin_records) {
-				auto *rec = rec_uptr.get();
-				if (rec == nullptr)
-					continue;
-				for (const auto &ptx : rec->ptxs) {
-					CUdeviceptr dptr;
-					size_t sz;
-					auto err = cuModuleGetGlobal(
-						&dptr, &sz, ptx->module_ptr,
-						name->c_str());
-					if (err != CUDA_SUCCESS)
-						continue;
-					if (offset >= sz) {
-						SPDLOG_WARN(
-							"mirror_cuda_memcpy_from_symbol: offset {} exceeds size {} for symbol {}",
-							offset, sz,
-							name->c_str());
-						return cudaErrorUnknown;
-					}
-					size_t writable = sz - offset;
-					size_t bytes_to_copy =
-						std::min(count, writable);
-					if (bytes_to_copy == 0)
-						return cudaErrorUnknown;
-					CUdeviceptr src = dptr + offset;
-					CUstream cu_stream =
-						reinterpret_cast<CUstream>(
-							stream);
-					CUresult status = CUDA_SUCCESS;
-
-					auto copy_device_ptr =
-						[](const void *ptr)
-						-> CUdeviceptr {
-						return static_cast<CUdeviceptr>(
-							reinterpret_cast<
-								uintptr_t>(
-								ptr));
-					};
-					switch (kind) {
-					case cudaMemcpyDeviceToHost:
-					case cudaMemcpyDefault:
-						status =
-							async ? cuMemcpyDtoHAsync(
-									dst,
-									src,
-									bytes_to_copy,
-									cu_stream) :
-								cuMemcpyDtoH(
-									dst,
-									src,
-									bytes_to_copy);
-						break;
-					case cudaMemcpyDeviceToDevice:
-						status =
-							async ? cuMemcpyDtoDAsync(
-									copy_device_ptr(
-										dst),
-									src,
-									bytes_to_copy,
-									cu_stream) :
-								cuMemcpyDtoD(
-									copy_device_ptr(
-										dst),
-									src,
-									bytes_to_copy);
-						break;
-					default:
-						return cudaErrorUnknown;
-					}
-					if (status != CUDA_SUCCESS)
-						return cudaErrorUnknown;
-					return cudaSuccess;
-				}
+				resolved_var =
+					rec_uptr->find_variable_info(*impl, *name);
+				if (resolved_var)
+					break;
 			}
 		}
-
+	}
+	if (!resolved_var) {
 		SPDLOG_DEBUG(
 			"In mirror_cuda_memcpy_from_symbol: calling original cudaMemcpyFromSymbol");
 		if (async) {
@@ -881,15 +807,7 @@ static cudaError_t mirror_cuda_memcpy_from_symbol(
 		}
 		return cudaErrorUnknown;
 	}
-	auto &record = *record_itr->second;
-	auto var_itr = record.variable_addr_to_symbol.find((void *)symbol);
-	if (var_itr == record.variable_addr_to_symbol.end()) {
-		SPDLOG_DEBUG(
-			"mirror_cuda_memcpy_from_symbol: no variable info for symbol pointer {:x}",
-			(uintptr_t)symbol);
-		return cudaErrorUnknown;
-	}
-	auto &var_info = var_itr->second;
+	auto &var_info = *resolved_var;
 	if (offset >= var_info.size) {
 		SPDLOG_WARN(
 			"mirror_cuda_memcpy_from_symbol: offset {} exceeds size {} for symbol {}",

--- a/attach/nv_attach_impl/nv_attach_impl_frida_setup.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl_frida_setup.cpp
@@ -66,7 +66,6 @@ using cu_graph_kernel_node_set_params_v1_fn_t =
 	CUresult (*)(CUgraphNode, const CUDA_KERNEL_NODE_PARAMS_v1 *);
 using cu_graph_kernel_node_set_params_v2_fn_t =
 	decltype(&cuGraphKernelNodeSetParams_v2);
-using cu_graph_launch_fn_t = CUresult (*)(CUgraphExec, CUstream);
 using cuda_memcpy_from_symbol_async_fn_t = decltype(&cudaMemcpyFromSymbolAsync);
 using cuda_memcpy_from_symbol_fn_t = decltype(&cudaMemcpyFromSymbol);
 
@@ -574,50 +573,6 @@ extern "C" CUresult cuda_driver_function__cuLaunchKernel(
 				       extra);
 }
 
-static CUresult cu_graph_launch_common(nv_attach_impl *impl,
-				       void *original_fn_ptr,
-				       CUgraphExec graph_exec, CUstream stream)
-{
-	auto original = reinterpret_cast<cu_graph_launch_fn_t>(original_fn_ptr);
-	if (!original)
-		return CUDA_ERROR_UNKNOWN;
-	auto result = original(graph_exec, stream);
-	if (result == CUDA_SUCCESS && impl != nullptr && impl->is_enabled())
-		impl->record_patched_launch(
-			reinterpret_cast<cudaStream_t>(stream));
-	return result;
-}
-
-extern "C" CUresult cuda_driver_function__cuGraphLaunch(CUgraphExec graph_exec,
-							CUstream stream)
-{
-	auto gum_ctx = gum_interceptor_get_current_invocation();
-	auto *state = (nv_attach_hook_state *)
-		gum_invocation_context_get_replacement_data(gum_ctx);
-	if (state == nullptr)
-		state = &nv_attach_get_hook_state();
-	return cu_graph_launch_common(
-		state->active_impl.load(std::memory_order_acquire),
-		state->orig_cu_graph_launch.load(std::memory_order_acquire),
-		graph_exec, stream);
-}
-
-extern "C" CUresult
-cuda_driver_function__cuGraphLaunch_ptsz(CUgraphExec graph_exec,
-					 CUstream stream)
-{
-	auto gum_ctx = gum_interceptor_get_current_invocation();
-	auto *state = (nv_attach_hook_state *)
-		gum_invocation_context_get_replacement_data(gum_ctx);
-	if (state == nullptr)
-		state = &nv_attach_get_hook_state();
-	return cu_graph_launch_common(
-		state->active_impl.load(std::memory_order_acquire),
-		state->orig_cu_graph_launch_ptsz.load(
-			std::memory_order_acquire),
-		graph_exec, stream);
-}
-
 extern "C" cudaError_t cuda_runtime_function__cudaLaunchKernel_ptsz(
 	const void *func, dim3 grid_dim, dim3 block_dim, void **args,
 	size_t shared_mem, cudaStream_t stream)
@@ -861,12 +816,7 @@ static cudaError_t mirror_cuda_memcpy_from_symbol(
 		if (auto name =
 			    impl->resolve_host_function_symbol((void *)symbol);
 		    name) {
-			for (const auto &rec_uptr : impl->fatbin_records) {
-				resolved_var =
-					rec_uptr->find_variable_info(*impl, *name);
-				if (resolved_var)
-					break;
-			}
+			resolved_var = impl->find_patched_global(*name);
 		}
 	}
 	if (!resolved_var) {

--- a/attach/nv_attach_impl/nv_attach_impl_frida_setup.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl_frida_setup.cpp
@@ -113,6 +113,7 @@ cuda_launch_kernel_common(nv_attach_impl *impl, void *original_fn_ptr,
 	if (impl == nullptr)
 		return original(func, grid_dim, block_dim, args, shared_mem,
 				stream);
+	auto state_guard = impl->lock_patched_state();
 	if (!impl->is_enabled())
 		return original(func, grid_dim, block_dim, args, shared_mem,
 				stream);
@@ -524,6 +525,7 @@ static CUresult cu_launch_kernel_common(
 		return original(func, grid_dim_x, grid_dim_y, grid_dim_z,
 				block_dim_x, block_dim_y, block_dim_z,
 				shared_mem_bytes, stream, kernel_params, extra);
+	auto state_guard = impl->lock_patched_state();
 	if (!impl->is_enabled())
 		return original(func, grid_dim_x, grid_dim_y, grid_dim_z,
 				block_dim_x, block_dim_y, block_dim_z,
@@ -806,6 +808,21 @@ static cudaError_t mirror_cuda_memcpy_from_symbol(
 	cuda_memcpy_from_symbol_fn_t original_sync,
 	cuda_memcpy_from_symbol_async_fn_t original_async)
 {
+	const auto call_original = [&]() {
+		if (async) {
+			if (!original_async)
+				return cudaErrorUnknown;
+			return original_async(dst, symbol, count, offset, kind,
+					      stream);
+		}
+		if (!original_sync)
+			return cudaErrorUnknown;
+		return original_sync(dst, symbol, count, offset, kind);
+	};
+	auto state_guard = impl->lock_patched_state();
+	if (!impl->is_enabled())
+		return call_original();
+
 	std::optional<variable_info> resolved_var;
 	auto record_itr = impl->symbol_address_to_fatbin.find((void *)symbol);
 	if (record_itr != impl->symbol_address_to_fatbin.end()) {
@@ -822,19 +839,7 @@ static cudaError_t mirror_cuda_memcpy_from_symbol(
 	if (!resolved_var) {
 		SPDLOG_DEBUG(
 			"In mirror_cuda_memcpy_from_symbol: calling original cudaMemcpyFromSymbol");
-		if (async) {
-			if (!original_async) {
-				return cudaErrorUnknown;
-			}
-			return original_async(dst, symbol, count, offset, kind,
-					      stream);
-		} else {
-			if (!original_sync) {
-				return cudaErrorUnknown;
-			}
-			return original_sync(dst, symbol, count, offset, kind);
-		}
-		return cudaErrorUnknown;
+		return call_original();
 	}
 	auto &var_info = *resolved_var;
 	if (offset >= var_info.size) {

--- a/attach/nv_attach_impl/nv_attach_impl_frida_setup.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl_frida_setup.cpp
@@ -66,6 +66,7 @@ using cu_graph_kernel_node_set_params_v1_fn_t =
 	CUresult (*)(CUgraphNode, const CUDA_KERNEL_NODE_PARAMS_v1 *);
 using cu_graph_kernel_node_set_params_v2_fn_t =
 	decltype(&cuGraphKernelNodeSetParams_v2);
+using cu_graph_launch_fn_t = CUresult (*)(CUgraphExec, CUstream);
 using cuda_memcpy_from_symbol_async_fn_t = decltype(&cudaMemcpyFromSymbolAsync);
 using cuda_memcpy_from_symbol_fn_t = decltype(&cudaMemcpyFromSymbol);
 
@@ -76,6 +77,16 @@ using cu_launch_kernel_fn_t = CUresult (*)(CUfunction, unsigned int,
 					   unsigned int, unsigned int,
 					   unsigned int, unsigned int, CUstream,
 					   void **, void **);
+
+struct cuda_memcpy_to_symbol_invocation {
+	const void *symbol;
+	const void *src;
+	size_t count;
+	size_t offset;
+	cudaMemcpyKind kind;
+	cudaStream_t stream;
+	bool async;
+};
 
 static bool cuda_graph_stream_is_capturing(cudaStream_t stream)
 {
@@ -375,8 +386,11 @@ static void example_listener_on_enter(GumInvocationListener *listener,
 				gum_invocation_context_get_nth_argument(gum_ctx,
 									5);
 		}
-		context->impl->mirror_cuda_memcpy_to_symbol(
-			symbol, src, count, offset, kind, stream, async);
+		auto *invocation = GUM_IC_GET_INVOCATION_DATA(
+			gum_ctx, cuda_memcpy_to_symbol_invocation);
+		*invocation = {
+			symbol, src, count, offset, kind, stream, async
+		};
 	}
 }
 
@@ -397,6 +411,23 @@ static void example_listener_on_leave(GumInvocationListener *listener,
 	} else if (context->to_function ==
 		   AttachedToFunction::RegisterFatbinEnd) {
 		SPDLOG_DEBUG("Leaving __cudaRegisterFatBinaryEnd..");
+	} else if (context->to_function ==
+			   AttachedToFunction::CudaMemcpyToSymbol ||
+		   context->to_function ==
+			   AttachedToFunction::CudaMemcpyToSymbolAsync) {
+		auto result =
+			static_cast<cudaError_t>(reinterpret_cast<uintptr_t>(
+				gum_invocation_context_get_return_value(
+					gum_ctx)));
+		if (result == cudaSuccess) {
+			auto *invocation = GUM_IC_GET_INVOCATION_DATA(
+				gum_ctx, cuda_memcpy_to_symbol_invocation);
+			context->impl->mirror_cuda_memcpy_to_symbol(
+				invocation->symbol, invocation->src,
+				invocation->count, invocation->offset,
+				invocation->kind, invocation->stream,
+				invocation->async);
+		}
 	}
 }
 
@@ -503,19 +534,23 @@ static CUresult cu_launch_kernel_common(
 				block_dim_x, block_dim_y, block_dim_z,
 				shared_mem_bytes, stream, kernel_params, extra);
 
+	bool patched_launch = false;
 	auto kernel_name = cuda_graph_maybe_get_kernel_name_from_cufunction(
 		*impl, func);
 	if (kernel_name) {
 		if (auto patched = impl->find_patched_kernel_function(*kernel_name);
 		    patched) {
 			func = *patched;
-			impl->record_patched_launch(
-				reinterpret_cast<cudaStream_t>(stream));
+			patched_launch = true;
 		}
 	}
-	return original(func, grid_dim_x, grid_dim_y, grid_dim_z, block_dim_x,
-			block_dim_y, block_dim_z, shared_mem_bytes, stream,
-			kernel_params, extra);
+	auto result = original(func, grid_dim_x, grid_dim_y, grid_dim_z,
+			       block_dim_x, block_dim_y, block_dim_z,
+			       shared_mem_bytes, stream, kernel_params, extra);
+	if (result == CUDA_SUCCESS && patched_launch)
+		impl->record_patched_launch(
+			reinterpret_cast<cudaStream_t>(stream));
+	return result;
 }
 
 extern "C" CUresult cuda_driver_function__cuLaunchKernel(
@@ -537,6 +572,50 @@ extern "C" CUresult cuda_driver_function__cuLaunchKernel(
 				       gridDimZ, blockDimX, blockDimY, blockDimZ,
 				       sharedMemBytes, hStream, kernelParams,
 				       extra);
+}
+
+static CUresult cu_graph_launch_common(nv_attach_impl *impl,
+				       void *original_fn_ptr,
+				       CUgraphExec graph_exec, CUstream stream)
+{
+	auto original = reinterpret_cast<cu_graph_launch_fn_t>(original_fn_ptr);
+	if (!original)
+		return CUDA_ERROR_UNKNOWN;
+	auto result = original(graph_exec, stream);
+	if (result == CUDA_SUCCESS && impl != nullptr && impl->is_enabled())
+		impl->record_patched_launch(
+			reinterpret_cast<cudaStream_t>(stream));
+	return result;
+}
+
+extern "C" CUresult cuda_driver_function__cuGraphLaunch(CUgraphExec graph_exec,
+							CUstream stream)
+{
+	auto gum_ctx = gum_interceptor_get_current_invocation();
+	auto *state = (nv_attach_hook_state *)
+		gum_invocation_context_get_replacement_data(gum_ctx);
+	if (state == nullptr)
+		state = &nv_attach_get_hook_state();
+	return cu_graph_launch_common(
+		state->active_impl.load(std::memory_order_acquire),
+		state->orig_cu_graph_launch.load(std::memory_order_acquire),
+		graph_exec, stream);
+}
+
+extern "C" CUresult
+cuda_driver_function__cuGraphLaunch_ptsz(CUgraphExec graph_exec,
+					 CUstream stream)
+{
+	auto gum_ctx = gum_interceptor_get_current_invocation();
+	auto *state = (nv_attach_hook_state *)
+		gum_invocation_context_get_replacement_data(gum_ctx);
+	if (state == nullptr)
+		state = &nv_attach_get_hook_state();
+	return cu_graph_launch_common(
+		state->active_impl.load(std::memory_order_acquire),
+		state->orig_cu_graph_launch_ptsz.load(
+			std::memory_order_acquire),
+		graph_exec, stream);
 }
 
 extern "C" cudaError_t cuda_runtime_function__cudaLaunchKernel_ptsz(

--- a/attach/nv_attach_impl/nv_attach_impl_frida_setup.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl_frida_setup.cpp
@@ -192,7 +192,7 @@ cuda_launch_kernel_common(nv_attach_impl *impl, void *original_fn_ptr,
 			return call_original();
 		SPDLOG_DEBUG("Launching kernel..");
 		if (auto err = launch_patched(
-			    handle->func, grid_dim.x, grid_dim.y, grid_dim.z,
+			    *handle, grid_dim.x, grid_dim.y, grid_dim.z,
 			    block_dim.x, block_dim.y, block_dim.z, shared_mem,
 			    stream, args, nullptr);
 		    err != CUDA_SUCCESS) {
@@ -205,7 +205,7 @@ cuda_launch_kernel_common(nv_attach_impl *impl, void *original_fn_ptr,
 				     error_string ? error_string :
 						    "No description");
 			SPDLOG_ERROR("Error code: {}", (int)err);
-			log_cufunc_attrs(handle->func);
+			log_cufunc_attrs(*handle);
 			// Preserve target semantics: fall back to the original
 			// runtime launch path if patched launch fails.
 			return call_original();
@@ -302,7 +302,6 @@ static void example_listener_on_enter(GumInvocationListener *listener,
 		SPDLOG_INFO("Patching PTXs");
 		auto fatbin_record = std::make_unique<struct fatbin_record>();
 		fatbin_record->original_ptx = extracted_ptx;
-		fatbin_record->module_pool = context->impl->module_pool;
 		fatbin_record->ptx_pool = context->impl->ptx_pool;
 
 		context->impl->current_fatbin = fatbin_record.get();
@@ -319,13 +318,13 @@ static void example_listener_on_enter(GumInvocationListener *listener,
 		auto symbol_name =
 			(const char *)gum_invocation_context_get_nth_argument(
 				gum_ctx, 3);
-		if (auto ok = current_fatbin->find_and_fill_function_info(
-			    func_addr, symbol_name);
-		    !ok) {
+		if (func_addr == nullptr || symbol_name == nullptr) {
 			SPDLOG_WARN(
-				"Unable to find_and_fill function info of symbol named {}, the PTX may not be compiled due to not modifying by nv_attach_impl",
+				"Unable to register function info for symbol {}",
 				symbol_name);
 		} else {
+			current_fatbin->function_addr_to_symbol[func_addr] =
+				symbol_name;
 			context->impl->symbol_address_to_fatbin[func_addr] =
 				current_fatbin;
 			SPDLOG_DEBUG(
@@ -337,8 +336,6 @@ static void example_listener_on_enter(GumInvocationListener *listener,
 		   AttachedToFunction::RegisterVariable) {
 		SPDLOG_DEBUG("Entering __cudaRegisterVar");
 		auto current_fatbin = context->impl->current_fatbin;
-		auto fatbin_handle =
-			gum_invocation_context_get_nth_argument(gum_ctx, 0);
 		auto var_addr =
 			gum_invocation_context_get_nth_argument(gum_ctx, 1);
 		auto symbol_name =
@@ -346,13 +343,13 @@ static void example_listener_on_enter(GumInvocationListener *listener,
 				gum_ctx, 3);
 		SPDLOG_DEBUG("Registering variable named {}", symbol_name);
 
-		if (bool ok = current_fatbin->find_and_fill_variable_info(
-			    var_addr, symbol_name);
-		    !ok) {
+		if (var_addr == nullptr || symbol_name == nullptr) {
 			SPDLOG_WARN(
-				"Unable to find_and_fill variable info of symbol names {}, the PTX may not be compiled due to not modifying by nv_attach_impl",
+				"Unable to register variable info for symbol {}",
 				symbol_name);
 		} else {
+			current_fatbin->variable_addr_to_symbol[var_addr] =
+				symbol_name;
 			context->impl->symbol_address_to_fatbin[var_addr] =
 				current_fatbin;
 			SPDLOG_DEBUG("Registered variable name {} addr {:x}",

--- a/attach/nv_attach_impl/nv_attach_impl_frida_setup.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl_frida_setup.cpp
@@ -113,11 +113,20 @@ cuda_launch_kernel_common(nv_attach_impl *impl, void *original_fn_ptr,
 	if (impl == nullptr)
 		return original(func, grid_dim, block_dim, args, shared_mem,
 				stream);
+	if (!impl->is_enabled())
+		return original(func, grid_dim, block_dim, args, shared_mem,
+				stream);
 	auto state_guard = impl->lock_patched_state();
 	if (!impl->is_enabled())
 		return original(func, grid_dim, block_dim, args, shared_mem,
 				stream);
 	if (cuda_graph_stream_is_capturing(stream))
+		return original(func, grid_dim, block_dim, args, shared_mem,
+				stream);
+	auto launch_patched = reinterpret_cast<cu_launch_kernel_fn_t>(
+		nv_attach_get_hook_state().orig_cu_launch_kernel.load(
+			std::memory_order_acquire));
+	if (!launch_patched)
 		return original(func, grid_dim, block_dim, args, shared_mem,
 				stream);
 
@@ -181,7 +190,7 @@ cuda_launch_kernel_common(nv_attach_impl *impl, void *original_fn_ptr,
 			return original(func, grid_dim, block_dim, args,
 					shared_mem, stream);
 		SPDLOG_DEBUG("Launching kernel..");
-		if (auto err = cuLaunchKernel(
+		if (auto err = launch_patched(
 			    handle->func, grid_dim.x, grid_dim.y, grid_dim.z,
 			    block_dim.x, block_dim.y, block_dim.z, shared_mem,
 			    stream, args, nullptr);
@@ -220,7 +229,7 @@ cuda_launch_kernel_common(nv_attach_impl *impl, void *original_fn_ptr,
 			SPDLOG_DEBUG(
 				"Late attach launch: resolved {} -> patched CUfunction",
 				name->c_str());
-			if (auto err = cuLaunchKernel(*patched, grid_dim.x,
+			if (auto err = launch_patched(*patched, grid_dim.x,
 						      grid_dim.y, grid_dim.z,
 						      block_dim.x, block_dim.y,
 						      block_dim.z, shared_mem,
@@ -525,6 +534,10 @@ static CUresult cu_launch_kernel_common(
 		return original(func, grid_dim_x, grid_dim_y, grid_dim_z,
 				block_dim_x, block_dim_y, block_dim_z,
 				shared_mem_bytes, stream, kernel_params, extra);
+	if (!impl->is_enabled())
+		return original(func, grid_dim_x, grid_dim_y, grid_dim_z,
+				block_dim_x, block_dim_y, block_dim_z,
+				shared_mem_bytes, stream, kernel_params, extra);
 	auto state_guard = impl->lock_patched_state();
 	if (!impl->is_enabled())
 		return original(func, grid_dim_x, grid_dim_y, grid_dim_z,
@@ -819,6 +832,8 @@ static cudaError_t mirror_cuda_memcpy_from_symbol(
 			return cudaErrorUnknown;
 		return original_sync(dst, symbol, count, offset, kind);
 	};
+	if (!impl->is_enabled())
+		return call_original();
 	auto state_guard = impl->lock_patched_state();
 	if (!impl->is_enabled())
 		return call_original();

--- a/attach/nv_attach_impl/nv_attach_impl_frida_setup.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl_frida_setup.cpp
@@ -117,18 +117,20 @@ cuda_launch_kernel_common(nv_attach_impl *impl, void *original_fn_ptr,
 		return original(func, grid_dim, block_dim, args, shared_mem,
 				stream);
 	auto state_guard = impl->lock_patched_state();
+	const auto call_original = [&]() {
+		state_guard.unlock();
+		return original(func, grid_dim, block_dim, args, shared_mem,
+				stream);
+	};
 	if (!impl->is_enabled())
-		return original(func, grid_dim, block_dim, args, shared_mem,
-				stream);
+		return call_original();
 	if (cuda_graph_stream_is_capturing(stream))
-		return original(func, grid_dim, block_dim, args, shared_mem,
-				stream);
+		return call_original();
 	auto launch_patched = reinterpret_cast<cu_launch_kernel_fn_t>(
 		nv_attach_get_hook_state().orig_cu_launch_kernel.load(
 			std::memory_order_acquire));
 	if (!launch_patched)
-		return original(func, grid_dim, block_dim, args, shared_mem,
-				stream);
+		return call_original();
 
 	// Ensure a CUDA context is current for this thread before calling
 	// driver APIs
@@ -187,8 +189,7 @@ cuda_launch_kernel_common(nv_attach_impl *impl, void *original_fn_ptr,
 		auto &fatbin = *itr1->second;
 		auto handle = fatbin.find_function_info(*impl, (void *)func);
 		if (!handle)
-			return original(func, grid_dim, block_dim, args,
-					shared_mem, stream);
+			return call_original();
 		SPDLOG_DEBUG("Launching kernel..");
 		if (auto err = launch_patched(
 			    handle->func, grid_dim.x, grid_dim.y, grid_dim.z,
@@ -207,8 +208,7 @@ cuda_launch_kernel_common(nv_attach_impl *impl, void *original_fn_ptr,
 			log_cufunc_attrs(handle->func);
 			// Preserve target semantics: fall back to the original
 			// runtime launch path if patched launch fails.
-			return original(func, grid_dim, block_dim, args,
-					shared_mem, stream);
+			return call_original();
 		}
 		impl->record_patched_launch(stream);
 		return cudaSuccess;
@@ -217,8 +217,7 @@ cuda_launch_kernel_common(nv_attach_impl *impl, void *original_fn_ptr,
 	// Late attach: if bootstrap hasn't completed yet, fall back to the
 	// original launch path (bootstrap is kicked off during attach/refresh).
 	if (!impl->is_late_bootstrap_done())
-		return original(func, grid_dim, block_dim, args, shared_mem,
-				stream);
+		return call_original();
 
 	// Fallback path for late attach: resolve host stub symbol name to
 	// locate the patched CUfunction mapping.
@@ -249,8 +248,7 @@ cuda_launch_kernel_common(nv_attach_impl *impl, void *original_fn_ptr,
 				// Preserve target semantics: fall back to
 				// original runtime launch path if patched
 				// launch fails.
-				return original(func, grid_dim, block_dim, args,
-						shared_mem, stream);
+				return call_original();
 			}
 			impl->record_patched_launch(stream);
 			return cudaSuccess;
@@ -264,7 +262,7 @@ cuda_launch_kernel_common(nv_attach_impl *impl, void *original_fn_ptr,
 			(uintptr_t)func);
 	}
 
-	return original(func, grid_dim, block_dim, args, shared_mem, stream);
+	return call_original();
 }
 
 static void example_listener_on_enter(GumInvocationListener *listener,

--- a/attach/nv_attach_impl/nv_attach_utils.cpp
+++ b/attach/nv_attach_impl/nv_attach_utils.cpp
@@ -153,12 +153,6 @@ std::string get_gpu_sm_arch()
 	SPDLOG_INFO("Auto-detected GPU SM arch: {} (compute capability {}.{})",
 		    sm_arch, major, minor);
 
-	if (setenv("BPFTIME_SM_ARCH", sm_arch.c_str(), 1) != 0) {
-		SPDLOG_WARN(
-			"Failed to set BPFTIME_SM_ARCH environment variable to {}",
-			sm_arch);
-	}
-
 	return sm_arch;
 }
 

--- a/attach/nv_attach_impl/nv_elf_introspect.cpp
+++ b/attach/nv_attach_impl/nv_elf_introspect.cpp
@@ -96,8 +96,8 @@ find_section_span(std::ifstream &ifs, std::string_view section_name)
 }
 
 template <typename Ehdr, typename Shdr, typename Sym>
-std::vector<symbol_range>
-read_function_symbols_impl(std::ifstream &ifs, std::uintptr_t base)
+std::vector<symbol_range> read_symbols_impl(std::ifstream &ifs,
+					    std::uintptr_t base)
 {
 	std::vector<symbol_range> out;
 
@@ -146,7 +146,7 @@ read_function_symbols_impl(std::ifstream &ifs, std::uintptr_t base)
 				break;
 
 			const unsigned char type = ELF64_ST_TYPE(sym.st_info);
-			if (type != STT_FUNC)
+			if (type != STT_FUNC && type != STT_OBJECT)
 				continue;
 			if (sym.st_value == 0)
 				continue;
@@ -258,7 +258,7 @@ scan_fatbin_wrappers(const void *section_addr, std::size_t section_size)
 	return out;
 }
 
-std::vector<symbol_range> read_function_symbols(const loaded_module &mod)
+std::vector<symbol_range> read_symbols(const loaded_module &mod)
 {
 	std::vector<symbol_range> out;
 	const std::string path = normalize_module_path(mod.path);
@@ -275,11 +275,11 @@ std::vector<symbol_range> read_function_symbols(const loaded_module &mod)
 		return out;
 
 	if (ident[EI_CLASS] == ELFCLASS64) {
-		return read_function_symbols_impl<Elf64_Ehdr, Elf64_Shdr, Elf64_Sym>(
+		return read_symbols_impl<Elf64_Ehdr, Elf64_Shdr, Elf64_Sym>(
 			ifs, mod.base_addr);
 	}
 	if (ident[EI_CLASS] == ELFCLASS32) {
-		return read_function_symbols_impl<Elf32_Ehdr, Elf32_Shdr, Elf32_Sym>(
+		return read_symbols_impl<Elf32_Ehdr, Elf32_Shdr, Elf32_Sym>(
 			ifs, mod.base_addr);
 	}
 	return out;

--- a/attach/nv_attach_impl/nv_elf_introspect.cpp
+++ b/attach/nv_attach_impl/nv_elf_introspect.cpp
@@ -148,6 +148,8 @@ std::vector<symbol_range> read_symbols_impl(std::ifstream &ifs,
 			const unsigned char type = ELF64_ST_TYPE(sym.st_info);
 			if (type != STT_FUNC && type != STT_OBJECT)
 				continue;
+			if (type == STT_OBJECT && sym.st_size == 0)
+				continue;
 			if (sym.st_value == 0)
 				continue;
 			const char *name = "";

--- a/attach/nv_attach_impl/nv_elf_introspect.hpp
+++ b/attach/nv_attach_impl/nv_elf_introspect.hpp
@@ -29,6 +29,6 @@ find_section_in_memory(const loaded_module &mod, std::string_view section_name);
 std::vector<const __fatBinC_Wrapper_t *>
 scan_fatbin_wrappers(const void *section_addr, std::size_t section_size);
 
-std::vector<symbol_range> read_function_symbols(const loaded_module &mod);
+std::vector<symbol_range> read_symbols(const loaded_module &mod);
 
 } // namespace bpftime::attach::elf_introspect

--- a/example/gpu/atomizer/Makefile
+++ b/example/gpu/atomizer/Makefile
@@ -70,7 +70,7 @@ all: $(APPS) vec_add
 
 vec_add: vec_add.cu
 	@if command -v nvcc >/dev/null 2>&1; then \
-		nvcc -cudart shared vec_add.cu -o vec_add -g; \
+		nvcc -cudart shared -gencode arch=compute_70,code=compute_70 -gencode arch=compute_86,code=compute_86 vec_add.cu -o vec_add -g; \
 	else \
 		echo "Warning: CUDA not found, skipping vec_add build"; \
 	fi

--- a/example/gpu/atomizer/Makefile
+++ b/example/gpu/atomizer/Makefile
@@ -70,7 +70,7 @@ all: $(APPS) vec_add
 
 vec_add: vec_add.cu
 	@if command -v nvcc >/dev/null 2>&1; then \
-		nvcc -cudart shared -gencode arch=compute_70,code=compute_70 -gencode arch=compute_86,code=compute_86 vec_add.cu -o vec_add -g; \
+		nvcc -cudart shared -gencode arch=compute_52,code=compute_52 -gencode arch=compute_86,code=compute_86 vec_add.cu -o vec_add -g; \
 	else \
 		echo "Warning: CUDA not found, skipping vec_add build"; \
 	fi

--- a/example/gpu/atomizer/vec_add.cu
+++ b/example/gpu/atomizer/vec_add.cu
@@ -31,9 +31,11 @@ __global__ void vectorAdd(const float *A, const float *B, float *C)
 
 int main()
 {
-    // Set vector size in constant memory
+    int device_count = 0;
+    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0)
+        return 1;
+
     const int h_N = BLOCK_SIZE;
-    cudaMemcpyToSymbol(d_N, &h_N, sizeof(h_N));
     size_t bytes = h_N * sizeof(float);
     
     // Allocate and initialize host memory using vectors
@@ -45,39 +47,30 @@ int main()
         h_B[i] = float(2 * i);
     }
 
-    // Allocate Device memory
-    float *d_A, *d_B, *d_C;
-    cudaMalloc(&d_A, bytes);
-    cudaMalloc(&d_B, bytes);
-    cudaMalloc(&d_C, bytes);
-
-    // Copy to device
-    cudaMemcpy(d_A, h_A.data(), bytes, cudaMemcpyHostToDevice);
-    cudaMemcpy(d_B, h_B.data(), bytes, cudaMemcpyHostToDevice);
+    std::vector<float *> d_A(device_count), d_B(device_count), d_C(device_count);
+    for (int device = 0; device < device_count; device++) {
+        cudaSetDevice(device);
+        cudaMemcpyToSymbol(d_N, &h_N, sizeof(h_N));
+        cudaMalloc(&d_A[device], bytes);
+        cudaMalloc(&d_B[device], bytes);
+        cudaMalloc(&d_C[device], bytes);
+        cudaMemcpy(d_A[device], h_A.data(), bytes, cudaMemcpyHostToDevice);
+        cudaMemcpy(d_B[device], h_B.data(), bytes, cudaMemcpyHostToDevice);
+    }
 
     // Run the kernel in an infinite loop
     while (true) {
-        // Zero output array
-        cudaMemset(d_C, 0, bytes);
-        
-        // Launch kernel
-        vectorAdd<<<BLOCK_SIZE, 1>>>(d_A, d_B, d_C);
-        cudaDeviceSynchronize();
-        // Copy result back to host
-        cudaMemcpy(h_C.data(), d_C, bytes, cudaMemcpyDeviceToHost);
-        
-        // Print first element as a check
-        std::cout << "C[1] = " << h_C[1] << " (expected 0)\n";
-        std::cout << "C[7] = " << h_C[7] << " (expected 21)\n";
-        
+        for (int device = 0; device < device_count; device++) {
+            cudaSetDevice(device);
+            cudaMemset(d_C[device], 0, bytes);
+            vectorAdd<<<BLOCK_SIZE, 1>>>(d_A[device], d_B[device], d_C[device]);
+            cudaDeviceSynchronize();
+            cudaMemcpy(h_C.data(), d_C[device], bytes, cudaMemcpyDeviceToHost);
+            std::cout << "GPU " << device << ": C[1] = " << h_C[1]
+                      << ", C[7] = " << h_C[7] << " (expected 3, 21)\n";
+        }
         // Sleep for 1 second
         sleep(1);
     }
 
-    // Note: This code will never reach cleanup due to infinite loop
-    cudaFree(d_A);
-    cudaFree(d_B);
-    cudaFree(d_C);
-
-    return 0;
 }

--- a/example/gpu/atomizer/vec_add.cu
+++ b/example/gpu/atomizer/vec_add.cu
@@ -9,6 +9,15 @@
 #include <unistd.h>
 #include <vector>
 
+#define CUDA_CHECK(call)                                                       \
+    do {                                                                       \
+        if (auto error = (call); error != cudaSuccess) {                       \
+            std::cerr << #call << " failed: " << cudaGetErrorString(error)     \
+                      << '\n';                                                 \
+            return 1;                                                          \
+        }                                                                      \
+    } while (false)
+
 /*
 nvcc -x cu -cuda vectorAdd.cu -o vectorAdd.cpp
 python filter_hashtag.py
@@ -32,7 +41,8 @@ __global__ void vectorAdd(const float *A, const float *B, float *C)
 int main()
 {
     int device_count = 0;
-    if (cudaGetDeviceCount(&device_count) != cudaSuccess || device_count == 0)
+    CUDA_CHECK(cudaGetDeviceCount(&device_count));
+    if (device_count == 0)
         return 1;
 
     const int h_N = BLOCK_SIZE;
@@ -49,26 +59,34 @@ int main()
 
     std::vector<float *> d_A(device_count), d_B(device_count), d_C(device_count);
     for (int device = 0; device < device_count; device++) {
-        cudaSetDevice(device);
-        cudaMemcpyToSymbol(d_N, &h_N, sizeof(h_N));
-        cudaMalloc(&d_A[device], bytes);
-        cudaMalloc(&d_B[device], bytes);
-        cudaMalloc(&d_C[device], bytes);
-        cudaMemcpy(d_A[device], h_A.data(), bytes, cudaMemcpyHostToDevice);
-        cudaMemcpy(d_B[device], h_B.data(), bytes, cudaMemcpyHostToDevice);
+        CUDA_CHECK(cudaSetDevice(device));
+        CUDA_CHECK(cudaMalloc(&d_A[device], bytes));
+        CUDA_CHECK(cudaMalloc(&d_B[device], bytes));
+        CUDA_CHECK(cudaMalloc(&d_C[device], bytes));
+        CUDA_CHECK(cudaMemcpy(d_A[device], h_A.data(), bytes,
+                              cudaMemcpyHostToDevice));
+        CUDA_CHECK(cudaMemcpy(d_B[device], h_B.data(), bytes,
+                              cudaMemcpyHostToDevice));
     }
 
     // Run the kernel in an infinite loop
     while (true) {
         for (int device = 0; device < device_count; device++) {
-            cudaSetDevice(device);
-            cudaMemset(d_C[device], 0, bytes);
+            CUDA_CHECK(cudaSetDevice(device));
+            CUDA_CHECK(cudaMemcpyToSymbol(d_N, &h_N, sizeof(h_N)));
+            CUDA_CHECK(cudaMemset(d_C[device], 0, bytes));
             vectorAdd<<<BLOCK_SIZE, 1>>>(d_A[device], d_B[device], d_C[device]);
-            cudaDeviceSynchronize();
-            cudaMemcpy(h_C.data(), d_C[device], bytes, cudaMemcpyDeviceToHost);
+            CUDA_CHECK(cudaGetLastError());
+            CUDA_CHECK(cudaDeviceSynchronize());
+            CUDA_CHECK(cudaMemcpy(h_C.data(), d_C[device], bytes,
+                                  cudaMemcpyDeviceToHost));
             std::cout << "GPU " << device << ": C[1] = " << h_C[1]
-                      << ", C[7] = " << h_C[7] << " (expected 3, 21)\n";
+                      << ", C[7] = " << h_C[7]
+                      << " (expected 0 or 3, 21)" << std::endl;
+            if ((h_C[1] != 0 && h_C[1] != 3) || h_C[7] != 21)
+                return 1;
         }
+        std::cout << "Validated all visible GPUs" << std::endl;
         // Sleep for 1 second
         sleep(1);
     }

--- a/example/gpu/atomizer/vec_add.cu
+++ b/example/gpu/atomizer/vec_add.cu
@@ -40,6 +40,7 @@ __global__ void vectorAdd(const float *A, const float *B, float *C)
 
 int main()
 {
+    const bool expect_patched = getenv("BPFTIME_EXPECT_PATCHED") != nullptr;
     int device_count = 0;
     CUDA_CHECK(cudaGetDeviceCount(&device_count));
     if (device_count == 0)
@@ -83,7 +84,9 @@ int main()
             std::cout << "GPU " << device << ": C[1] = " << h_C[1]
                       << ", C[7] = " << h_C[7]
                       << " (expected 0 or 3, 21)" << std::endl;
-            if ((h_C[1] != 0 && h_C[1] != 3) || h_C[7] != 21)
+            if ((expect_patched ? h_C[1] != 0
+                                : (h_C[1] != 0 && h_C[1] != 3)) ||
+                h_C[7] != 21)
                 return 1;
         }
         std::cout << "Validated all visible GPUs" << std::endl;


### PR DESCRIPTION
## Summary

- lazily compile and load late-discovered patched fatbins in the active CUDA context
- key patched modules, kernels, globals, launch events, and cleanup by CUDA context
- select regular CUDA fatbin wrappers, reject ambiguous cross-fatbin symbols, and keep cache identity per fatbin
- snapshot attach entries before dispatching PTX workers so first-launch patching cannot race attach/detach mutation
- close replacement admission before attach/detach waits, hold shared state through patching/launch/event recording, call the saved driver trampoline, and release the guard before original-runtime fallback
- mirror late-attach constant-symbol updates into each context patched module
- make the existing atomizer CI fixture prove that patched multi-PTX kernels run
- supersede incomplete late-bootstrap generations without unloading modules that may still have in-flight launches

Fixes #497

## Current-base regression fix

After synchronizing current `master`, the CUDA Graph job exposed two bootstrap passes for the same fatbin: the kprobe pass was ingested first, then adding the kretprobe reran bootstrap and left two active patched CUfunctions for the same kernel. Resolution treated that as a real cross-module ambiguity and fell back to the original graph launch.

The latest commit assigns bootstrap records to generations, publishes a generation only after a complete staged scan, invalidates name-resolution caches before publication, and filters superseded generations while retaining their modules for in-flight safety. Registration-hook records are content-deduplicated one-for-one against the current bootstrap snapshot, so distinct or extra registrations still preserve conservative ambiguity.

## Diff and validation

Exact HEAD: `ec7a62b52810dc51d1c2bacf12c3e9173f8faa0c`

- 11 files, +758/-572, 12 commits relative to current `master`
- built `bpftime-agent`, `bpftime-syscall-server`, and `bpftime_nv_attach_tests`
- `bpftime_nv_attach_tests`: 21 cases, 94 assertions passed
- CUDA 12.9 / RTX 5090 two-process `cudagraph` E2E: non-zero call count progressed from 2 to 6 with no late-attach ambiguity
- `git diff --check` and changed-line clang-format passed
- dedicated concurrency/lifetime review: PASS
- independent external read-only review: PASS
- fresh Copilot review requested; no unresolved review threads
- exact-head GitHub CI: 86 passed, 2 skipped, 0 failed or pending

The PR is Ready (not Draft), mergeable, and remains unmerged pending maintainer approval.
