### PR TITLE
fix(syscall): contain callback exceptions

### DIFF
--- a/attach/syscall_trace_attach_impl/src/syscall_trace_attach_impl.cpp
+++ b/attach/syscall_trace_attach_impl/src/syscall_trace_attach_impl.cpp
@@ -37,6 +37,20 @@ int64_t syscall_trace_attach_impl::dispatch_syscall(int64_t sys_nr,
 			user_ret = v;
 			user_ret_ctx = ctx;
 		});
+	auto run_callbacks = [](const auto &callbacks,
+				const auto &ctx) noexcept {
+		for (auto prog : callbacks) {
+			try {
+				auto ctx_copy = ctx;
+				uint64_t callback_ret = 0;
+				int err = prog->cb(&ctx_copy, sizeof(ctx_copy),
+						   &callback_ret);
+				SPDLOG_DEBUG("ret {}, err {}", callback_ret,
+					     err);
+			} catch (...) {
+			}
+		}
+	};
 
 	if (!sys_enter_callbacks[sys_nr].empty() ||
 	    !global_enter_callbacks.empty()) {
@@ -49,18 +63,8 @@ int64_t syscall_trace_attach_impl::dispatch_syscall(int64_t sys_nr,
 		ctx.args[3] = arg4;
 		ctx.args[4] = arg5;
 		ctx.args[5] = arg6;
-		for (auto prog : sys_enter_callbacks[sys_nr]) {
-			auto ctx_copy = ctx;
-			uint64_t ret;
-			int err = prog->cb(&ctx_copy, sizeof(ctx_copy), &ret);
-			SPDLOG_DEBUG("ret {}, err {}", ret, err);
-		}
-		for (auto prog : global_enter_callbacks) {
-			auto ctx_copy = ctx;
-			uint64_t ret;
-			int err = prog->cb(&ctx_copy, sizeof(ctx_copy), &ret);
-			SPDLOG_DEBUG("ret {}, err {}", ret, err);
-		}
+		run_callbacks(sys_enter_callbacks[sys_nr], ctx);
+		run_callbacks(global_enter_callbacks, ctx);
 	}
 	curr_thread_override_return_callback.reset();
 	if (is_overrided) {
@@ -80,18 +84,8 @@ int64_t syscall_trace_attach_impl::dispatch_syscall(int64_t sys_nr,
 		memset(&ctx, 0, sizeof(ctx));
 		ctx.id = sys_nr;
 		ctx.ret = ret;
-		for (auto prog : sys_exit_callbacks[sys_nr]) {
-			auto ctx_copy = ctx;
-			uint64_t ret;
-			int err = prog->cb(&ctx_copy, sizeof(ctx_copy), &ret);
-			SPDLOG_DEBUG("ret {}, err {}", ret, err);
-		}
-		for (const auto prog : global_exit_callbacks) {
-			auto ctx_copy = ctx;
-			uint64_t ret;
-			int err = prog->cb(&ctx_copy, sizeof(ctx_copy), &ret);
-			SPDLOG_DEBUG("ret {}, err {}", ret, err);
-		}
+		run_callbacks(sys_exit_callbacks[sys_nr], ctx);
+		run_callbacks(global_exit_callbacks, ctx);
 	}
 	curr_thread_override_return_callback.reset();
 	if (is_overrided) {

--- a/attach/syscall_trace_attach_impl/test/test_syscall_dispatch.cpp
+++ b/attach/syscall_trace_attach_impl/test/test_syscall_dispatch.cpp
@@ -2,6 +2,7 @@
 #include "syscall_trace_attach_private_data.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstdint>
+#include <stdexcept>
 #include <syscall_trace_attach_impl.hpp>
 using namespace bpftime::attach;
 
@@ -9,6 +10,13 @@ extern "C" int64_t _bpftime_dummy_syscall(int64_t, int64_t, int64_t, int64_t,
 					  int64_t, int64_t, int64_t)
 {
 	return 0;
+}
+
+static int syscall_call_count;
+extern "C" int64_t _bpftime_counting_syscall(int64_t, int64_t, int64_t, int64_t,
+					     int64_t, int64_t, int64_t)
+{
+	return ++syscall_call_count;
 }
 
 TEST_CASE("Test syscall dispatch - global")
@@ -172,4 +180,22 @@ TEST_CASE("Test syscall dispatch - multiple")
 	invoke_cnt = 0;
 	attacher.dispatch_syscall(sys_name_to_nr.at("write"), 0, 0, 0, 0, 0, 0);
 	REQUIRE(invoke_cnt == 0);
+}
+
+TEST_CASE("A failing exit callback does not repeat the original syscall")
+{
+	syscall_trace_attach_private_data data;
+	data.sys_nr = 11;
+	data.is_enter = false;
+	syscall_trace_attach_impl attacher;
+	attacher.set_original_syscall_function(_bpftime_counting_syscall);
+	REQUIRE(attacher.create_attach_with_ebpf_callback(
+			[&](const void *, size_t, uint64_t *) -> int {
+				throw std::runtime_error(
+					"test callback failure");
+			},
+			data, ATTACH_SYSCALL_TRACE) >= 0);
+	syscall_call_count = 0;
+	REQUIRE(attacher.dispatch_syscall(11, 0, 0, 0, 0, 0, 0) == 1);
+	REQUIRE(syscall_call_count == 1);
 }

--- a/attach/syscall_trace_attach_impl/test/test_syscall_dispatch.cpp
+++ b/attach/syscall_trace_attach_impl/test/test_syscall_dispatch.cpp
@@ -182,7 +182,7 @@ TEST_CASE("Test syscall dispatch - multiple")
 	REQUIRE(invoke_cnt == 0);
 }
 
-TEST_CASE("A failing exit callback does not repeat the original syscall")
+TEST_CASE("A failing exit callback is contained")
 {
 	syscall_trace_attach_private_data data;
 	data.sys_nr = 11;
@@ -195,7 +195,16 @@ TEST_CASE("A failing exit callback does not repeat the original syscall")
 					"test callback failure");
 			},
 			data, ATTACH_SYSCALL_TRACE) >= 0);
+	int later_callback_count = 0;
+	data.sys_nr = -1;
+	REQUIRE(attacher.create_attach_with_ebpf_callback(
+			[&](const void *, size_t, uint64_t *) -> int {
+				return ++later_callback_count;
+			},
+			data, ATTACH_SYSCALL_TRACE) >= 0);
 	syscall_call_count = 0;
 	REQUIRE(attacher.dispatch_syscall(11, 0, 0, 0, 0, 0, 0) == 1);
 	REQUIRE(syscall_call_count == 1);
+	REQUIRE(later_callback_count == 1);
+	REQUIRE(!curr_thread_override_return_callback.has_value());
 }


### PR DESCRIPTION
## Summary

- catch exceptions from syscall enter and exit callbacks at the single shared dispatch boundary
- continue dispatching later callbacks after one callback fails
- preserve one original-syscall execution even when an exit callback throws
- add a focused regression test for that fail-open path

Part of #605.

## Minimal scope

- 2 files, +53/-24
- production: +18/-24 (net -6)
- focused regression: +35
- the four duplicated callback loops are consolidated into one local dispatcher
- no unrelated preload, transformer, agent, allocation, logging, or ABI changes
- no new public API, configuration, dependency, fixture framework, or documentation

## Validation

Exact HEAD: `9c31da75a248b650f9dfea1703da20cb731f4dde`

- synchronized with current `master`, including #626
- clean Debug build of `bpftime_syscall_trace_attach_tests`
- focused callback-exception regression: 6 assertions in 1 test case passed
- the regression proves a global exit callback still runs after a syscall-specific callback throws and that thread-local override state is cleared
- complete component binary: focused test passed; the other 3 existing cases require unavailable `/sys/kernel/tracing/events/syscalls/*/id` files in this environment
- `git diff --check` passed
- changed-range clang-format produced no changes

## Review and CI

Final-head subagent review and independent read-only review passed with no blockers. Copilot was explicitly requested; the final GitHub audit found no Copilot review, inline comment, or review thread to address. GitHub Actions reached terminal green with 85 passed checks and 2 conditional skips. This PR is Ready for maintainer approval; no merge has been performed.
