### PR TITLE
fix(runtime): keep preload logging off host stdio

### DIFF
--- a/runtime/include/bpftime_logger.hpp
+++ b/runtime/include/bpftime_logger.hpp
@@ -1,6 +1,7 @@
 #include <string>
 #include "spdlog/spdlog.h"
 #include "spdlog/cfg/env.h"
+#include "spdlog/sinks/null_sink.h"
 #include "spdlog/sinks/rotating_file_sink.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include <cstdlib>
@@ -38,16 +39,27 @@ inline std::string expand_user_path(const std::string &input_path)
 inline void bpftime_set_logger(const std::string &target) noexcept
 {
 	auto silence_logger = []() noexcept {
-		if (auto *logger = spdlog::default_logger_raw();
-		    logger != nullptr)
+		try {
+			auto sink =
+				std::make_shared<spdlog::sinks::null_sink_mt>();
+			auto logger = std::make_shared<spdlog::logger>(
+				"bpftime_quiet", std::move(sink));
 			logger->set_level(spdlog::level::off);
+			spdlog::set_default_logger(std::move(logger));
+		} catch (...) {
+			try {
+				if (auto *logger = spdlog::default_logger_raw();
+				    logger != nullptr)
+					logger->set_level(spdlog::level::off);
+			} catch (...) {
+			}
+		}
 	};
+	silence_logger();
 	try {
 		std::string logger_target = expand_user_path(target);
-		if (logger_target.empty()) {
-			silence_logger();
+		if (logger_target.empty())
 			return;
-		}
 
 		std::shared_ptr<spdlog::sinks::sink> sink;
 		if (logger_target == "console") {
@@ -87,7 +99,8 @@ inline void bpftime_set_logger(const std::string &target) noexcept
 inline void bpftime_logger_flush() noexcept
 {
 	try {
-		if (auto logger = spdlog::default_logger(); logger != nullptr)
+		if (auto logger = spdlog::default_logger();
+		    logger != nullptr && logger->level() != spdlog::level::off)
 			logger->flush();
 	} catch (...) {
 	}

--- a/runtime/include/bpftime_logger.hpp
+++ b/runtime/include/bpftime_logger.hpp
@@ -1,7 +1,6 @@
 #include <string>
 #include "spdlog/spdlog.h"
 #include "spdlog/cfg/env.h"
-#include "spdlog/sinks/null_sink.h"
 #include "spdlog/sinks/rotating_file_sink.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include <cstdlib>
@@ -38,25 +37,15 @@ inline std::string expand_user_path(const std::string &input_path)
 
 inline void bpftime_set_logger(const std::string &target) noexcept
 {
-	auto set_quiet_logger = []() noexcept {
-		try {
-			auto sink =
-				std::make_shared<spdlog::sinks::null_sink_mt>();
-			auto logger = std::make_shared<spdlog::logger>(
-				"bpftime_quiet", sink);
+	auto silence_logger = []() noexcept {
+		if (auto *logger = spdlog::default_logger_raw();
+		    logger != nullptr)
 			logger->set_level(spdlog::level::off);
-			logger->set_error_handler([](const std::string &) {});
-			spdlog::set_default_logger(std::move(logger));
-		} catch (...) {
-			if (auto *logger = spdlog::default_logger_raw();
-			    logger != nullptr)
-				logger->set_level(spdlog::level::off);
-		}
 	};
 	try {
 		std::string logger_target = expand_user_path(target);
 		if (logger_target.empty()) {
-			set_quiet_logger();
+			silence_logger();
 			return;
 		}
 
@@ -73,8 +62,10 @@ inline void bpftime_set_logger(const std::string &target) noexcept
 				spdlog::sinks::rotating_file_sink_mt>(
 				logger_target, max_size, max_files);
 		}
-		auto logger = std::make_shared<spdlog::logger>("bpftime_logger",
-							       std::move(sink));
+		auto logger = std::make_shared<spdlog::logger>(
+			logger_target == "console" ? "stderr" :
+						     "bpftime_logger",
+			std::move(sink));
 		std::weak_ptr<spdlog::logger> weak_logger = logger;
 		logger->set_error_handler([weak_logger](const std::string &) {
 			if (auto failed_logger = weak_logger.lock())
@@ -86,7 +77,7 @@ inline void bpftime_set_logger(const std::string &target) noexcept
 
 		spdlog::cfg::load_env_levels();
 	} catch (...) {
-		set_quiet_logger();
+		silence_logger();
 	}
 }
 

--- a/runtime/include/bpftime_logger.hpp
+++ b/runtime/include/bpftime_logger.hpp
@@ -55,11 +55,10 @@ inline void bpftime_set_logger(const std::string &target) noexcept
 			}
 		}
 	};
-	silence_logger();
 	try {
 		std::string logger_target = expand_user_path(target);
 		if (logger_target.empty())
-			return;
+			return silence_logger();
 
 		std::shared_ptr<spdlog::sinks::sink> sink;
 		if (logger_target == "console") {

--- a/runtime/include/bpftime_logger.hpp
+++ b/runtime/include/bpftime_logger.hpp
@@ -1,12 +1,11 @@
 #include <string>
 #include "spdlog/spdlog.h"
 #include "spdlog/cfg/env.h"
+#include "spdlog/sinks/null_sink.h"
 #include "spdlog/sinks/rotating_file_sink.h"
 #include "spdlog/sinks/stdout_color_sinks.h"
 #include <cstdlib>
-#include <iostream>
-#include <filesystem>
-#include <fstream>
+#include <memory>
 
 namespace bpftime
 {
@@ -14,13 +13,13 @@ namespace bpftime
 inline std::string expand_user_path(const std::string &input_path)
 {
 	if (input_path.empty()) {
-		return "console";
+		return {};
 	}
 
 	if (input_path[0] == '~') {
 		const char *homeDir = getenv("HOME");
 		if (!homeDir) {
-			return "console";
+			return {};
 		}
 
 		if (input_path.size() == 1 || input_path[1] == '/') {
@@ -29,7 +28,7 @@ inline std::string expand_user_path(const std::string &input_path)
 				homeDir + input_path.substr(1);
 			return expandedPath;
 		} else {
-			return "console"; // Unsupported path format
+			return {}; // Unsupported path format
 		}
 	}
 
@@ -39,35 +38,68 @@ inline std::string expand_user_path(const std::string &input_path)
 
 inline void bpftime_set_logger(const std::string &target) noexcept
 {
-	std::string logger_target = expand_user_path(target);
-	spdlog::drop_all();
-	if (logger_target == "console") {
-		// Set logger to stderr
-		auto logger = spdlog::stderr_color_mt("stderr");
-		logger->set_pattern("[%Y-%m-%d %H:%M:%S][%^%l%$][%t] %v");
-		logger->flush_on(spdlog::level::info);
-		spdlog::set_default_logger(logger);
-	} else {
-		// Set logger to file, with rotation 5MB and 3 files
-		auto max_size = 1048576 * 5;
-		auto max_files = 3;
-		auto logger = spdlog::rotating_logger_mt(
-			"bpftime_logger", logger_target, max_size, max_files);
-		logger->set_pattern("[%Y-%m-%d %H:%M:%S][%^%l%$][%t] %v");
-		logger->flush_on(spdlog::level::info);
-		spdlog::set_default_logger(logger);
-	}
+	auto set_quiet_logger = []() noexcept {
+		try {
+			auto sink =
+				std::make_shared<spdlog::sinks::null_sink_mt>();
+			auto logger = std::make_shared<spdlog::logger>(
+				"bpftime_quiet", sink);
+			logger->set_level(spdlog::level::off);
+			logger->set_error_handler([](const std::string &) {});
+			spdlog::set_default_logger(std::move(logger));
+		} catch (...) {
+			if (auto *logger = spdlog::default_logger_raw();
+			    logger != nullptr)
+				logger->set_level(spdlog::level::off);
+		}
+	};
+	try {
+		std::string logger_target = expand_user_path(target);
+		if (logger_target.empty()) {
+			set_quiet_logger();
+			return;
+		}
 
-	// Load log level from environment
-	spdlog::cfg::load_env_levels();
+		std::shared_ptr<spdlog::sinks::sink> sink;
+		if (logger_target == "console") {
+			// Console logging is explicitly opt-in and writes to
+			// stderr.
+			sink = std::make_shared<
+				spdlog::sinks::stderr_color_sink_mt>();
+		} else {
+			constexpr size_t max_size = 1048576 * 5;
+			constexpr size_t max_files = 3;
+			sink = std::make_shared<
+				spdlog::sinks::rotating_file_sink_mt>(
+				logger_target, max_size, max_files);
+		}
+		auto logger = std::make_shared<spdlog::logger>("bpftime_logger",
+							       std::move(sink));
+		std::weak_ptr<spdlog::logger> weak_logger = logger;
+		logger->set_error_handler([weak_logger](const std::string &) {
+			if (auto failed_logger = weak_logger.lock())
+				failed_logger->set_level(spdlog::level::off);
+		});
+		logger->set_pattern("[%Y-%m-%d %H:%M:%S][%^%l%$][%t] %v");
+		logger->flush_on(spdlog::level::info);
+		spdlog::set_default_logger(std::move(logger));
+
+		spdlog::cfg::load_env_levels();
+	} catch (...) {
+		set_quiet_logger();
+	}
 }
 
 /*
     Flush the logger.
 */
-inline void bpftime_logger_flush()
+inline void bpftime_logger_flush() noexcept
 {
-	spdlog::default_logger()->flush();
+	try {
+		if (auto logger = spdlog::default_logger(); logger != nullptr)
+			logger->flush();
+	} catch (...) {
+	}
 }
 
 } // namespace bpftime

--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -144,7 +144,8 @@ void syscall_context::load_config_from_env()
 
 syscall_context::syscall_context()
 {
-	bpftime_set_logger(std::string{});
+	if (auto *logger = spdlog::default_logger_raw(); logger != nullptr)
+		logger->set_level(spdlog::level::off);
 	init_original_functions();
 	// FIXME: merge this into the runtime config
 	load_config_from_env();

--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -144,9 +144,11 @@ void syscall_context::load_config_from_env()
 syscall_context::syscall_context()
 {
 	init_original_functions();
+	enable_mock.store(false, std::memory_order_relaxed);
 	const char *logger_target = getenv("BPFTIME_LOG_OUTPUT");
 	bpftime_set_logger(logger_target == nullptr ? DEFAULT_LOGGER_OUTPUT_PATH :
 						     logger_target);
+	SPDLOG_DEBUG("Resolved original libc function pointers");
 	// FIXME: merge this into the runtime config
 	load_config_from_env();
 	auto runtime_config = bpftime::construct_runtime_config_from_env();
@@ -154,6 +156,7 @@ syscall_context::syscall_context()
 	SPDLOG_INFO("Init bpftime syscall mocking..");
 	SPDLOG_INFO("The log will be written to: {}",
 		    runtime_config.get_logger_output_path());
+	enable_mock.store(true, std::memory_order_relaxed);
 }
 
 #ifdef BPFTIME_ENABLE_CUDA_ATTACH

--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -13,7 +13,6 @@
 #ifdef BPFTIME_ENABLE_CUDA_ATTACH
 #include "cuda.h"
 #endif
-#include "spdlog/cfg/env.h"
 #include "spdlog/fmt/fmt.h"
 #include <cstdio>
 #include <ebpf-vm.h>
@@ -144,9 +143,10 @@ void syscall_context::load_config_from_env()
 
 syscall_context::syscall_context()
 {
-	if (auto *logger = spdlog::default_logger_raw(); logger != nullptr)
-		logger->set_level(spdlog::level::off);
 	init_original_functions();
+	const char *logger_target = getenv("BPFTIME_LOG_OUTPUT");
+	bpftime_set_logger(logger_target == nullptr ? DEFAULT_LOGGER_OUTPUT_PATH :
+						     logger_target);
 	// FIXME: merge this into the runtime config
 	load_config_from_env();
 	auto runtime_config = bpftime::construct_runtime_config_from_env();
@@ -154,7 +154,6 @@ syscall_context::syscall_context()
 	SPDLOG_INFO("Init bpftime syscall mocking..");
 	SPDLOG_INFO("The log will be written to: {}",
 		    runtime_config.get_logger_output_path());
-	spdlog::cfg::load_env_levels();
 }
 
 #ifdef BPFTIME_ENABLE_CUDA_ATTACH

--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -144,6 +144,7 @@ void syscall_context::load_config_from_env()
 
 syscall_context::syscall_context()
 {
+	bpftime_set_logger(std::string{});
 	init_original_functions();
 	// FIXME: merge this into the runtime config
 	load_config_from_env();

--- a/runtime/syscall-server/syscall_context.hpp
+++ b/runtime/syscall-server/syscall_context.hpp
@@ -131,9 +131,6 @@ class syscall_context {
 		// unset the LD_PRELOAD env var after syscall context being
 		// initialized
 		unsetenv("LD_PRELOAD");
-		// Keep this log allocation-free. spdlog/fmt may throw in extremely
-		// early init paths (and will print "[*** LOG ERROR ***]").
-		SPDLOG_DEBUG("Resolved original libc function pointers");
 	}
 
 	int create_kernel_bpf_map(int fd, int bpftime_map_type);

--- a/runtime/syscall-server/syscall_server_utils.cpp
+++ b/runtime/syscall-server/syscall_server_utils.cpp
@@ -42,10 +42,10 @@ static const std::string KRETPROBE_BIT_FILE_NAME =
 void start_up(syscall_context &ctx)
 {
 	std::call_once(g_startup_once, [&ctx]() {
-		SPDLOG_INFO("Starting syscall server..");
 		auto runtime_config = construct_runtime_config_from_env();
 		bpftime_set_logger(
 			std::string(runtime_config.get_logger_output_path()));
+		SPDLOG_INFO("Starting syscall server..");
 		SPDLOG_INFO("Initialize syscall server");
 
 		bpftime_initialize_global_shm(

--- a/runtime/syscall-server/syscall_server_utils.cpp
+++ b/runtime/syscall-server/syscall_server_utils.cpp
@@ -14,9 +14,7 @@
 #include <filesystem>
 #include <memory>
 #include <mutex>
-#include <spdlog/cfg/env.h>
 #include <spdlog/spdlog.h>
-#include "bpftime_logger.hpp"
 #include <bpftime_shm.hpp>
 #include <string>
 #include <system_error>
@@ -42,10 +40,8 @@ static const std::string KRETPROBE_BIT_FILE_NAME =
 void start_up(syscall_context &ctx)
 {
 	std::call_once(g_startup_once, [&ctx]() {
-		auto runtime_config = construct_runtime_config_from_env();
-		bpftime_set_logger(
-			std::string(runtime_config.get_logger_output_path()));
 		SPDLOG_INFO("Starting syscall server..");
+		auto runtime_config = construct_runtime_config_from_env();
 		SPDLOG_INFO("Initialize syscall server");
 
 		bpftime_initialize_global_shm(

--- a/runtime/unit-test/test_shm_allocation_failure.cpp
+++ b/runtime/unit-test/test_shm_allocation_failure.cpp
@@ -104,6 +104,7 @@ TEST_CASE("Syscall server exits cleanly when startup shared memory is too small"
 		run_allocation_helper("startup", "64", "1048576", "console");
 	REQUIRE(WIFEXITED(result.status));
 	REQUIRE(WEXITSTATUS(result.status) == 1);
+	REQUIRE_FALSE(result.output.empty());
 }
 
 TEST_CASE("Syscall server perf mmap reports shared memory exhaustion",
@@ -129,6 +130,16 @@ TEST_CASE("Syscall server keeps default logging off host stdio",
 {
 	auto result =
 		run_allocation_helper("startup", "64", "1048576", nullptr);
+	REQUIRE(WIFEXITED(result.status));
+	REQUIRE(WEXITSTATUS(result.status) == 1);
+	REQUIRE(result.output.empty());
+}
+
+TEST_CASE("Global log level cannot enable default host stdio",
+	  "[allocation][syscall_server][logging]")
+{
+	auto result = run_allocation_helper("startup", "64", "1048576", nullptr,
+					    "info");
 	REQUIRE(WIFEXITED(result.status));
 	REQUIRE(WEXITSTATUS(result.status) == 1);
 	REQUIRE(result.output.empty());

--- a/runtime/unit-test/test_shm_allocation_failure.cpp
+++ b/runtime/unit-test/test_shm_allocation_failure.cpp
@@ -11,6 +11,8 @@
 #include <boost/interprocess/shared_memory_object.hpp>
 #include <cerrno>
 #include <cstdlib>
+#include <fstream>
+#include <iterator>
 #include <string>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -143,6 +145,26 @@ TEST_CASE("Global log level cannot enable default host stdio",
 	REQUIRE(WIFEXITED(result.status));
 	REQUIRE(WEXITSTATUS(result.status) == 1);
 	REQUIRE(result.output.empty());
+}
+
+TEST_CASE("File logger is installed before syscall startup",
+	  "[allocation][syscall_server][logging]")
+{
+	const std::string log_path = "/tmp/bpftime-syscall-startup-" +
+				     std::to_string(getpid()) + ".log";
+	unlink(log_path.c_str());
+	auto result = run_allocation_helper("perf-mmap", "4", "128",
+				    log_path.c_str());
+	std::ifstream log(log_path);
+	std::string contents{ std::istreambuf_iterator<char>(log), {} };
+	unlink(log_path.c_str());
+
+	REQUIRE(WIFEXITED(result.status));
+	REQUIRE(WEXITSTATUS(result.status) == 0);
+	REQUIRE(result.output.empty());
+	REQUIRE(contents.find("Starting syscall server") != std::string::npos);
+	REQUIRE(contents.find("bpftime-syscall-server started") !=
+		std::string::npos);
 }
 
 TEST_CASE("Syscall server preserves the console logger level name",

--- a/runtime/unit-test/test_shm_allocation_failure.cpp
+++ b/runtime/unit-test/test_shm_allocation_failure.cpp
@@ -25,7 +25,8 @@ struct helper_result {
 
 helper_result run_allocation_helper(const char *mode, const char *memory_mb,
 				    const char *max_fd_count,
-				    const char *log_output)
+				    const char *log_output,
+				    const char *log_level = nullptr)
 {
 	const std::string shm_name = "bpftime-shm-allocation-test-" +
 				     std::string(mode) + "-" +
@@ -44,6 +45,7 @@ helper_result run_allocation_helper(const char *mode, const char *memory_mb,
 		}
 		close(output_pipe[1]);
 		if (unsetenv("BPFTIME_LOG_OUTPUT") != 0 ||
+		    unsetenv("SPDLOG_LEVEL") != 0 ||
 		    unsetenv("BPFTIME_SHM_MEMORY_MB") != 0 ||
 		    unsetenv("BPFTIME_MAX_FD_COUNT") != 0 ||
 		    setenv("HOME", "/proc/bpftime-unwritable-home", 1) != 0 ||
@@ -61,6 +63,9 @@ helper_result run_allocation_helper(const char *mode, const char *memory_mb,
 			_exit(126);
 		if (log_output != nullptr &&
 		    setenv("BPFTIME_LOG_OUTPUT", log_output, 1) != 0)
+			_exit(126);
+		if (log_level != nullptr &&
+		    setenv("SPDLOG_LEVEL", log_level, 1) != 0)
 			_exit(126);
 		execl(BPFTIME_SHM_ALLOCATION_TEST_HELPER,
 		      BPFTIME_SHM_ALLOCATION_TEST_HELPER, mode, nullptr);
@@ -124,6 +129,16 @@ TEST_CASE("Syscall server keeps default logging off host stdio",
 {
 	auto result =
 		run_allocation_helper("startup", "64", "1048576", nullptr);
+	REQUIRE(WIFEXITED(result.status));
+	REQUIRE(WEXITSTATUS(result.status) == 1);
+	REQUIRE(result.output.empty());
+}
+
+TEST_CASE("Syscall server preserves the console logger level name",
+	  "[allocation][syscall_server][logging]")
+{
+	auto result = run_allocation_helper("startup", "64", "1048576",
+					    "console", "stderr=off");
 	REQUIRE(WIFEXITED(result.status));
 	REQUIRE(WEXITSTATUS(result.status) == 1);
 	REQUIRE(result.output.empty());

--- a/runtime/unit-test/test_shm_allocation_failure.cpp
+++ b/runtime/unit-test/test_shm_allocation_failure.cpp
@@ -14,54 +14,118 @@
 #include <string>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <utility>
 
 namespace
 {
-int run_allocation_helper(const char *mode, const char *memory_mb,
-			  const char *max_fd_count)
+struct helper_result {
+	int status;
+	std::string output;
+};
+
+helper_result run_allocation_helper(const char *mode, const char *memory_mb,
+				    const char *max_fd_count,
+				    const char *log_output)
 {
-	const std::string shm_name =
-		"bpftime-shm-allocation-test-" + std::string(mode) + "-" +
-		std::to_string(getpid());
+	const std::string shm_name = "bpftime-shm-allocation-test-" +
+				     std::string(mode) + "-" +
+				     std::to_string(getpid());
 	boost::interprocess::shared_memory_object::remove(shm_name.c_str());
+	int output_pipe[2];
+	REQUIRE(pipe(output_pipe) == 0);
 
 	pid_t pid = fork();
 	REQUIRE(pid >= 0);
 	if (pid == 0) {
-		if (setenv("BPFTIME_GLOBAL_SHM_NAME", shm_name.c_str(), 1) != 0 ||
-		    setenv("BPFTIME_LOG_OUTPUT", "console", 1) != 0 ||
-		    setenv("BPFTIME_SHM_MEMORY_MB", memory_mb, 1) != 0 ||
-		    setenv("BPFTIME_MAX_FD_COUNT", max_fd_count, 1) != 0 ||
-		    setenv("LD_PRELOAD", BPFTIME_SYSCALL_SERVER_LIBRARY, 1) != 0) {
+		close(output_pipe[0]);
+		if (dup2(output_pipe[1], STDOUT_FILENO) == -1 ||
+		    dup2(output_pipe[1], STDERR_FILENO) == -1) {
+			_exit(125);
+		}
+		close(output_pipe[1]);
+		if (unsetenv("BPFTIME_LOG_OUTPUT") != 0 ||
+		    unsetenv("BPFTIME_SHM_MEMORY_MB") != 0 ||
+		    unsetenv("BPFTIME_MAX_FD_COUNT") != 0 ||
+		    setenv("HOME", "/proc/bpftime-unwritable-home", 1) != 0 ||
+		    setenv("BPFTIME_GLOBAL_SHM_NAME", shm_name.c_str(), 1) !=
+			    0 ||
+		    setenv("LD_PRELOAD", BPFTIME_SYSCALL_SERVER_LIBRARY, 1) !=
+			    0) {
 			_exit(126);
 		}
+		if (memory_mb != nullptr &&
+		    setenv("BPFTIME_SHM_MEMORY_MB", memory_mb, 1) != 0)
+			_exit(126);
+		if (max_fd_count != nullptr &&
+		    setenv("BPFTIME_MAX_FD_COUNT", max_fd_count, 1) != 0)
+			_exit(126);
+		if (log_output != nullptr &&
+		    setenv("BPFTIME_LOG_OUTPUT", log_output, 1) != 0)
+			_exit(126);
 		execl(BPFTIME_SHM_ALLOCATION_TEST_HELPER,
 		      BPFTIME_SHM_ALLOCATION_TEST_HELPER, mode, nullptr);
 		_exit(127);
 	}
+
+	close(output_pipe[1]);
+	std::string output;
+	char buffer[4096];
+	for (;;) {
+		ssize_t count = read(output_pipe[0], buffer, sizeof(buffer));
+		if (count > 0) {
+			output.append(buffer, static_cast<size_t>(count));
+			continue;
+		}
+		if (count == -1 && errno == EINTR)
+			continue;
+		REQUIRE(count == 0);
+		break;
+	}
+	close(output_pipe[0]);
 
 	int status = 0;
 	while (waitpid(pid, &status, 0) == -1) {
 		REQUIRE(errno == EINTR);
 	}
 	boost::interprocess::shared_memory_object::remove(shm_name.c_str());
-	return status;
+	return { status, std::move(output) };
 }
 } // namespace
 
 TEST_CASE("Syscall server exits cleanly when startup shared memory is too small",
 	  "[allocation][syscall_server]")
 {
-	int status = run_allocation_helper("startup", "64", "1048576");
-	REQUIRE(WIFEXITED(status));
-	REQUIRE(WEXITSTATUS(status) == 1);
+	auto result =
+		run_allocation_helper("startup", "64", "1048576", "console");
+	REQUIRE(WIFEXITED(result.status));
+	REQUIRE(WEXITSTATUS(result.status) == 1);
 }
 
 TEST_CASE("Syscall server perf mmap reports shared memory exhaustion",
 	  "[allocation][syscall_server]")
 {
-	int status = run_allocation_helper("perf-mmap", "4", "128");
-	REQUIRE(WIFEXITED(status));
-	REQUIRE(WEXITSTATUS(status) == 0);
+	auto result = run_allocation_helper("perf-mmap", "4", "128", "console");
+	REQUIRE(WIFEXITED(result.status));
+	REQUIRE(WEXITSTATUS(result.status) == 0);
+}
+
+TEST_CASE("Syscall server keeps logger sink failures off host stdio",
+	  "[allocation][syscall_server][logging]")
+{
+	auto result =
+		run_allocation_helper("startup", "64", "1048576", "/dev/full");
+	REQUIRE(WIFEXITED(result.status));
+	REQUIRE(WEXITSTATUS(result.status) == 1);
+	REQUIRE(result.output.empty());
+}
+
+TEST_CASE("Syscall server keeps default logging off host stdio",
+	  "[allocation][syscall_server][logging]")
+{
+	auto result =
+		run_allocation_helper("startup", "64", "1048576", nullptr);
+	REQUIRE(WIFEXITED(result.status));
+	REQUIRE(WEXITSTATUS(result.status) == 1);
+	REQUIRE(result.output.empty());
 }
 #endif


### PR DESCRIPTION
Part of #605.

## Scope

This is the first of four small preload-transparency fixes. It only hardens common logger setup and the syscall-server early logging path. It does not remove syscall/transformer exits or assertions, and it does not change interception fallback behavior.

## Changes

- resolve original syscall functions before initializing spdlog
- keep syscall mocking disabled until logger setup, config parsing, lock initialization, and constructor logging complete
- use the configured file logger directly on the normal path; install a null fallback only if the target is invalid or setup fails
- require `BPFTIME_LOG_OUTPUT=console` before writing to host stderr
- keep invalid/unwritable paths, runtime sink errors, and disabled flushes off host stdout/stderr
- preserve global and named `SPDLOG_LEVEL` behavior on the configured sink

## Validation

- `cmake --build build --config Debug --target bpftime_runtime_tests -j4`
- `bpftime_runtime_tests "[logging]"`: 5 test cases, 32 assertions passed
- `bpftime_runtime_tests "[allocation]"`: 7 test cases, 43 assertions passed
- `git diff --check`
- local full runtime run on the initial patch: 80/82 cases passed; the two failures were the environment-dependent Frida executable-equivalence and kernel tailcall tests, outside this patch

The regression suite covers default/unwritable output, `/dev/full`, global `SPDLOG_LEVEL`, named `stderr=off`, positive explicit-console output, and complete startup logging through a valid file sink without constructor re-entry.

## Diff size

5 files, +196/-52. Production code is +67/-35 (net +32); tests are +129/-17.