### PR TITLE
feat(runtime): select fuzzy Frida backtracer

### DIFF
--- a/attach/frida_uprobe_attach_impl/CMakeLists.txt
+++ b/attach/frida_uprobe_attach_impl/CMakeLists.txt
@@ -28,6 +28,16 @@ set(TEST_SOURCES
     test/test_back_trace.cpp
 )
 option(TEST_LCOV "option for lcov" OFF)
+add_library(bpftime_frida_stripped_backtrace_fixture SHARED
+    test/stripped_back_trace_fixture.cpp)
+target_compile_options(bpftime_frida_stripped_backtrace_fixture PRIVATE
+    -O2
+    -g0
+    -fno-exceptions
+    -fomit-frame-pointer
+    -fno-asynchronous-unwind-tables
+    -fno-unwind-tables
+    -fno-optimize-sibling-calls)
 add_executable(bpftime_frida_uprobe_attach_tests ${TEST_SOURCES})
 
 if (${TEST_LCOV}) 
@@ -50,9 +60,9 @@ endif()
 add_dependencies(bpftime_frida_uprobe_attach_tests Catch2 bpftime_frida_uprobe_attach_impl spdlog::spdlog)
 if (${TEST_LCOV}) 
     target_link_options(bpftime_frida_uprobe_attach_tests PRIVATE -lgcov)
-    target_link_libraries(bpftime_frida_uprobe_attach_tests PRIVATE Catch2::Catch2WithMain bpftime_frida_uprobe_attach_impl spdlog::spdlog gcov)
+    target_link_libraries(bpftime_frida_uprobe_attach_tests PRIVATE Catch2::Catch2WithMain bpftime_frida_uprobe_attach_impl bpftime_frida_stripped_backtrace_fixture spdlog::spdlog gcov)
 else ()
-    target_link_libraries(bpftime_frida_uprobe_attach_tests PRIVATE Catch2::Catch2WithMain bpftime_frida_uprobe_attach_impl spdlog::spdlog)
+    target_link_libraries(bpftime_frida_uprobe_attach_tests PRIVATE Catch2::Catch2WithMain bpftime_frida_uprobe_attach_impl bpftime_frida_stripped_backtrace_fixture spdlog::spdlog)
 endif()
 target_include_directories(bpftime_frida_uprobe_attach_tests PRIVATE ${FRIDA_UPROBE_ATTACH_IMPL_INCLUDE} ${Catch2_INCLUDE} ${SPDLOG_INCLUDE})
 

--- a/attach/frida_uprobe_attach_impl/include/frida_uprobe_attach_impl.hpp
+++ b/attach/frida_uprobe_attach_impl/include/frida_uprobe_attach_impl.hpp
@@ -64,7 +64,7 @@ extern thread_local std::optional<void *> current_thread_gum_cpu_context;
 // The frida uprobe attach implementation
 class frida_attach_impl final : public base_attach_impl {
     public:
-	frida_attach_impl();
+	explicit frida_attach_impl(bool use_fuzzy_backtracer = false);
 	~frida_attach_impl();
 	// Create a uprobe attach entry at the specified address
 	int create_uprobe_at(void *func_addr, uprobe_callback &&cb);
@@ -101,6 +101,7 @@ class frida_attach_impl final : public base_attach_impl {
 	std::unordered_map<void *,
 			   std::unique_ptr<class frida_internal_attach_entry> >
 		internal_attaches;
+	bool use_fuzzy_backtracer;
 
 	friend class frida_internal_attach_entry;
 	int attach_at(void *func_addr, frida_attach_entry_callback &&cb);

--- a/attach/frida_uprobe_attach_impl/src/frida_uprobe_attach_impl.cpp
+++ b/attach/frida_uprobe_attach_impl/src/frida_uprobe_attach_impl.cpp
@@ -33,7 +33,8 @@ frida_attach_impl::~frida_attach_impl()
 	gum_object_unref((GumInterceptor *)interceptor);
 }
 
-frida_attach_impl::frida_attach_impl()
+frida_attach_impl::frida_attach_impl(bool use_fuzzy_backtracer)
+	: use_fuzzy_backtracer(use_fuzzy_backtracer)
 {
 	SPDLOG_DEBUG("Initializing frida attach manager");
 	gum_init_embedded();
@@ -305,7 +306,9 @@ void *frida_attach_impl::call_attach_specific_function(const std::string& name,
 			GumReturnAddress items[127];
 		} array;
 		array.len = 0;
-		auto tracer = gum_backtracer_make_accurate();
+		auto tracer = use_fuzzy_backtracer ?
+				      gum_backtracer_make_fuzzy() :
+				      gum_backtracer_make_accurate();
 		gum_backtracer_generate(
 			tracer,
 			(GumCpuContext *)*current_thread_gum_cpu_context,

--- a/attach/frida_uprobe_attach_impl/test/stripped_back_trace_fixture.cpp
+++ b/attach/frida_uprobe_attach_impl/test/stripped_back_trace_fixture.cpp
@@ -1,0 +1,32 @@
+#include <cstdint>
+
+extern "C" __attribute__((noinline)) uint64_t
+__bpftime_test_stripped_back_trace__func5(uint64_t x)
+{
+	asm volatile("" : "+r"(x));
+	return x + 5;
+}
+
+extern "C" __attribute__((noinline)) uint64_t
+__bpftime_test_stripped_back_trace__func4(uint64_t x)
+{
+	return __bpftime_test_stripped_back_trace__func5(x) + 4;
+}
+
+extern "C" __attribute__((noinline)) uint64_t
+__bpftime_test_stripped_back_trace__func3(uint64_t x)
+{
+	return __bpftime_test_stripped_back_trace__func4(x) + 3;
+}
+
+extern "C" __attribute__((noinline)) uint64_t
+__bpftime_test_stripped_back_trace__func2(uint64_t x)
+{
+	return __bpftime_test_stripped_back_trace__func3(x) + 2;
+}
+
+extern "C" __attribute__((noinline)) uint64_t
+__bpftime_test_stripped_back_trace__func1(uint64_t x)
+{
+	return __bpftime_test_stripped_back_trace__func2(x) + 1;
+}

--- a/attach/frida_uprobe_attach_impl/test/test_back_trace.cpp
+++ b/attach/frida_uprobe_attach_impl/test/test_back_trace.cpp
@@ -3,11 +3,16 @@
 #include "frida_register_def.hpp"
 #include "frida_uprobe_attach_impl.hpp"
 #include "spdlog/spdlog.h"
+#include <array>
 #include <cstdint>
 #include <cmath>
 #include <string>
+#include <vector>
 using namespace bpftime;
 using namespace attach;
+
+extern "C" uint64_t __bpftime_test_stripped_back_trace__func1(uint64_t x);
+extern "C" uint64_t __bpftime_test_stripped_back_trace__func5(uint64_t x);
 
 extern "C" __attribute__((__noinline__)) uint64_t
 __bpftime_test_attach_with_back_trace__func5(uint64_t x)
@@ -50,7 +55,16 @@ __bpftime_test_attach_with_back_trace__func1(uint64_t x)
 
 TEST_CASE("Test with backtrace")
 {
-	frida_attach_impl impl;
+	bool use_fuzzy_backtracer = false;
+	SECTION("accurate")
+	{
+		use_fuzzy_backtracer = false;
+	}
+	SECTION("fuzzy")
+	{
+		use_fuzzy_backtracer = true;
+	}
+	frida_attach_impl impl(use_fuzzy_backtracer);
 	bool invoked = false;
 	impl.create_uprobe_at(
 		(void *)&__bpftime_test_attach_with_back_trace__func5,
@@ -59,22 +73,57 @@ TEST_CASE("Test with backtrace")
 			auto stack = (std::vector<uint64_t> *)
 					     impl.call_attach_specific_function(
 						     "generate_stack", nullptr);
-			for (int i = 0; i < 4; i++) {
-				auto addr = stack->at(i);
-				GumDebugSymbolDetails debug_details;
-				REQUIRE(gum_symbol_details_from_address(
-						(GumReturnAddress)addr,
-						&debug_details) == true);
-				SPDLOG_INFO("symbol name {}",
-					    debug_details.symbol_name);
-				auto expected_name = std::string(
-					"__bpftime_test_attach_with_back_trace__func");
-				REQUIRE(std::string(debug_details.symbol_name)
-						.starts_with(expected_name));
+			REQUIRE_FALSE(stack->empty());
+			if (!use_fuzzy_backtracer) {
+				for (int i = 0; i < 4; i++) {
+					auto addr = stack->at(i);
+					GumDebugSymbolDetails debug_details;
+					REQUIRE(gum_symbol_details_from_address(
+							(GumReturnAddress)addr,
+							&debug_details) == true);
+					SPDLOG_INFO("symbol name {}",
+						    debug_details.symbol_name);
+					auto expected_name = std::string(
+						"__bpftime_test_attach_with_back_trace__func");
+					REQUIRE(std::string(debug_details.symbol_name)
+							.starts_with(expected_name));
+				}
 			}
 
 			delete stack;
 		});
 	REQUIRE(__bpftime_test_attach_with_back_trace__func1(100) == 635);
 	REQUIRE(invoked == true);
+}
+
+TEST_CASE("Fuzzy backtracer recovers a call chain without unwind metadata")
+{
+	std::array<std::size_t, 2> fixture_frames{};
+	for (const bool use_fuzzy_backtracer : { false, true }) {
+		frida_attach_impl impl(use_fuzzy_backtracer);
+		impl.create_uprobe_at(
+			(void *)&__bpftime_test_stripped_back_trace__func5,
+			[&](const pt_regs &) {
+				auto stack = (std::vector<uint64_t> *)
+						     impl.call_attach_specific_function(
+							     "generate_stack", nullptr);
+				REQUIRE(stack != nullptr);
+				for (const auto addr : *stack) {
+					GumDebugSymbolDetails details;
+					if (gum_symbol_details_from_address(
+						    (GumReturnAddress)addr,
+						    &details) &&
+					    std::string(details.symbol_name)
+						    .starts_with(
+							    "__bpftime_test_stripped_back_trace__func")) {
+						fixture_frames[use_fuzzy_backtracer]++;
+					}
+				}
+				delete stack;
+			});
+		REQUIRE(__bpftime_test_stripped_back_trace__func1(1) == 16);
+	}
+
+	REQUIRE(fixture_frames[1] >= 3);
+	REQUIRE(fixture_frames[1] > fixture_frames[0]);
 }

--- a/runtime/agent/agent.cpp
+++ b/runtime/agent/agent.cpp
@@ -872,7 +872,8 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 			ctx_holder.ctx.register_attach_impl(
 				{ ATTACH_UPROBE, ATTACH_URETPROBE,
 				  ATTACH_UPROBE_OVERRIDE, ATTACH_UREPLACE },
-				std::make_unique<attach::frida_attach_impl>(),
+				std::make_unique<attach::frida_attach_impl>(
+					runtime_config.enable_frida_fuzzy_backtracer),
 				[](const std::string_view &sv, int &err) {
 					std::unique_ptr<attach_private_data>
 						priv_data =

--- a/runtime/include/bpftime_config.hpp
+++ b/runtime/include/bpftime_config.hpp
@@ -70,6 +70,10 @@ struct runtime_config {
 	// rejected
 	bool allow_non_buildin_map_types = false;
 
+	// Use Frida's fuzzy backtracer for user stack collection. Accurate
+	// unwinding remains the default.
+	bool enable_frida_fuzzy_backtracer = false;
+
 	// memory size will determine the maximum size of the shared memory
 	// available for the eBPF programs and maps
 	// The value is in MB

--- a/runtime/src/bpftime_config.cpp
+++ b/runtime/src/bpftime_config.cpp
@@ -111,6 +111,10 @@ runtime_config bpftime::construct_runtime_config_from_env() noexcept
 		runtime_config.allow_non_buildin_map_types = true;
 	}
 
+	if (getenv("BPFTIME_FRIDA_FUZZY_BACKTRACER") != nullptr) {
+		runtime_config.enable_frida_fuzzy_backtracer = true;
+	}
+
 	// Parse shared memory size with validation (1MB min, 10GB max)
 	if (auto shm_size = parse_numeric_env<int>("BPFTIME_SHM_MEMORY_MB", 1, 10240)) {
 		runtime_config.shm_memory_size = *shm_size;

--- a/runtime/unit-test/test_config.cpp
+++ b/runtime/unit-test/test_config.cpp
@@ -38,3 +38,23 @@ TEST_CASE("Allow external maps from the environment")
 	REQUIRE(restore_result == 0);
 	REQUIRE(cfg.allow_non_buildin_map_types);
 }
+
+TEST_CASE("Select Frida's fuzzy backtracer from the environment")
+{
+	const char *old_value = getenv("BPFTIME_FRIDA_FUZZY_BACKTRACER");
+	const bool was_set = old_value != nullptr;
+	const std::string saved_value = was_set ? old_value : "";
+
+	REQUIRE(unsetenv("BPFTIME_FRIDA_FUZZY_BACKTRACER") == 0);
+	REQUIRE_FALSE(construct_runtime_config_from_env()
+			      .enable_frida_fuzzy_backtracer);
+	REQUIRE(setenv("BPFTIME_FRIDA_FUZZY_BACKTRACER", "1", 1) == 0);
+	REQUIRE(construct_runtime_config_from_env()
+			.enable_frida_fuzzy_backtracer);
+
+	const int restore_result =
+		was_set ? setenv("BPFTIME_FRIDA_FUZZY_BACKTRACER",
+				 saved_value.c_str(), 1) :
+			  unsetenv("BPFTIME_FRIDA_FUZZY_BACKTRACER");
+	REQUIRE(restore_result == 0);
+}

--- a/tools/cli/main.cpp
+++ b/tools/cli/main.cpp
@@ -815,6 +815,10 @@ extract_path_and_args(const argparse::ArgumentParser &parser,
 				env_args.emplace_back(
 					"BPFTIME_ALLOW_EXTERNAL_MAPS=true");
 			}
+			if (parser.get<bool>("--fuzzy-backtracer")) {
+				env_args.emplace_back(
+					"BPFTIME_FRIDA_FUZZY_BACKTRACER=true");
+			}
 			if (parser.is_used("--memory-size")) {
 				env_args.emplace_back(
 					"BPFTIME_SHM_MEMORY_MB=" +
@@ -843,6 +847,9 @@ add_common_runtime_env_cli_options(argparse::ArgumentParser &command)
 		.help("Same as BPFTIME_LOG_OUTPUT, control the log output destination, for example 'console' or a file path.");
 	command.add_argument("--allow-external-maps")
 		.help("Same as BPFTIME_ALLOW_EXTERNAL_MAPS, allow loading unsupported external maps with the bpftime syscall-server library.")
+		.flag();
+	command.add_argument("--fuzzy-backtracer")
+		.help("Use Frida's fuzzy backtracer for user stack collection; accurate unwinding remains the default.")
 		.flag();
 	command.add_argument("--memory-size")
 		.help("Same as BPFTIME_SHM_MEMORY_MB, set the shared memory size for bpftime maps in MB.")

--- a/usage.md
+++ b/usage.md
@@ -18,6 +18,7 @@ If you find any bugs or suggestions, please feel free to open an issue, thanks!
     - [Controlling the Log Path](#controlling-the-log-path)
     - [Allow external maps](#allow-external-maps)
     - [Set memory size for shared memory maps](#set-memory-size-for-shared-memory-maps)
+    - [Use fuzzy stack unwinding](#use-fuzzy-stack-unwinding)
   - [Verifier](#verifier)
 
 ## Uprobe and uretprobe
@@ -225,6 +226,20 @@ BPFTIME_SHM_MEMORY_MB=1024 LD_PRELOAD=~/.bpftime/libbpftime-syscall-server.so ex
 ```
 
 The shared memory also contains the handler table. Its capacity can be set with `BPFTIME_MAX_FD_COUNT` (the default is 6144), and larger values require more shared memory before any maps or perf buffers are allocated. If startup reports insufficient shared memory, increase `BPFTIME_SHM_MEMORY_MB` or reduce `BPFTIME_MAX_FD_COUNT`. Allocation failures while creating a perf buffer are reported to the caller as `ENOMEM`.
+
+### Use fuzzy stack unwinding
+
+User stack collection uses Frida's accurate backtracer by default. For stripped
+binaries where accurate unwinding cannot recover enough frames, select the fuzzy
+backtracer when starting the loader:
+
+```sh
+bpftime load --fuzzy-backtracer bpftrace simple.bt
+```
+
+The equivalent environment variable is `BPFTIME_FRIDA_FUZZY_BACKTRACER=true`.
+It affects user stack collection after the agent attaches; omit it to keep the
+default accurate unwinding behavior.
 
 ## Verifier
 


### PR DESCRIPTION
## Summary

- keep Frida accurate stack unwinding as the default
- add `bpftime load --fuzzy-backtracer` and the equivalent `BPFTIME_FRIDA_FUZZY_BACKTRACER` runtime setting
- propagate the setting through runtime configuration into the Frida attach implementation
- document when to choose fuzzy unwinding for binaries without usable unwind metadata

## Regression coverage

A separate shared fixture is compiled without frame pointers or usable unwind metadata. The focused test runs accurate and fuzzy backtracers over the same call chain, requires fuzzy unwinding to recover at least three fixture frames, and requires it to recover more fixture frames than accurate unwinding.

## Validation

- full Frida attach suite: 14 cases / 1,051 assertions passed
- focused accurate/fuzzy smoke test: 14 assertions passed
- no-unwind fixture regression: 6 assertions passed and 50/50 repeated runs passed
- runtime environment/default test: 5 assertions passed
- `bpftime load --help` exposes `--fuzzy-backtracer`
- `git diff --check`

Diff scope: 11 files, +165/-19; production code remains +24/-4, with the additional growth concentrated in the fixture, tests, and documentation.

Refs #630