### PR TITLE
chore: bump development version to 0.9.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ add_definitions(-DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1)
 #
 project(
   "bpftime"
-  VERSION 0.1.0
+  VERSION 0.9.0
   LANGUAGES C CXX
 )
 
@@ -64,7 +64,7 @@ function(bpftime_add_libs_component_command target_path)
     if(CMAKE_AR_NAME STREQUAL "ar")
       list(APPEND CMDS
         COMMAND ${CMAKE_COMMAND} -E make_directory objs/${target_name}
-        COMMAND ${CMAKE_COMMAND} -E env bash ${CMAKE_SOURCE_DIR}/cmake/extract_and_rename.sh ${target_path} ${CMAKE_BINARY_DIR}/objs/${target_name}
+        COMMAND bash ${CMAKE_SOURCE_DIR}/cmake/extract_and_rename.sh $<TARGET_FILE:${target}> objs/${target}
       )
       set(BPFTIME_STATIC_LLVM_LIB_AR_CMDS ${BPFTIME_STATIC_LLVM_LIB_AR_CMDS} ${CMDS} PARENT_SCOPE)
     else()
@@ -73,7 +73,7 @@ function(bpftime_add_libs_component_command target_path)
   else()
     list(APPEND CMDS
       COMMAND ${CMAKE_COMMAND} -E make_directory objs/${target_name}
-      COMMAND ${CMAKE_COMMAND} -E env bash ${CMAKE_SOURCE_DIR}/cmake/extract_and_rename.sh ${target_path} ${CMAKE_BINARY_DIR}/objs/${target_name}
+      COMMAND bash ${CMAKE_SOURCE_DIR}/cmake/extract_and_rename.sh ${target_path} ${CMAKE_BINARY_DIR}/objs/${target_name}
     )
     set(BPFTIME_STATIC_LLVM_LIB_AR_CMDS ${BPFTIME_STATIC_LLVM_LIB_AR_CMDS} ${CMDS} PARENT_SCOPE)
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ function(bpftime_add_libs_component_command target_path)
     if(CMAKE_AR_NAME STREQUAL "ar")
       list(APPEND CMDS
         COMMAND ${CMAKE_COMMAND} -E make_directory objs/${target_name}
-        COMMAND bash ${CMAKE_SOURCE_DIR}/cmake/extract_and_rename.sh $<TARGET_FILE:${target}> objs/${target}
+        COMMAND ${CMAKE_COMMAND} -E env bash ${CMAKE_SOURCE_DIR}/cmake/extract_and_rename.sh ${target_path} ${CMAKE_BINARY_DIR}/objs/${target_name}
       )
       set(BPFTIME_STATIC_LLVM_LIB_AR_CMDS ${BPFTIME_STATIC_LLVM_LIB_AR_CMDS} ${CMDS} PARENT_SCOPE)
     else()
@@ -73,7 +73,7 @@ function(bpftime_add_libs_component_command target_path)
   else()
     list(APPEND CMDS
       COMMAND ${CMAKE_COMMAND} -E make_directory objs/${target_name}
-      COMMAND bash ${CMAKE_SOURCE_DIR}/cmake/extract_and_rename.sh ${target_path} ${CMAKE_BINARY_DIR}/objs/${target_name}
+      COMMAND ${CMAKE_COMMAND} -E env bash ${CMAKE_SOURCE_DIR}/cmake/extract_and_rename.sh ${target_path} ${CMAKE_BINARY_DIR}/objs/${target_name}
     )
     set(BPFTIME_STATIC_LLVM_LIB_AR_CMDS ${BPFTIME_STATIC_LLVM_LIB_AR_CMDS} ${CMDS} PARENT_SCOPE)
   endif()

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 #
 project(
   "runtime"
-  VERSION 0.1.0
+  VERSION 0.9.0
   LANGUAGES C CXX
 )
 

--- a/runtime/syscall-server/CMakeLists.txt
+++ b/runtime/syscall-server/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(
     "bpftime-syscall-polyfill"
-    VERSION 0.1.0
+    VERSION 0.9.0
     LANGUAGES C CXX
 )
 

--- a/vm/CMakeLists.txt
+++ b/vm/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.16)
 #
 project(
   "vm-bpf"
-  VERSION 0.1.0
+  VERSION 0.9.0
   LANGUAGES C CXX
 )
 


### PR DESCRIPTION
## Summary

- bump the top-level bpftime CMake project version from `0.1.0` to `0.9.0`
- keep the runtime, VM, and syscall-server subproject versions aligned at `0.9.0`
- make this a version-only change; no runtime, API, build, or feature behavior changes

## Why

The repository's CMake project versions were still `0.1.0` even though the latest published GitHub release is `v0.2.0`. Moving the development version to `0.9.0` marks the start of the stabilization cycle toward `1.0.0` and gives downstream builds a coherent version.

This PR does not create the `v0.9.0` release tag. Release readiness can be evaluated separately after the remaining stabilization blockers are resolved.

## Validation

- compared the branch against `master`
- exactly four files change
- each file changes only one `VERSION 0.1.0` line to `VERSION 0.9.0`
