### PR TITLE
fix(runtime): clean syscall session resources

### DIFF
--- a/runtime/agent/agent.cpp
+++ b/runtime/agent/agent.cpp
@@ -389,6 +389,10 @@ static int perform_detach()
 	// destroying the whole attach context (which may block inside driver
 	// teardown while kernels are still running).
 	ctx_holder.ctx.reset_instantiated_state();
+	if (detach_err >= 0) {
+		shm_holder.global_shared_memory.remove_pid_from_alive_agent_set(
+			getpid());
+	}
 	SPDLOG_DEBUG("Detaching done");
 	bpftime_logger_flush();
 	return detach_err < 0 ? detach_err : 0;
@@ -616,6 +620,13 @@ static int refresh_attach_session(const gchar *data)
 			res);
 		return res < 0 ? res : -EINVAL;
 	}
+	if (!shm_holder.global_shared_memory.add_pid_into_alive_agent_set(
+		    getpid())) {
+		SPDLOG_ERROR("agent_control: unable to record alive agent pid");
+		(void)ctx_holder.ctx.destroy_all_attach_links();
+		ctx_holder.ctx.reset_instantiated_state();
+		return -EAGAIN;
+	}
 
 	int auto_refresh_ms = parse_auto_refresh_ms(data);
 	pid_t loader_pid = parse_loader_pid(data);
@@ -807,14 +818,19 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 			// flakiness in "spawn loader then inject agent" workflows.
 			std::string last_err;
 			bool shm_ok = false;
+			std::unique_ptr<shm_lifecycle_lock> shm_lock;
 			for (int attempt = 0; attempt < 60; attempt++) {
 				try {
+					shm_lock =
+						std::make_unique<shm_lifecycle_lock>(
+							get_global_shm_name());
 					bpftime_initialize_global_shm(
 						shm_open_type::SHM_OPEN_ONLY);
 					shm_ok = true;
 					break;
 				} catch (const std::exception &ex) {
 					last_err = ex.what();
+					shm_lock.reset();
 					std::this_thread::sleep_for(
 						std::chrono::milliseconds(
 							50));
@@ -831,13 +847,6 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 			bpftime_set_logger(std::string(
 				runtime_config.get_logger_output_path()));
 			apply_injected_kv_overrides(data);
-			// Only agents injected through frida could be detached.
-			if (injected_with_frida) {
-				// Record the pid
-				shm_holder.global_shared_memory
-					.add_pid_into_alive_agent_set(getpid());
-				recorded_alive_pid = true;
-			}
 			ctx_holder.init();
 			ctx_constructed = true;
 			global_ctx_constructed.store(
@@ -995,6 +1004,14 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 				std::atexit(stop_auto_refresh_at_exit);
 			}
 
+			if (!shm_holder.global_shared_memory
+				     .add_pid_into_alive_agent_set(getpid())) {
+				SPDLOG_ERROR("Unable to record alive agent pid");
+				init_fail();
+				return;
+			}
+			recorded_alive_pid = true;
+			shm_lock.reset();
 			SPDLOG_INFO("Attach successfully");
 		} catch (const std::exception &ex) {
 			fprintf(stderr,

--- a/runtime/include/bpftime_shm.hpp
+++ b/runtime/include/bpftime_shm.hpp
@@ -139,6 +139,7 @@ enum class shm_open_type {
 	SHM_OPEN_ONLY,
 	SHM_NO_CREATE,
 	SHM_CREATE_OR_OPEN,
+	SHM_CREATE_ONLY,
 };
 
 enum class bpf_prog_type {

--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -14,10 +14,18 @@
 #include "spdlog/spdlog.h"
 #include <bpftime_shm_internal.hpp>
 #include <cerrno>
+#include <cctype>
+#include <chrono>
 #include <cstdint>
 #include <cstdio>
 #include <memory>
+#include <string>
+#include <thread>
+#include <vector>
 #if __linux__
+#include <fcntl.h>
+#include <sys/file.h>
+#include <sys/stat.h>
 #include <sys/epoll.h>
 #ifdef BPFTIME_ENABLE_CUDA_ATTACH
 #include <cuda_runtime.h>
@@ -108,10 +116,129 @@ namespace bpftime
 
 bpftime_shm_holder shm_holder;
 
+namespace
+{
+class pid_set_scoped_lock {
+public:
+	explicit pid_set_scoped_lock(
+		boost::interprocess::interprocess_mutex *mutex)
+		: mutex(mutex)
+	{
+		if (mutex == nullptr) {
+			locked = true;
+			return;
+		}
+
+		const auto deadline = std::chrono::steady_clock::now() +
+				      std::chrono::milliseconds(250);
+		do {
+			try {
+				if (mutex->try_lock()) {
+					locked = true;
+					return;
+				}
+			} catch (const std::exception &ex) {
+				SPDLOG_WARN(
+					"Unable to lock bpftime pid set: {}",
+					ex.what());
+				return;
+			} catch (...) {
+				SPDLOG_WARN(
+					"Unable to lock bpftime pid set");
+				return;
+			}
+			std::this_thread::sleep_for(std::chrono::milliseconds(1));
+		} while (std::chrono::steady_clock::now() < deadline);
+
+		SPDLOG_WARN("Timed out locking bpftime pid set");
+	}
+
+	pid_set_scoped_lock(const pid_set_scoped_lock &) = delete;
+	pid_set_scoped_lock &
+	operator=(const pid_set_scoped_lock &) = delete;
+
+	~pid_set_scoped_lock()
+	{
+		if (locked && mutex != nullptr) {
+			try {
+				mutex->unlock();
+			} catch (...) {
+			}
+		}
+	}
+
+	bool owns_lock() const noexcept { return locked; }
+
+private:
+	boost::interprocess::interprocess_mutex *mutex = nullptr;
+	bool locked = false;
+};
+} // namespace
+
+shm_lifecycle_lock::shm_lifecycle_lock(const char *shm_name) noexcept
+{
+#if __linux__
+	try {
+		std::string sanitized;
+		for (const unsigned char ch :
+		     std::string(shm_name == nullptr ? "" : shm_name)) {
+			if (std::isalnum(ch) || ch == '_' || ch == '-' ||
+			    ch == '.') {
+				sanitized.push_back(static_cast<char>(ch));
+			} else {
+				sanitized.push_back('_');
+			}
+		}
+		if (sanitized.empty()) {
+			sanitized = "default";
+		}
+		std::string lock_path =
+			"/tmp/bpftime-shm-" + sanitized + ".lock";
+		lock_fd = open(lock_path.c_str(), O_CREAT | O_RDWR | O_CLOEXEC,
+			       0666);
+		if (lock_fd < 0) {
+			return;
+		}
+		(void)fchmod(lock_fd, 0666);
+		while (flock(lock_fd, LOCK_EX) != 0) {
+			if (errno != EINTR) {
+				close(lock_fd);
+				lock_fd = -1;
+				return;
+			}
+		}
+	} catch (...) {
+		if (lock_fd >= 0) {
+			close(lock_fd);
+			lock_fd = -1;
+		}
+	}
+#else
+	(void)shm_name;
+#endif
+}
+
+shm_lifecycle_lock::~shm_lifecycle_lock()
+{
+#if __linux__
+	if (lock_fd >= 0) {
+		(void)flock(lock_fd, LOCK_UN);
+		close(lock_fd);
+	}
+#endif
+}
+
 // Check whether a certain pid was already equipped with syscall tracer
 // Using a set stored in the shared memory
 bool bpftime_shm::check_syscall_trace_setup(int pid)
 {
+	if (syscall_installed_pids == nullptr) {
+		return false;
+	}
+	pid_set_scoped_lock lock(pid_set_lock);
+	if (!lock.owns_lock()) {
+		return false;
+	}
 	return syscall_installed_pids->contains(pid);
 }
 
@@ -119,11 +246,21 @@ bool bpftime_shm::check_syscall_trace_setup(int pid)
 // Using a set stored in the shared memory
 void bpftime_shm::set_syscall_trace_setup(int pid, bool whether)
 {
-	if (whether) {
-		syscall_installed_pids->insert(pid);
-	} else {
-		syscall_installed_pids->erase(pid);
+	if (syscall_installed_pids == nullptr) {
+		return;
 	}
+	auto update = [&]() {
+		if (whether) {
+			syscall_installed_pids->insert(pid);
+		} else {
+			syscall_installed_pids->erase(pid);
+		}
+	};
+	pid_set_scoped_lock lock(pid_set_lock);
+	if (!lock.owns_lock()) {
+		return;
+	}
+	update();
 }
 
 const bpf_map_handler *bpftime_shm::try_get_map_handler(int fd) const
@@ -672,18 +809,32 @@ bpftime_shm::bpftime_shm(const char *shm_name, shm_open_type type)
 			segment.find<alive_agent_pids>(
 				       bpftime::DEFAULT_ALIVE_AGENT_PIDS_NAME)
 				.first;
+		alive_syscall_server_pids =
+			segment.find<alive_syscall_server_pid_set>(
+				       bpftime::DEFAULT_ALIVE_SYSCALL_SERVER_PIDS_NAME)
+				.first;
+		pid_set_lock =
+			segment.find<boost::interprocess::interprocess_mutex>(
+				       bpftime::DEFAULT_PID_SET_LOCK_NAME)
+				.first;
 		epoch_state = segment.find<bpftime_global_epoch_state>(
 					     "bpftime_global_epoch_state")
 				      .first;
 		SPDLOG_DEBUG("done: bpftime_shm for client setup");
-	} else if (type == shm_open_type::SHM_CREATE_OR_OPEN) {
+	} else if (type == shm_open_type::SHM_CREATE_OR_OPEN ||
+		   type == shm_open_type::SHM_CREATE_ONLY) {
 		SPDLOG_DEBUG(
 			"start: bpftime_shm for create or open setup for memory size {}",
 			memory_size);
-		segment = boost::interprocess::managed_shared_memory(
-			boost::interprocess::open_or_create,
-			// Allocate 20M bytes of memory by default
-			shm_name, memory_size << 20);
+		if (type == shm_open_type::SHM_CREATE_ONLY) {
+			segment = boost::interprocess::managed_shared_memory(
+				boost::interprocess::create_only, shm_name,
+				memory_size << 20);
+		} else {
+			segment = boost::interprocess::managed_shared_memory(
+				boost::interprocess::open_or_create, shm_name,
+				memory_size << 20);
+		}
 
 		manager = segment.find_or_construct<bpftime::handler_manager>(
 			bpftime::DEFAULT_GLOBAL_HANDLER_NAME)(segment,
@@ -707,6 +858,16 @@ bpftime_shm::bpftime_shm(const char *shm_name, shm_open_type type)
 			std::less<int>(),
 			alive_agent_pid_set_allocator(
 				segment.get_segment_manager()));
+		alive_syscall_server_pids =
+			segment.find_or_construct<alive_syscall_server_pid_set>(
+				bpftime::DEFAULT_ALIVE_SYSCALL_SERVER_PIDS_NAME)(
+				std::less<int>(),
+				alive_syscall_server_pid_set_allocator(
+					segment.get_segment_manager()));
+		pid_set_lock =
+			segment.find_or_construct<
+				boost::interprocess::interprocess_mutex>(
+				bpftime::DEFAULT_PID_SET_LOCK_NAME)();
 		epoch_state =
 			segment.find_or_construct<bpftime_global_epoch_state>(
 				"bpftime_global_epoch_state")();
@@ -748,6 +909,16 @@ bpftime_shm::bpftime_shm(const char *shm_name, shm_open_type type)
 			std::less<int>(),
 			alive_agent_pid_set_allocator(
 				segment.get_segment_manager()));
+		alive_syscall_server_pids =
+			segment.construct<alive_syscall_server_pid_set>(
+				bpftime::DEFAULT_ALIVE_SYSCALL_SERVER_PIDS_NAME)(
+				std::less<int>(),
+				alive_syscall_server_pid_set_allocator(
+					segment.get_segment_manager()));
+		pid_set_lock =
+			segment.construct<
+				boost::interprocess::interprocess_mutex>(
+				bpftime::DEFAULT_PID_SET_LOCK_NAME)();
 		epoch_state = segment.construct<bpftime_global_epoch_state>(
 			"bpftime_global_epoch_state")();
 		SPDLOG_DEBUG("done: bpftime_shm for server setup.");
@@ -1106,20 +1277,99 @@ bpftime::bpftime_shm::~bpftime_shm()
 #endif
 }
 
-void bpftime_shm::add_pid_into_alive_agent_set(int pid)
+bool bpftime_shm::add_pid_into_alive_agent_set(int pid)
 {
-	injected_pids->insert(pid);
+	if (injected_pids == nullptr) {
+		return true;
+	}
+	auto update = [&]() { injected_pids->insert(pid); };
+	pid_set_scoped_lock lock(pid_set_lock);
+	if (!lock.owns_lock()) {
+		return false;
+	}
+	update();
+	return true;
 }
-void bpftime_shm::remove_pid_from_alive_agent_set(int pid)
+bool bpftime_shm::remove_pid_from_alive_agent_set(int pid)
 {
-	injected_pids->erase(pid);
+	if (injected_pids == nullptr) {
+		return true;
+	}
+	auto update = [&]() { injected_pids->erase(pid); };
+	pid_set_scoped_lock lock(pid_set_lock);
+	if (!lock.owns_lock()) {
+		return false;
+	}
+	update();
+	return true;
 }
-void bpftime_shm::iterate_all_pids_in_alive_agent_set(
+bool bpftime_shm::iterate_all_pids_in_alive_agent_set(
 	std::function<void(int)> &&cb)
 {
-	for (auto x : *injected_pids) {
+	std::vector<int> pids;
+	auto snapshot = [&]() {
+		if (injected_pids != nullptr) {
+			pids.assign(injected_pids->begin(), injected_pids->end());
+		}
+	};
+	pid_set_scoped_lock lock(pid_set_lock);
+	if (!lock.owns_lock()) {
+		return false;
+	}
+	snapshot();
+	for (auto x : pids) {
 		cb(x);
 	}
+	return true;
+}
+
+bool bpftime_shm::add_pid_into_alive_syscall_server_set(int pid)
+{
+	if (alive_syscall_server_pids == nullptr) {
+		return true;
+	}
+	auto update = [&]() { alive_syscall_server_pids->insert(pid); };
+	pid_set_scoped_lock lock(pid_set_lock);
+	if (!lock.owns_lock()) {
+		return false;
+	}
+	update();
+	return true;
+}
+
+bool bpftime_shm::remove_pid_from_alive_syscall_server_set(int pid)
+{
+	if (alive_syscall_server_pids == nullptr) {
+		return true;
+	}
+	auto update = [&]() { alive_syscall_server_pids->erase(pid); };
+	pid_set_scoped_lock lock(pid_set_lock);
+	if (!lock.owns_lock()) {
+		return false;
+	}
+	update();
+	return true;
+}
+
+bool bpftime_shm::iterate_all_pids_in_alive_syscall_server_set(
+	std::function<void(int)> &&cb)
+{
+	std::vector<int> pids;
+	auto snapshot = [&]() {
+		if (alive_syscall_server_pids != nullptr) {
+			pids.assign(alive_syscall_server_pids->begin(),
+				    alive_syscall_server_pids->end());
+		}
+	};
+	pid_set_scoped_lock lock(pid_set_lock);
+	if (!lock.owns_lock()) {
+		return false;
+	}
+	snapshot();
+	for (auto x : pids) {
+		cb(x);
+	}
+	return true;
 }
 
 void bpftime_shm::reset_server_state()
@@ -1129,7 +1379,14 @@ void bpftime_shm::reset_server_state()
 	}
 	manager->clear_all(segment);
 	if (syscall_installed_pids != nullptr) {
-		syscall_installed_pids->clear();
+		auto clear_syscall_pids = [&]() {
+			syscall_installed_pids->clear();
+		};
+		pid_set_scoped_lock lock(pid_set_lock);
+		if (!lock.owns_lock()) {
+			return;
+		}
+		clear_syscall_pids();
 	}
 }
 #ifdef BPFTIME_ENABLE_CUDA_ATTACH

--- a/runtime/src/bpftime_shm_internal.hpp
+++ b/runtime/src/bpftime_shm_internal.hpp
@@ -9,6 +9,7 @@
 #include "bpf_map/userspace/ringbuf_map.hpp"
 #include "bpf_map/userspace/stack_trace_map.hpp"
 #include <boost/interprocess/managed_shared_memory.hpp>
+#include <boost/interprocess/sync/interprocess_mutex.hpp>
 #include <cstddef>
 #include <functional>
 #include <boost/interprocess/containers/set.hpp>
@@ -29,6 +30,18 @@ struct CommSharedMem;
 
 namespace bpftime
 {
+
+class shm_lifecycle_lock {
+    public:
+	explicit shm_lifecycle_lock(const char *shm_name) noexcept;
+	~shm_lifecycle_lock();
+
+	shm_lifecycle_lock(const shm_lifecycle_lock &) = delete;
+	shm_lifecycle_lock &operator=(const shm_lifecycle_lock &) = delete;
+
+    private:
+	int lock_fd = -1;
+};
 
 static constexpr std::uint64_t BPFTIME_EPOCH_SEQ_UNSTABLE = UINT64_MAX;
 static constexpr std::uint64_t BPFTIME_EPOCH_SEQ_MISSING = UINT64_MAX - 1;
@@ -53,6 +66,14 @@ using alive_agent_pids =
 	boost::interprocess::set<int, std::less<int>,
 				 alive_agent_pid_set_allocator>;
 
+using alive_syscall_server_pid_set_allocator =
+	boost::interprocess::allocator<
+		int, boost::interprocess::managed_shared_memory::segment_manager>;
+
+using alive_syscall_server_pid_set =
+	boost::interprocess::set<int, std::less<int>,
+				 alive_syscall_server_pid_set_allocator>;
+
 // global bpftime share memory
 class bpftime_shm {
 	std::optional<std::function<void(bool)>> mock_setter;
@@ -72,6 +93,12 @@ class bpftime_shm {
 
 	// Record which pids are injected by agent
 	alive_agent_pids *injected_pids;
+
+	// Record which pids own or use the syscall-server side of this shm.
+	alive_syscall_server_pid_set *alive_syscall_server_pids = nullptr;
+
+	// Guards pid bookkeeping sets stored in shared memory.
+	boost::interprocess::interprocess_mutex *pid_set_lock = nullptr;
 
 	bpftime_global_epoch_state *epoch_state = nullptr;
 
@@ -115,12 +142,22 @@ class bpftime_shm {
 	// Using a set stored in the shared memory
 	void set_syscall_trace_setup(int pid, bool whether);
 
-	// Add a pid into alive agent set
-	void add_pid_into_alive_agent_set(int pid);
-	// Remove a pid from alive agent set
-	void remove_pid_from_alive_agent_set(int pid);
-	// Iterate over all pids from the alive agent set
-	void iterate_all_pids_in_alive_agent_set(std::function<void(int)> &&cb);
+		// Add a pid into alive agent set
+		bool add_pid_into_alive_agent_set(int pid);
+		// Remove a pid from alive agent set
+		bool remove_pid_from_alive_agent_set(int pid);
+		// Iterate over all pids from the alive agent set. Returns false when
+		// the snapshot could not be read safely.
+		bool iterate_all_pids_in_alive_agent_set(
+			std::function<void(int)> &&cb);
+		// Add a pid into alive syscall-server set
+		bool add_pid_into_alive_syscall_server_set(int pid);
+		// Remove a pid from alive syscall-server set
+		bool remove_pid_from_alive_syscall_server_set(int pid);
+		// Iterate over all pids from the alive syscall-server set. Returns
+		// false when the snapshot could not be read safely.
+		bool iterate_all_pids_in_alive_syscall_server_set(
+			std::function<void(int)> &&cb);
 
 	// Server-side: clear all existing handlers (maps/progs/links/events) and
 	// reset per-session bookkeeping stored in shm. This is used to allow

--- a/runtime/src/handler/handler_manager.hpp
+++ b/runtime/src/handler/handler_manager.hpp
@@ -54,6 +54,9 @@ constexpr const char *DEFAULT_SYSCALL_PID_SET_NAME = "bpftime_syscall_pid_set";
 constexpr const char *DEFAULT_AGENT_CONFIG_NAME = "bpftime_runtime_config";
 constexpr const char *DEFAULT_ALIVE_AGENT_PIDS_NAME =
 	"bpftime_alive_agent_pids";
+constexpr const char *DEFAULT_ALIVE_SYSCALL_SERVER_PIDS_NAME =
+	"bpftime_alive_syscall_server_pids";
+constexpr const char *DEFAULT_PID_SET_LOCK_NAME = "bpftime_pid_set_lock";
 inline const char *get_global_shm_name()
 {
 	const char *name = getenv("BPFTIME_GLOBAL_SHM_NAME");

--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -41,6 +41,7 @@
 #include "syscall_server_utils.hpp"
 #include <optional>
 #include <sys/mman.h>
+#include <string>
 #include <unistd.h>
 #include <regex>
 
@@ -81,6 +82,69 @@ exit_for_startup_allocation_failure(const std::exception &error)
 	SPDLOG_CRITICAL(
 		"Increase BPFTIME_SHM_MEMORY_MB or decrease BPFTIME_MAX_FD_COUNT");
 	std::exit(EXIT_FAILURE);
+}
+
+void set_mock_fd_cloexec(int fd)
+{
+	int flags = fcntl(fd, F_GETFD);
+	if (flags < 0) {
+		return;
+	}
+	(void)fcntl(fd, F_SETFD, flags | FD_CLOEXEC);
+}
+
+int create_unlinked_mock_fd(bool close_on_exec)
+{
+	char filename_buf[] = "/tmp/bpftime-mock.XXXXXX";
+#if defined(__linux__)
+	int fd = close_on_exec ? mkostemp(filename_buf, O_CLOEXEC) :
+				 mkstemp(filename_buf);
+#else
+	int fd = mkstemp(filename_buf);
+#endif
+	if (fd < 0) {
+		return fd;
+	}
+#if !defined(__linux__)
+	if (close_on_exec) {
+		set_mock_fd_cloexec(fd);
+	}
+#else
+	(void)close_on_exec;
+#endif
+	if (unlink(filename_buf) != 0) {
+		int err = errno;
+		SPDLOG_WARN("Unable to unlink mock file {}: {}", filename_buf,
+			    err);
+	}
+	return fd;
+}
+
+bool fopen_flags_request_cloexec(const char *flags)
+{
+	return flags != nullptr && strchr(flags, 'e') != nullptr;
+}
+
+bool write_all_to_fd(int fd, const std::string &buf)
+{
+	const char *data = buf.data();
+	size_t bytes_left = buf.size();
+	while (bytes_left > 0) {
+		ssize_t written = write(fd, data, bytes_left);
+		if (written < 0) {
+			if (errno == EINTR) {
+				continue;
+			}
+			return false;
+		}
+		if (written == 0) {
+			errno = ENOSPC;
+			return false;
+		}
+		data += written;
+		bytes_left -= written;
+	}
+	return true;
 }
 
 int get_bpf_obj_info_by_fd(int fd, void *info, uint32_t *info_len,
@@ -207,7 +271,7 @@ int syscall_context::handle_close(int fd)
 		    itr != this->mocked_files.end()) {
 			SPDLOG_DEBUG("Removing mocked file fd {}", fd);
 			this->mocked_files.erase(itr);
-			return 0;
+			return orig_close_fn(fd);
 		}
 	}
 	bpftime_close(fd);
@@ -230,11 +294,11 @@ int syscall_context::handle_openat(int fd, const char *file, int oflag,
 	if (auto mocker = create_mocked_file_based_on_full_path(*path);
 	    mocker) {
 		bpftime_lock_guard _guard(this->mocked_file_lock);
-		char filename_buf[] = "/tmp/bpftime-mock.XXXXXX";
-		int fake_fd = mkstemp(filename_buf);
+		int fake_fd = create_unlinked_mock_fd(
+			(oflag & O_CLOEXEC) != 0);
 		if (fake_fd < 0) {
 			SPDLOG_WARN("Unable to create mock fd: {}", errno);
-			return orig_open_fn(file, oflag, mode);
+			return orig_openat_fn(fd, file, oflag, mode);
 		}
 		this->mocked_files.emplace(fake_fd, std::move(*mocker));
 		SPDLOG_DEBUG("Created mocked file with fd {}", fake_fd);
@@ -254,8 +318,8 @@ int syscall_context::handle_open(const char *file, int oflag,
 	try_startup();
 	if (auto mocker = create_mocked_file_based_on_full_path(file); mocker) {
 		bpftime_lock_guard _guard(this->mocked_file_lock);
-		char filename_buf[] = "/tmp/bpftime-mock.XXXXXX";
-		int fake_fd = mkstemp(filename_buf);
+		int fake_fd = create_unlinked_mock_fd(
+			(oflag & O_CLOEXEC) != 0);
 		if (fake_fd < 0) {
 			SPDLOG_WARN("Unable to create mock fd: {}", errno);
 			return orig_open_fn(file, oflag, mode);
@@ -1089,23 +1153,38 @@ FILE *syscall_context::handle_fopen(const char *pathname, const char *flags)
 	if (auto mocker = create_mocked_file_based_on_full_path(pathname);
 	    mocker) {
 		bpftime_lock_guard _guard(this->mocked_file_lock);
-		char filename_buf[] = "/tmp/bpftime-mock.XXXXXX";
-		int fake_fd = mkstemp(filename_buf);
+		int fake_fd = create_unlinked_mock_fd(
+			fopen_flags_request_cloexec(flags));
 		if (fake_fd < 0) {
 			SPDLOG_WARN("Unable to create mock fd: {}", errno);
 			return orig_fopen_fn(pathname, flags);
 		}
-		auto itr =
-			this->mocked_files.emplace(fake_fd, std::move(*mocker))
-				.first;
-		FILE *replacement_fp = fopen(filename_buf, "r");
+		int err = 0;
+		if (!write_all_to_fd(fake_fd, (*mocker)->buf)) {
+			err = errno;
+			orig_close_fn(fake_fd);
+			errno = err;
+			return orig_fopen_fn(pathname, flags);
+		}
+		if (lseek(fake_fd, 0, SEEK_SET) < 0) {
+			err = errno;
+			SPDLOG_WARN("Unable to rewind mock fd {}: {}", fake_fd,
+				    err);
+			orig_close_fn(fake_fd);
+			errno = err;
+			return orig_fopen_fn(pathname, flags);
+		}
+		FILE *replacement_fp = fdopen(fake_fd, "r");
+		if (replacement_fp == nullptr) {
+			err = errno;
+			orig_close_fn(fake_fd);
+			errno = err;
+			return orig_fopen_fn(pathname, flags);
+		}
 
-		itr->second->replacement_file = replacement_fp;
-		auto size_written = write(fake_fd, itr->second->buf.c_str(),
-					  itr->second->buf.size());
 		SPDLOG_DEBUG(
 			"Created fake fd {}, replacement fp {:x}, written {} bytes",
-			fake_fd, (uintptr_t)replacement_fp, size_written);
+			fake_fd, (uintptr_t)replacement_fp, (*mocker)->buf.size());
 		return replacement_fp;
 	}
 	return orig_fopen_fn(pathname, flags);

--- a/runtime/syscall-server/syscall_server_utils.cpp
+++ b/runtime/syscall-server/syscall_server_utils.cpp
@@ -6,18 +6,24 @@
 #include "bpftime_config.hpp"
 #include "bpftime_helper_group.hpp"
 #include "bpftime_shm_internal.hpp"
+#include <boost/interprocess/exceptions.hpp>
+#include <boost/interprocess/shared_memory_object.hpp>
 #if defined(BPFTIME_ENABLE_CUDA_ATTACH)
 #include "cuda.h"
 #endif
 #include "syscall_context.hpp"
+#include <cerrno>
+#include <cstdlib>
 #include <fcntl.h>
 #include <filesystem>
 #include <memory>
 #include <mutex>
+#include <signal.h>
 #include <spdlog/spdlog.h>
 #include <bpftime_shm.hpp>
 #include <string>
 #include <system_error>
+#include <unistd.h>
 #ifdef ENABLE_BPFTIME_VERIFIER
 #include <bpftime-verifier.hpp>
 #include <iomanip>
@@ -26,6 +32,9 @@
 namespace bpftime
 {
 static std::once_flag g_startup_once;
+static std::string g_syscall_server_shm_name;
+static pid_t g_syscall_server_shm_owner_pid = -1;
+static bool g_syscall_server_owns_shm = false;
 using namespace bpftime;
 // Why not use string_view? because parse_uint_from_file requires a c-string
 static const std::string UPROBE_TYPE_FILE_NAME =
@@ -37,6 +46,102 @@ static const std::string KPROBE_TYPE_FILE_NAME =
 static const std::string KRETPROBE_BIT_FILE_NAME =
 	"/sys/bus/event_source/devices/kprobe/format/retprobe";
 
+static bool pid_is_alive(int pid)
+{
+	return kill(pid, 0) == 0 || errno == EPERM;
+}
+
+static void remove_syscall_server_global_shm() noexcept
+{
+	if (g_syscall_server_shm_name.empty()) {
+		return;
+	}
+	if (getpid() != g_syscall_server_shm_owner_pid) {
+		try {
+			shm_holder.global_shared_memory
+				.remove_pid_from_alive_syscall_server_set(
+					getpid());
+		} catch (...) {
+		}
+		return;
+	}
+	if (!g_syscall_server_owns_shm) {
+		try {
+			shm_holder.global_shared_memory
+				.remove_pid_from_alive_syscall_server_set(
+					getpid());
+		} catch (...) {
+		}
+		return;
+	}
+	shm_lifecycle_lock lifecycle_lock(g_syscall_server_shm_name.c_str());
+	try {
+		shm_holder.global_shared_memory
+			.remove_pid_from_alive_syscall_server_set(getpid());
+
+		bool has_alive_server = false;
+		bool server_snapshot_ok =
+			shm_holder.global_shared_memory
+				.iterate_all_pids_in_alive_syscall_server_set(
+					[&](int pid) {
+						if (has_alive_server) {
+							return;
+						}
+						if (pid_is_alive(pid)) {
+							has_alive_server = true;
+						}
+					});
+		if (!server_snapshot_ok) {
+			return;
+		}
+		if (has_alive_server) {
+			return;
+		}
+
+		bool has_alive_agent = false;
+		bool agent_snapshot_ok =
+			shm_holder.global_shared_memory
+				.iterate_all_pids_in_alive_agent_set([&](int pid) {
+					if (has_alive_agent) {
+						return;
+					}
+					if (pid_is_alive(pid)) {
+						has_alive_agent = true;
+					}
+				});
+		if (!agent_snapshot_ok) {
+			return;
+		}
+		if (has_alive_agent) {
+			return;
+		}
+		boost::interprocess::shared_memory_object::remove(
+			g_syscall_server_shm_name.c_str());
+	} catch (...) {
+	}
+}
+
+static bool initialize_global_shm_with_ownership()
+{
+	try {
+		bpftime_initialize_global_shm(shm_open_type::SHM_CREATE_ONLY);
+		return true;
+	} catch (const boost::interprocess::interprocess_exception &error) {
+		if (error.get_error_code() !=
+		    boost::interprocess::already_exists_error) {
+			boost::interprocess::shared_memory_object::remove(
+				g_syscall_server_shm_name.c_str());
+			throw;
+		}
+	} catch (...) {
+		boost::interprocess::shared_memory_object::remove(
+			g_syscall_server_shm_name.c_str());
+		throw;
+	}
+	bpftime_initialize_global_shm(shm_open_type::SHM_CREATE_OR_OPEN);
+	return false;
+}
+
 void start_up(syscall_context &ctx)
 {
 	std::call_once(g_startup_once, [&ctx]() {
@@ -44,8 +149,19 @@ void start_up(syscall_context &ctx)
 		auto runtime_config = construct_runtime_config_from_env();
 		SPDLOG_INFO("Initialize syscall server");
 
-		bpftime_initialize_global_shm(
-			shm_open_type::SHM_CREATE_OR_OPEN);
+		g_syscall_server_shm_name = get_global_shm_name();
+		g_syscall_server_shm_owner_pid = getpid();
+		shm_lifecycle_lock lifecycle_lock(
+			g_syscall_server_shm_name.c_str());
+		g_syscall_server_owns_shm =
+			initialize_global_shm_with_ownership();
+		std::atexit(remove_syscall_server_global_shm);
+		if (!shm_holder.global_shared_memory
+			     .add_pid_into_alive_syscall_server_set(getpid())) {
+			SPDLOG_WARN(
+				"Unable to record alive syscall-server pid; disabling automatic shm removal");
+			g_syscall_server_owns_shm = false;
+		}
 #if defined(BPFTIME_ENABLE_CUDA_ATTACH)
 		ctx.initialize_cuda();
 #endif

--- a/runtime/unit-test/assets/shm_allocation_test_helper.c
+++ b/runtime/unit-test/assets/shm_allocation_test_helper.c
@@ -3,14 +3,53 @@
  * Copyright (c) 2026, eunomia-bpf org
  * All rights reserved.
  */
+#define _GNU_SOURCE
 #include <errno.h>
 #include <fcntl.h>
 #include <linux/perf_event.h>
+#include <limits.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
 #include <sys/syscall.h>
 #include <unistd.h>
+
+static int global_shm_exists(void)
+{
+	const char *shm_name = getenv("BPFTIME_GLOBAL_SHM_NAME");
+	if (shm_name == NULL || shm_name[0] == '\0') {
+		return 0;
+	}
+
+	char path[512];
+	int written = snprintf(path, sizeof(path), "/dev/shm/%s", shm_name);
+	if (written < 0 || (size_t)written >= sizeof(path)) {
+		return 0;
+	}
+	return access(path, F_OK) == 0;
+}
+
+static int fd_is_unlinked_mock_tmp_file(int fd)
+{
+	char proc_path[64];
+	int written = snprintf(proc_path, sizeof(proc_path), "/proc/self/fd/%d",
+			       fd);
+	if (written < 0 || (size_t)written >= sizeof(proc_path)) {
+		return 0;
+	}
+
+	char target[PATH_MAX];
+	ssize_t len = readlink(proc_path, target, sizeof(target) - 1);
+	if (len < 0) {
+		perror("readlink");
+		return 0;
+	}
+	target[len] = '\0';
+	const char *prefix = "/tmp/bpftime-mock.";
+	return strncmp(target, prefix, strlen(prefix)) == 0 &&
+	       strstr(target, " (deleted)") != NULL;
+}
 
 static int trigger_startup(void)
 {
@@ -23,6 +62,96 @@ static int trigger_startup(void)
 	}
 	close(fd);
 	return 100;
+}
+
+static int trigger_startup_ok(void)
+{
+	int fd = open("/dev/null", O_RDONLY, 0);
+	if (fd < 0) {
+		return 101;
+	}
+	close(fd);
+	if (getenv("BPFTIME_USED") == NULL || !global_shm_exists()) {
+		return 102;
+	}
+	return 0;
+}
+
+static int trigger_startup_wait(void)
+{
+	int err = trigger_startup_ok();
+	if (err != 0) {
+		return err;
+	}
+
+	const char *ready_file = getenv("BPFTIME_HELPER_READY_FILE");
+	const char *release_file = getenv("BPFTIME_HELPER_RELEASE_FILE");
+	if (ready_file == NULL || release_file == NULL) {
+		return 103;
+	}
+
+	FILE *fp = fopen(ready_file, "w");
+	if (fp == NULL) {
+		perror("fopen ready");
+		return 104;
+	}
+	fclose(fp);
+
+	for (int i = 0; i < 3000; i++) {
+		if (access(release_file, F_OK) == 0) {
+			return 0;
+		}
+		usleep(10000);
+	}
+	return 105;
+}
+
+static int trigger_mock_tmp_files(void)
+{
+	int fd = open("/sys/bus/event_source/devices/uprobe/type",
+		      O_RDONLY | O_CLOEXEC, 0);
+	if (fd < 0) {
+		perror("open");
+		return 11;
+	}
+	if (!fd_is_unlinked_mock_tmp_file(fd)) {
+		close(fd);
+		return 12;
+	}
+	if ((fcntl(fd, F_GETFD) & FD_CLOEXEC) == 0) {
+		close(fd);
+		return 13;
+	}
+	char buf[64];
+	if (read(fd, buf, sizeof(buf)) < 0) {
+		perror("read");
+		close(fd);
+		return 14;
+	}
+	close(fd);
+
+	FILE *fp = fopen("/sys/bus/event_source/devices/uprobe/format/retprobe",
+			 "re");
+	if (fp == NULL) {
+		perror("fopen");
+		return 15;
+	}
+	fd = fileno(fp);
+	if (!fd_is_unlinked_mock_tmp_file(fd)) {
+		fclose(fp);
+		return 16;
+	}
+	if ((fcntl(fd, F_GETFD) & FD_CLOEXEC) == 0) {
+		fclose(fp);
+		return 17;
+	}
+	if (fgets(buf, sizeof(buf), fp) == NULL && ferror(fp)) {
+		perror("fgets");
+		fclose(fp);
+		return 18;
+	}
+	fclose(fp);
+	return 0;
 }
 
 static int trigger_perf_mmap(void)
@@ -59,6 +188,15 @@ int main(int argc, char **argv)
 	}
 	if (strcmp(argv[1], "startup") == 0) {
 		return trigger_startup();
+	}
+	if (strcmp(argv[1], "startup-ok") == 0) {
+		return trigger_startup_ok();
+	}
+	if (strcmp(argv[1], "startup-wait") == 0) {
+		return trigger_startup_wait();
+	}
+	if (strcmp(argv[1], "mock-tmp") == 0) {
+		return trigger_mock_tmp_files();
 	}
 	if (strcmp(argv[1], "perf-mmap") == 0) {
 		return trigger_perf_mmap();

--- a/runtime/unit-test/test_shm_allocation_failure.cpp
+++ b/runtime/unit-test/test_shm_allocation_failure.cpp
@@ -8,6 +8,8 @@
 #if defined(__linux__)
 #include "shm_allocation_test_paths.hpp"
 
+#include "bpftime_shm_internal.hpp"
+#include <boost/interprocess/managed_shared_memory.hpp>
 #include <boost/interprocess/shared_memory_object.hpp>
 #include <cerrno>
 #include <cstdlib>
@@ -25,15 +27,83 @@ struct helper_result {
 	std::string output;
 };
 
+struct env_var_guard {
+	const char *name;
+	std::string old_value;
+	bool had_value;
+
+	explicit env_var_guard(const char *env_name)
+		: name(env_name), old_value(), had_value(getenv(env_name) != nullptr)
+	{
+		if (had_value) {
+			old_value = getenv(env_name);
+		}
+	}
+
+	~env_var_guard()
+	{
+		if (had_value) {
+			setenv(name, old_value.c_str(), 1);
+		} else {
+			unsetenv(name);
+		}
+	}
+};
+
+struct parent_shm_guard {
+	bool initialized = false;
+	bool pid_added = false;
+	bool added_as_syscall_server = false;
+
+	void cleanup()
+	{
+		if (!initialized) {
+			return;
+		}
+		if (pid_added) {
+			if (added_as_syscall_server) {
+				bpftime::shm_holder.global_shared_memory
+					.remove_pid_from_alive_syscall_server_set(
+						getpid());
+			} else {
+				bpftime::shm_holder.global_shared_memory
+					.remove_pid_from_alive_agent_set(
+						getpid());
+			}
+			pid_added = false;
+		}
+		bpftime_destroy_global_shm();
+		bpftime_initialize_global_shm(
+			bpftime::shm_open_type::SHM_NO_CREATE);
+		initialized = false;
+	}
+
+	~parent_shm_guard()
+	{
+		cleanup();
+	}
+};
+
+enum class live_pid_set { alive_agent, syscall_server };
+
 helper_result run_allocation_helper(const char *mode, const char *memory_mb,
 				    const char *max_fd_count,
 				    const char *log_output,
-				    const char *log_level = nullptr)
+				    const char *log_level = nullptr,
+				    bool cleanup_shm = true,
+				    std::string *shm_name_out = nullptr,
+				    bool remove_before_start = true)
 {
 	const std::string shm_name = "bpftime-shm-allocation-test-" +
 				     std::string(mode) + "-" +
 				     std::to_string(getpid());
-	boost::interprocess::shared_memory_object::remove(shm_name.c_str());
+	if (shm_name_out != nullptr) {
+		*shm_name_out = shm_name;
+	}
+	if (remove_before_start) {
+		boost::interprocess::shared_memory_object::remove(
+			shm_name.c_str());
+	}
 	int output_pipe[2];
 	REQUIRE(pipe(output_pipe) == 0);
 
@@ -94,7 +164,112 @@ helper_result run_allocation_helper(const char *mode, const char *memory_mb,
 	while (waitpid(pid, &status, 0) == -1) {
 		REQUIRE(errno == EINTR);
 	}
+	if (cleanup_shm) {
+		boost::interprocess::shared_memory_object::remove(
+			shm_name.c_str());
+	}
+	return { status, std::move(output) };
+}
+
+bool wait_for_file(const std::string &path)
+{
+	for (int i = 0; i < 3000; i++) {
+		if (access(path.c_str(), F_OK) == 0) {
+			return true;
+		}
+		usleep(10000);
+	}
+	return false;
+}
+
+helper_result run_waiting_helper_with_live_pid(const std::string &shm_name,
+					       live_pid_set set_name)
+{
+	const std::string ready_file =
+		"/tmp/bpftime-shm-allocation-ready-" + std::to_string(getpid());
+	const std::string release_file =
+		"/tmp/bpftime-shm-allocation-release-" +
+		std::to_string(getpid());
+	unlink(ready_file.c_str());
+	unlink(release_file.c_str());
 	boost::interprocess::shared_memory_object::remove(shm_name.c_str());
+
+	int output_pipe[2];
+	REQUIRE(pipe(output_pipe) == 0);
+	pid_t pid = fork();
+	REQUIRE(pid >= 0);
+	if (pid == 0) {
+		close(output_pipe[0]);
+		if (dup2(output_pipe[1], STDOUT_FILENO) == -1 ||
+		    dup2(output_pipe[1], STDERR_FILENO) == -1) {
+			_exit(125);
+		}
+		close(output_pipe[1]);
+		if (setenv("HOME", "/proc/bpftime-unwritable-home", 1) != 0 ||
+		    setenv("BPFTIME_GLOBAL_SHM_NAME", shm_name.c_str(), 1) !=
+			    0 ||
+		    setenv("BPFTIME_SHM_MEMORY_MB", "4", 1) != 0 ||
+		    setenv("BPFTIME_MAX_FD_COUNT", "128", 1) != 0 ||
+		    setenv("BPFTIME_HELPER_READY_FILE", ready_file.c_str(),
+			   1) != 0 ||
+		    setenv("BPFTIME_HELPER_RELEASE_FILE", release_file.c_str(),
+			   1) != 0 ||
+		    setenv("LD_PRELOAD", BPFTIME_SYSCALL_SERVER_LIBRARY, 1) !=
+			    0) {
+			_exit(126);
+		}
+		execl(BPFTIME_SHM_ALLOCATION_TEST_HELPER,
+		      BPFTIME_SHM_ALLOCATION_TEST_HELPER, "startup-wait",
+		      nullptr);
+		_exit(127);
+	}
+
+	close(output_pipe[1]);
+	REQUIRE(wait_for_file(ready_file));
+
+	env_var_guard shm_name_guard("BPFTIME_GLOBAL_SHM_NAME");
+	REQUIRE(setenv("BPFTIME_GLOBAL_SHM_NAME", shm_name.c_str(), 1) == 0);
+	parent_shm_guard parent_shm;
+	bpftime_destroy_global_shm();
+	bpftime_initialize_global_shm(bpftime::shm_open_type::SHM_OPEN_ONLY);
+	parent_shm.initialized = true;
+	if (set_name == live_pid_set::syscall_server) {
+		bpftime::shm_holder.global_shared_memory
+			.add_pid_into_alive_syscall_server_set(getpid());
+		parent_shm.added_as_syscall_server = true;
+	} else {
+		bpftime::shm_holder.global_shared_memory
+			.add_pid_into_alive_agent_set(getpid());
+	}
+	parent_shm.pid_added = true;
+
+	{
+		std::ofstream release(release_file);
+		REQUIRE(release.good());
+	}
+
+	std::string output;
+	char buf[256];
+	for (;;) {
+		ssize_t bytes_read = read(output_pipe[0], buf, sizeof(buf));
+		if (bytes_read < 0) {
+			REQUIRE(errno == EINTR);
+			continue;
+		}
+		if (bytes_read == 0) {
+			break;
+		}
+		output.append(buf, buf + bytes_read);
+	}
+	close(output_pipe[0]);
+
+	int status = 0;
+	while (waitpid(pid, &status, 0) == -1) {
+		REQUIRE(errno == EINTR);
+	}
+	parent_shm.cleanup();
+	unlink(ready_file.c_str());
+	unlink(release_file.c_str());
 	return { status, std::move(output) };
 }
 } // namespace
@@ -174,6 +349,88 @@ TEST_CASE("Syscall server preserves the console logger level name",
 					    "console", "stderr=off");
 	REQUIRE(WIFEXITED(result.status));
 	REQUIRE(WEXITSTATUS(result.status) == 1);
+	REQUIRE(result.output.empty());
+}
+
+TEST_CASE("Syscall server removes owned shared memory on normal exit",
+	  "[allocation][syscall_server][cleanup]")
+{
+	std::string shm_name;
+	auto result = run_allocation_helper("startup-ok", "4", "128", nullptr,
+					    nullptr, false, &shm_name);
+
+	REQUIRE(WIFEXITED(result.status));
+	REQUIRE(WEXITSTATUS(result.status) == 0);
+	REQUIRE_FALSE(
+		boost::interprocess::shared_memory_object::remove(
+			shm_name.c_str()));
+}
+
+TEST_CASE("Syscall server preserves shared memory it only opened",
+	  "[allocation][syscall_server][cleanup]")
+{
+	const std::string shm_name = "bpftime-shm-allocation-test-startup-ok-" +
+				     std::to_string(getpid());
+	boost::interprocess::shared_memory_object::remove(shm_name.c_str());
+	boost::interprocess::managed_shared_memory existing_segment(
+		boost::interprocess::create_only, shm_name.c_str(), 4 << 20);
+
+	std::string helper_shm_name;
+	auto result = run_allocation_helper("startup-ok", "4", "128", nullptr,
+					    nullptr, false, &helper_shm_name,
+					    false);
+
+	REQUIRE(helper_shm_name == shm_name);
+	REQUIRE(WIFEXITED(result.status));
+	REQUIRE(WEXITSTATUS(result.status) == 0);
+	REQUIRE(
+		boost::interprocess::shared_memory_object::remove(
+			shm_name.c_str()));
+}
+
+TEST_CASE("Syscall server keeps shared memory while an agent pid is alive",
+	  "[allocation][syscall_server][cleanup]")
+{
+	const std::string shm_name =
+		"bpftime-shm-allocation-test-live-agent-" +
+		std::to_string(getpid());
+	auto result =
+		run_waiting_helper_with_live_pid(shm_name,
+						 live_pid_set::alive_agent);
+
+	REQUIRE(WIFEXITED(result.status));
+	REQUIRE(WEXITSTATUS(result.status) == 0);
+	REQUIRE(result.output.empty());
+	REQUIRE(
+		boost::interprocess::shared_memory_object::remove(
+			shm_name.c_str()));
+}
+
+TEST_CASE("Syscall server keeps shared memory while a peer server pid is alive",
+	  "[allocation][syscall_server][cleanup]")
+{
+	const std::string shm_name =
+		"bpftime-shm-allocation-test-live-server-" +
+		std::to_string(getpid());
+	auto result =
+		run_waiting_helper_with_live_pid(shm_name,
+						 live_pid_set::syscall_server);
+
+	REQUIRE(WIFEXITED(result.status));
+	REQUIRE(WEXITSTATUS(result.status) == 0);
+	REQUIRE(result.output.empty());
+	REQUIRE(
+		boost::interprocess::shared_memory_object::remove(
+			shm_name.c_str()));
+}
+
+TEST_CASE("Syscall server mock files do not leave tmp entries",
+	  "[allocation][syscall_server][cleanup]")
+{
+	auto result = run_allocation_helper("mock-tmp", "4", "128", nullptr);
+
+	REQUIRE(WIFEXITED(result.status));
+	REQUIRE(WEXITSTATUS(result.status) == 0);
 	REQUIRE(result.output.empty());
 }
 #endif


### PR DESCRIPTION
## Summary
- Fix syscall-server-owned global shm cleanup so the creator removes the segment on normal exit only when no live syscall-server peers or agents remain.
- Add lifecycle locking plus alive pid bookkeeping for syscall servers and agents; pid-set reads/writes now fail closed instead of hanging or treating unknown state as empty.
- Stop leaking mocked `/tmp/bpftime-mock.*` files by unlinking them immediately, preserving `O_CLOEXEC`, closing mocked fds, and making `fopen` mock failures fall back cleanly.
- Add regression coverage for owned cleanup, non-owner preservation, live agent/server preservation, unlinked mock temp files, and parent-test shm holder isolation.

Fixes #637
Fixes #638

## Validation
- `git diff --check`
- `cmake --build build-release-cleanup-llvm --config Debug --target bpftime_runtime_tests bpftime-agent -j$(nproc)`
- `cmake --build build-release-cleanup --config Debug --target bpftime_runtime_tests bpftime-agent -j$(nproc)`
- `./build-release-cleanup-llvm/runtime/unit-test/bpftime_runtime_tests "[cleanup]"`
- `./build-release-cleanup-llvm/runtime/unit-test/bpftime_runtime_tests "[allocation][syscall_server]"`
- `./build-release-cleanup/runtime/unit-test/bpftime_runtime_tests "[cleanup]"`
- `./build-release-cleanup/runtime/unit-test/bpftime_runtime_tests "[allocation][syscall_server]"`

Note: after the final test-isolation fix, the local full LLVM runtime suite no longer hits the prior attach-filter SIGSEGV. It still reports two local environment-sensitive failures unrelated to this PR (`Test shm progs attach` path equivalence and `Test tail calling from userspace to kernel` map creation), which were already observed while auditing this branch.
