### PR TITLE
Fix preload fail-open error boundaries

### DIFF
--- a/.github/workflows/test-gpu-examples.yml
+++ b/.github/workflows/test-gpu-examples.yml
@@ -380,12 +380,8 @@ jobs:
 
           if [ -d "$ART_ROOT/build" ]; then
             mv "$ART_ROOT/build" build
-            exit 0
-          fi
-
-          if [ -d "$ART_ROOT/bpftime-gpu-build/build" ]; then
+          elif [ -d "$ART_ROOT/bpftime-gpu-build/build" ]; then
             mv "$ART_ROOT/bpftime-gpu-build/build" build
-            exit 0
           fi
 
           # If upload-artifact chose 'build/' as the artifact root, downloaded files look like:
@@ -399,6 +395,15 @@ jobs:
               fi
             done
           fi
+
+          # Directory inputs can also be extracted without the leading attach/
+          # component. Put those directories back where the GPU tests expect them.
+          for d in text_segment_transformer nv_attach_impl; do
+            if [ -d "$ART_ROOT/$d" ]; then
+              mkdir -p "build/attach/$d"
+              cp -a "$ART_ROOT/$d/." "build/attach/$d/"
+            fi
+          done
 
           if [ -d build ]; then
             echo "Found build/ in workspace."

--- a/runtime/agent/agent.cpp
+++ b/runtime/agent/agent.cpp
@@ -763,16 +763,26 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 	bool force_reinit = false;
 	bool recorded_alive_pid = false;
 	bool ctx_constructed = false;
-	auto init_fail = [&]() {
-		reset_syscall_trace_global();
+	auto init_fail = [&]() noexcept {
+		try {
+			reset_syscall_trace_global();
+		} catch (...) {
+		}
 		if (ctx_constructed) {
-			ctx_holder.destroy();
+			try {
+				ctx_holder.destroy();
+			} catch (...) {
+			}
 			ctx_constructed = false;
 		}
 		global_ctx_constructed.store(false, std::memory_order_release);
 		if (recorded_alive_pid) {
-			shm_holder.global_shared_memory
-				.remove_pid_from_alive_agent_set(getpid());
+			try {
+				shm_holder.global_shared_memory
+					.remove_pid_from_alive_agent_set(
+						getpid());
+			} catch (...) {
+			}
 			recorded_alive_pid = false;
 		}
 		__atomic_store_n(&initialized, 0, __ATOMIC_SEQ_CST);
@@ -818,12 +828,6 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 			}
 
 			SPDLOG_DEBUG("Entered bpftime_agent_main");
-			SPDLOG_DEBUG("Registering signal handler");
-
-			srand(std::random_device()());
-			// We use SIGUSR1 to indicate the detaching.
-			ensure_detach_worker_started();
-			signal(SIGUSR1, sig_handler_sigusr1_detach);
 
 			// SHM can race with the loader process; retry a bit to avoid
 			// flakiness in "spawn loader then inject agent" workflows.
@@ -849,6 +853,11 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 				init_fail();
 				return;
 			}
+			SPDLOG_DEBUG("Registering signal handler");
+			srand(std::random_device()());
+			// We use SIGUSR1 to indicate the detaching.
+			ensure_detach_worker_started();
+			signal(SIGUSR1, sig_handler_sigusr1_detach);
 			auto &runtime_config = bpftime_get_runtime_config();
 			bpftime_set_logger(std::string(
 				runtime_config.get_logger_output_path()));

--- a/runtime/agent/agent.cpp
+++ b/runtime/agent/agent.cpp
@@ -276,7 +276,8 @@ static void start_agent_ipc_server_once()
 		}
 		agent_ipc_fd = fd;
 		agent_ipc_stop.store(false, std::memory_order_release);
-		agent_ipc_thread = std::thread([]() {
+		try {
+			agent_ipc_thread = std::thread([]() {
 			for (;;) {
 				if (agent_ipc_stop.load(std::memory_order_acquire))
 					return;
@@ -369,7 +370,13 @@ static void start_agent_ipc_server_once()
 				}
 				::close(cfd);
 			}
-		});
+			});
+		} catch (...) {
+			agent_ipc_stop.store(true, std::memory_order_release);
+			::close(fd);
+			agent_ipc_fd = -1;
+			return;
+		}
 		std::atexit([]() {
 			agent_ipc_stop.store(true, std::memory_order_release);
 			if (agent_ipc_fd >= 0) {
@@ -379,7 +386,11 @@ static void start_agent_ipc_server_once()
 			if (agent_ipc_thread.joinable())
 				agent_ipc_thread.detach();
 		});
-		SPDLOG_INFO("agent ipc: listening (abstract) for pid {}", (int)getpid());
+		try {
+			SPDLOG_INFO("agent ipc: listening (abstract) for pid {}",
+				    (int)getpid());
+		} catch (...) {
+		}
 	});
 #else
 	(void)0;
@@ -806,6 +817,13 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 				auto_refresh_thread.join();
 		} catch (...) {
 		}
+		for (int &fd : detach_pipe_fds) {
+			if (fd >= 0) {
+				::close(fd);
+				fd = -1;
+			}
+		}
+		detach_thread_started.store(false, std::memory_order_release);
 		if (ctx_constructed) {
 			try {
 				ctx_holder.destroy();
@@ -1000,10 +1018,6 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 			}
 			srand(std::random_device()());
 
-			// Start IPC control plane for repeat attach/refresh (used by
-			// `bpftime trace`).
-			start_agent_ipc_server_once();
-
 			int auto_refresh_ms = parse_auto_refresh_ms(data);
 			pid_t loader_pid = parse_loader_pid(data);
 			if (auto_refresh_ms > 0) {
@@ -1069,6 +1083,9 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 				init_fail();
 				return;
 			}
+			// Start IPC control plane for repeat attach/refresh (used by
+			// `bpftime trace`).
+			start_agent_ipc_server_once();
 			signal(SIGUSR1, sig_handler_sigusr1_detach);
 			/* We don't want our library to be unloaded after we return. */
 			*stay_resident = TRUE;

--- a/runtime/agent/agent.cpp
+++ b/runtime/agent/agent.cpp
@@ -1065,8 +1065,11 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 			} catch (...) {
 			}
 			// We use SIGUSR1 to indicate the detaching.
-			if (ensure_detach_worker_started())
-				signal(SIGUSR1, sig_handler_sigusr1_detach);
+			if (!ensure_detach_worker_started()) {
+				init_fail();
+				return;
+			}
+			signal(SIGUSR1, sig_handler_sigusr1_detach);
 			/* We don't want our library to be unloaded after we return. */
 			*stay_resident = TRUE;
 			setenv("BPFTIME_USED", "1", 0);

--- a/runtime/agent/agent.cpp
+++ b/runtime/agent/agent.cpp
@@ -52,7 +52,12 @@ using main_func_t = int (*)(int, char **, char **);
 
 static main_func_t orig_main_func = nullptr;
 
-static int initialized = 0;
+enum agent_init_state {
+	AGENT_UNINITIALIZED = 0,
+	AGENT_INITIALIZING = 1,
+	AGENT_READY = 2,
+};
+static int initialized = AGENT_UNINITIALIZED;
 
 using agent_control_fn_t = void (*)(const gchar *);
 
@@ -109,7 +114,8 @@ static int perform_detach();
 
 static void install_agent_bootstrap_logger() noexcept
 {
-	if (__atomic_load_n(&initialized, __ATOMIC_SEQ_CST) == 1)
+	if (__atomic_load_n(&initialized, __ATOMIC_SEQ_CST) !=
+	    AGENT_UNINITIALIZED)
 		return;
 	const char *logger_target = getenv("BPFTIME_LOG_OUTPUT");
 	bpftime_set_logger(logger_target == nullptr ? DEFAULT_LOGGER_OUTPUT_PATH :
@@ -401,7 +407,8 @@ static int perform_detach()
 {
 	std::lock_guard<std::mutex> detach_guard(detach_mutex);
 	if (!global_ctx_constructed.load(std::memory_order_acquire)) {
-		__atomic_store_n(&initialized, 0, __ATOMIC_SEQ_CST);
+		__atomic_store_n(&initialized, AGENT_UNINITIALIZED,
+				 __ATOMIC_SEQ_CST);
 		return 0;
 	}
 	SPDLOG_INFO("Detaching..");
@@ -494,7 +501,8 @@ static bool ensure_detach_worker_started() noexcept
 					return;
 				}
 				if (__atomic_load_n(&initialized,
-						    __ATOMIC_SEQ_CST) != 1) {
+						    __ATOMIC_SEQ_CST) !=
+				    AGENT_READY) {
 					continue;
 				}
 				perform_detach();
@@ -654,7 +662,7 @@ static bool parse_force_reinit(const gchar *data)
 
 static int refresh_attach_session(const gchar *data)
 {
-	if (__atomic_load_n(&initialized, __ATOMIC_SEQ_CST) != 1) {
+	if (__atomic_load_n(&initialized, __ATOMIC_SEQ_CST) != AGENT_READY) {
 		SPDLOG_WARN("agent_control: agent not initialized");
 		return -EINVAL;
 	}
@@ -852,7 +860,8 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 			}
 			recorded_alive_pid = false;
 		}
-		__atomic_store_n(&initialized, 0, __ATOMIC_SEQ_CST);
+		__atomic_store_n(&initialized, AGENT_UNINITIALIZED,
+				 __ATOMIC_SEQ_CST);
 	};
 	try {
 #ifdef __linux__
@@ -875,11 +884,16 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 
 			force_reinit = parse_force_reinit(data);
 			{
-				int expected = 0;
+				int expected = AGENT_UNINITIALIZED;
 				if (!__atomic_compare_exchange_n(
-					    &initialized, &expected, 1, false,
+					    &initialized, &expected,
+					    AGENT_INITIALIZING, false,
 					    __ATOMIC_SEQ_CST,
 					    __ATOMIC_SEQ_CST)) {
+					if (expected != AGENT_READY) {
+						*stay_resident = FALSE;
+						return;
+					}
 					if (!force_reinit) {
 						SPDLOG_INFO(
 							"Agent already initialized, skipping re-initializing..");
@@ -1107,6 +1121,8 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 			/* We don't want our library to be unloaded after we return. */
 			*stay_resident = TRUE;
 			setenv("BPFTIME_USED", "1", 0);
+			__atomic_store_n(&initialized, AGENT_READY,
+					 __ATOMIC_SEQ_CST);
 			try {
 				SPDLOG_DEBUG("Set environment variable BPFTIME_USED");
 			} catch (...) {

--- a/runtime/agent/agent.cpp
+++ b/runtime/agent/agent.cpp
@@ -5,6 +5,7 @@
 #include "frida_uprobe_attach_impl.hpp"
 
 #include "spdlog/common.h"
+#include "bpftime_config.hpp"
 #include "bpftime_logger.hpp"
 #include <chrono>
 #include <csignal>
@@ -106,11 +107,31 @@ static void apply_injected_kv_overrides(const gchar *data);
 static int refresh_attach_session(const gchar *data);
 static int perform_detach();
 
+static void install_agent_bootstrap_logger() noexcept
+{
+	if (__atomic_load_n(&initialized, __ATOMIC_SEQ_CST) == 1)
+		return;
+	const char *logger_target = getenv("BPFTIME_LOG_OUTPUT");
+	bpftime_set_logger(logger_target == nullptr ? DEFAULT_LOGGER_OUTPUT_PATH :
+						     logger_target);
+}
+
+static void reset_syscall_trace_global() noexcept
+{
+#if __linux__ && BPFTIME_BUILD_WITH_LIBBPF
+	try {
+		bpftime::attach::global_syscall_trace_attach_impl.reset();
+	} catch (...) {
+	}
+#endif
+}
+
 extern "C" __attribute__((visibility("default"))) void
 bpftime_agent_control(const gchar *data)
 {
 	// External control entrypoint used to avoid loading multiple agent copies
 	// into the same target process (Frida typically loads via /proc/self/fd/*).
+	install_agent_bootstrap_logger();
 	try {
 		(void)refresh_attach_session(data);
 	} catch (...) {
@@ -738,6 +759,7 @@ extern "C" void **__cudaRegisterFatBinary(void *fatbin)
 #endif
 extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 {
+	install_agent_bootstrap_logger();
 	try {
 #ifdef __linux__
 			// If an agent IPC server is already present in this process,
@@ -761,6 +783,7 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 			bool recorded_alive_pid = false;
 			bool ctx_constructed = false;
 			auto init_fail = [&]() {
+				reset_syscall_trace_global();
 				if (ctx_constructed) {
 					ctx_holder.destroy();
 					ctx_constructed = false;
@@ -849,7 +872,7 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 				std::make_unique<syscall_trace_attach_impl>();
 			syscall_trace_impl->set_original_syscall_function(
 				orig_hooker);
-			syscall_trace_impl->set_to_global();
+			auto *syscall_trace_impl_ptr = syscall_trace_impl.get();
 			ctx_holder.ctx.register_attach_impl(
 				{ ATTACH_SYSCALL_TRACE },
 				std::move(syscall_trace_impl),
@@ -911,6 +934,9 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 					}
 					return priv_data;
 				});
+#endif
+#if __linux__ && BPFTIME_BUILD_WITH_LIBBPF
+			syscall_trace_impl_ptr->set_to_global();
 #endif
 			SPDLOG_INFO("Initializing agent..");
 			/* We don't want our library to be unloaded after we return. */
@@ -998,8 +1024,10 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 
 			SPDLOG_INFO("Attach successfully");
 		} catch (const std::exception &) {
+			reset_syscall_trace_global();
 			__atomic_store_n(&initialized, 0, __ATOMIC_SEQ_CST);
 	} catch (...) {
+			reset_syscall_trace_global();
 			__atomic_store_n(&initialized, 0, __ATOMIC_SEQ_CST);
 		}
 }

--- a/runtime/agent/agent.cpp
+++ b/runtime/agent/agent.cpp
@@ -760,6 +760,23 @@ extern "C" void **__cudaRegisterFatBinary(void *fatbin)
 extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 {
 	install_agent_bootstrap_logger();
+	bool force_reinit = false;
+	bool recorded_alive_pid = false;
+	bool ctx_constructed = false;
+	auto init_fail = [&]() {
+		reset_syscall_trace_global();
+		if (ctx_constructed) {
+			ctx_holder.destroy();
+			ctx_constructed = false;
+		}
+		global_ctx_constructed.store(false, std::memory_order_release);
+		if (recorded_alive_pid) {
+			shm_holder.global_shared_memory
+				.remove_pid_from_alive_agent_set(getpid());
+			recorded_alive_pid = false;
+		}
+		__atomic_store_n(&initialized, 0, __ATOMIC_SEQ_CST);
+	};
 	try {
 #ifdef __linux__
 			// If an agent IPC server is already present in this process,
@@ -779,26 +796,7 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 				return;
 			}
 
-			bool force_reinit = parse_force_reinit(data);
-			bool recorded_alive_pid = false;
-			bool ctx_constructed = false;
-			auto init_fail = [&]() {
-				reset_syscall_trace_global();
-				if (ctx_constructed) {
-					ctx_holder.destroy();
-					ctx_constructed = false;
-				}
-				global_ctx_constructed.store(false,
-							     std::memory_order_release);
-				if (recorded_alive_pid) {
-					shm_holder.global_shared_memory
-						.remove_pid_from_alive_agent_set(
-							getpid());
-					recorded_alive_pid = false;
-				}
-				__atomic_store_n(&initialized, 0,
-						 __ATOMIC_SEQ_CST);
-			};
+			force_reinit = parse_force_reinit(data);
 			{
 				int expected = 0;
 				if (!__atomic_compare_exchange_n(
@@ -1024,11 +1022,9 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 
 			SPDLOG_INFO("Attach successfully");
 		} catch (const std::exception &) {
-			reset_syscall_trace_global();
-			__atomic_store_n(&initialized, 0, __ATOMIC_SEQ_CST);
-	} catch (...) {
-			reset_syscall_trace_global();
-			__atomic_store_n(&initialized, 0, __ATOMIC_SEQ_CST);
+			init_fail();
+		} catch (...) {
+			init_fail();
 		}
 }
 

--- a/runtime/agent/agent.cpp
+++ b/runtime/agent/agent.cpp
@@ -111,7 +111,10 @@ bpftime_agent_control(const gchar *data)
 {
 	// External control entrypoint used to avoid loading multiple agent copies
 	// into the same target process (Frida typically loads via /proc/self/fd/*).
-	(void)refresh_attach_session(data);
+	try {
+		(void)refresh_attach_session(data);
+	} catch (...) {
+	}
 }
 
 static void start_agent_ipc_server_once();
@@ -720,17 +723,15 @@ extern "C" void **__cudaRegisterFatBinary(void *fatbin)
 	try {
 		auto orig = try_get_original_func("__cudaRegisterFatBinary",
 						 original___cudaRegisterFatBinary);
+		if (orig == nullptr)
+			return nullptr;
 		// We have to register llvmbpf manually, since this function
 		// (__cudaRegisterFatBinary) might be called before llvm is registered
 		bpftime::vm::compat::llvm::register_llvm_vm_factory();
 		return orig(fatbin);
-	} catch (const std::exception &ex) {
-		fprintf(stderr,
-			"bpftime-agent: __cudaRegisterFatBinary wrapper failed: %s\n",
-			ex.what());
 	} catch (...) {
-		fprintf(stderr,
-			"bpftime-agent: __cudaRegisterFatBinary wrapper failed: unknown error\n");
+		if (original___cudaRegisterFatBinary != nullptr)
+			return original___cudaRegisterFatBinary(fatbin);
 	}
 	return nullptr;
 }
@@ -996,14 +997,9 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 			}
 
 			SPDLOG_INFO("Attach successfully");
-		} catch (const std::exception &ex) {
-			fprintf(stderr,
-				"bpftime-agent: bpftime_agent_main failed: %s\n",
-				ex.what());
+		} catch (const std::exception &) {
 			__atomic_store_n(&initialized, 0, __ATOMIC_SEQ_CST);
 	} catch (...) {
-			fprintf(stderr,
-				"bpftime-agent: bpftime_agent_main failed: unknown error\n");
 			__atomic_store_n(&initialized, 0, __ATOMIC_SEQ_CST);
 		}
 }
@@ -1015,17 +1011,31 @@ extern "C" int64_t syscall_callback(int64_t sys_nr, int64_t arg1, int64_t arg2,
 				    int64_t arg3, int64_t arg4, int64_t arg5,
 				    int64_t arg6)
 {
-	return bpftime::attach::global_syscall_trace_attach_impl.value()
-		->dispatch_syscall(sys_nr, arg1, arg2, arg3, arg4, arg5, arg6);
+	try {
+		auto impl = bpftime::attach::global_syscall_trace_attach_impl;
+		if (impl.has_value() && impl.value() != nullptr) {
+			return impl.value()->dispatch_syscall(
+				sys_nr, arg1, arg2, arg3, arg4, arg5, arg6);
+		}
+	} catch (...) {
+	}
+	if (orig_hooker != nullptr)
+		return orig_hooker(sys_nr, arg1, arg2, arg3, arg4, arg5, arg6);
+	return -ENOSYS;
 }
 
 extern "C" void
 _bpftime__setup_syscall_trace_callback(syscall_hooker_func_t *hooker)
 {
+	if (hooker == nullptr)
+		return;
 	orig_hooker = *hooker;
 	*hooker = &syscall_callback;
-	gboolean val;
-	bpftime_agent_main("", &val);
-	SPDLOG_INFO("Agent syscall trace setup exiting..");
+	gboolean val = FALSE;
+	try {
+		bpftime_agent_main("", &val);
+		SPDLOG_INFO("Agent syscall trace setup exiting..");
+	} catch (...) {
+	}
 }
 #endif

--- a/runtime/agent/agent.cpp
+++ b/runtime/agent/agent.cpp
@@ -426,43 +426,70 @@ static void stop_auto_refresh_at_exit()
 		auto_refresh_thread.join();
 }
 
-static void ensure_detach_worker_started()
+static bool ensure_detach_worker_started() noexcept
 {
 	bool expected = false;
 	if (!detach_thread_started.compare_exchange_strong(
 		    expected, true, std::memory_order_acq_rel,
 		    std::memory_order_acquire)) {
-		return;
+		return true;
 	}
-	int fds[2];
-#ifdef __linux__
-	if (pipe2(fds, O_CLOEXEC) != 0) {
-		SPDLOG_WARN("pipe2 failed, detach by SIGUSR1 will be disabled");
-		detach_thread_started.store(false, std::memory_order_release);
-		return;
-	}
-#else
-	if (pipe(fds) != 0) {
-		SPDLOG_WARN("pipe failed, detach by SIGUSR1 will be disabled");
-		detach_thread_started.store(false, std::memory_order_release);
-		return;
-	}
-#endif
-	detach_pipe_fds[0] = fds[0];
-	detach_pipe_fds[1] = fds[1];
-	std::thread([]() {
-		for (;;) {
-			uint8_t buf[16];
-			ssize_t n = read(detach_pipe_fds[0], buf, sizeof(buf));
-			if (n <= 0) {
-				return;
+	int fds[2] = { -1, -1 };
+	auto clear_fds = [&]() {
+		for (int &fd : fds) {
+			if (fd >= 0) {
+				::close(fd);
+				fd = -1;
 			}
-			if (__atomic_load_n(&initialized, __ATOMIC_SEQ_CST) != 1) {
-				continue;
-			}
-			perform_detach();
 		}
-	}).detach();
+		for (int &fd : detach_pipe_fds) {
+			if (fd >= 0) {
+				::close(fd);
+				fd = -1;
+			}
+		}
+		detach_thread_started.store(false, std::memory_order_release);
+	};
+	try {
+#ifdef __linux__
+		if (pipe2(fds, O_CLOEXEC) != 0) {
+			SPDLOG_WARN(
+				"pipe2 failed, detach by SIGUSR1 will be disabled");
+			clear_fds();
+			return false;
+		}
+#else
+		if (pipe(fds) != 0) {
+			SPDLOG_WARN(
+				"pipe failed, detach by SIGUSR1 will be disabled");
+			clear_fds();
+			return false;
+		}
+#endif
+		detach_pipe_fds[0] = fds[0];
+		detach_pipe_fds[1] = fds[1];
+		fds[0] = -1;
+		fds[1] = -1;
+		std::thread([]() {
+			for (;;) {
+				uint8_t buf[16];
+				ssize_t n =
+					read(detach_pipe_fds[0], buf, sizeof(buf));
+				if (n <= 0) {
+					return;
+				}
+				if (__atomic_load_n(&initialized,
+						    __ATOMIC_SEQ_CST) != 1) {
+					continue;
+				}
+				perform_detach();
+			}
+		}).detach();
+		return true;
+	} catch (...) {
+		clear_fds();
+		return false;
+	}
 }
 
 syscall_hooker_func_t orig_hooker;
@@ -763,9 +790,20 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 	bool force_reinit = false;
 	bool recorded_alive_pid = false;
 	bool ctx_constructed = false;
+	bool claimed_initialization = false;
 	auto init_fail = [&]() noexcept {
+		if (!claimed_initialization)
+			return;
 		try {
 			reset_syscall_trace_global();
+		} catch (...) {
+		}
+		try {
+			auto_refresh_epoch.fetch_add(1, std::memory_order_acq_rel);
+			std::lock_guard<std::mutex> guard(
+				auto_refresh_thread_mutex);
+			if (auto_refresh_thread.joinable())
+				auto_refresh_thread.join();
 		} catch (...) {
 		}
 		if (ctx_constructed) {
@@ -825,6 +863,7 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 					*stay_resident = TRUE;
 					return;
 				}
+				claimed_initialization = true;
 			}
 
 			SPDLOG_DEBUG("Entered bpftime_agent_main");
@@ -853,11 +892,6 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 				init_fail();
 				return;
 			}
-			SPDLOG_DEBUG("Registering signal handler");
-			srand(std::random_device()());
-			// We use SIGUSR1 to indicate the detaching.
-			ensure_detach_worker_started();
-			signal(SIGUSR1, sig_handler_sigusr1_detach);
 			auto &runtime_config = bpftime_get_runtime_config();
 			bpftime_set_logger(std::string(
 				runtime_config.get_logger_output_path()));
@@ -946,11 +980,7 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 			syscall_trace_impl_ptr->set_to_global();
 #endif
 			SPDLOG_INFO("Initializing agent..");
-			/* We don't want our library to be unloaded after we return. */
-			*stay_resident = TRUE;
 
-			setenv("BPFTIME_USED", "1", 0);
-			SPDLOG_DEBUG("Set environment variable BPFTIME_USED");
 			try {
 				int res = ctx_holder.ctx
 						  .init_attach_ctx_from_handlers(
@@ -968,6 +998,7 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 				init_fail();
 				return;
 			}
+			srand(std::random_device()());
 
 			// Start IPC control plane for repeat attach/refresh (used by
 			// `bpftime trace`).
@@ -1029,7 +1060,24 @@ extern "C" void bpftime_agent_main(const gchar *data, gboolean *stay_resident)
 				std::atexit(stop_auto_refresh_at_exit);
 			}
 
-			SPDLOG_INFO("Attach successfully");
+			try {
+				SPDLOG_DEBUG("Registering signal handler");
+			} catch (...) {
+			}
+			// We use SIGUSR1 to indicate the detaching.
+			if (ensure_detach_worker_started())
+				signal(SIGUSR1, sig_handler_sigusr1_detach);
+			/* We don't want our library to be unloaded after we return. */
+			*stay_resident = TRUE;
+			setenv("BPFTIME_USED", "1", 0);
+			try {
+				SPDLOG_DEBUG("Set environment variable BPFTIME_USED");
+			} catch (...) {
+			}
+			try {
+				SPDLOG_INFO("Attach successfully");
+			} catch (...) {
+			}
 		} catch (const std::exception &) {
 			init_fail();
 		} catch (...) {

--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -180,7 +180,13 @@ void syscall_context::try_startup()
 			enable_mock.store(true, std::memory_order_relaxed);
 		}
 	} guard{ enable_mock };
-	start_up(*this);
+	try {
+		start_up(*this);
+	} catch (...) {
+		enable_mock_after_initialized.store(false,
+						    std::memory_order_relaxed);
+		throw;
+	}
 }
 
 int syscall_context::handle_close(int fd)
@@ -880,7 +886,8 @@ void *syscall_context::handle_mmap64(void *addr, size_t length, int prot,
 				     int flags, int fd, off64_t offset)
 {
 	if (!enable_mock.load(std::memory_order_relaxed) || run_with_kernel ||
-	    initializing_cuda.load(std::memory_order_acquire))
+	    initializing_cuda.load(std::memory_order_acquire) ||
+	    !enable_mock_after_initialized.load(std::memory_order_relaxed))
 		return orig_mmap64_fn(addr, length, prot, flags, fd, offset);
 	try_startup();
 	SPDLOG_DEBUG("Calling mocked mmap64");
@@ -1059,8 +1066,12 @@ int syscall_context::handle_munmap(void *addr, size_t size)
 	try_startup();
 	if (auto itr = mocked_mmap_values.find((uintptr_t)addr);
 	    itr != mocked_mmap_values.end()) {
-		SPDLOG_DEBUG("Handling munmap of mocked addr: {:x}, size {}",
-			     (uintptr_t)addr, size);
+		try {
+			SPDLOG_DEBUG(
+				"Handling munmap of mocked addr: {:x}, size {}",
+				(uintptr_t)addr, size);
+		} catch (...) {
+		}
 		mocked_mmap_values.erase(itr);
 		return 0;
 	} else {

--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -72,18 +72,6 @@ using namespace bpftime_epoll;
 namespace fmt_lib = spdlog::fmt_lib;
 
 namespace {
-[[noreturn]] void
-exit_for_startup_allocation_failure(const std::exception &error)
-{
-	auto config = bpftime::construct_runtime_config_from_env();
-	SPDLOG_CRITICAL(
-		"Unable to initialize bpftime shared memory ({} MiB, {} fd slots): {}",
-		config.shm_memory_size, config.max_fd_count, error.what());
-	SPDLOG_CRITICAL(
-		"Increase BPFTIME_SHM_MEMORY_MB or decrease BPFTIME_MAX_FD_COUNT");
-	std::exit(EXIT_FAILURE);
-}
-
 void set_mock_fd_cloexec(int fd)
 {
 	int flags = fcntl(fd, F_GETFD);

--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -1134,8 +1134,9 @@ int syscall_context::handle_memfd_create(const char *name, int flags)
 	if (!enable_mock.load(std::memory_order_relaxed) ||
 	    initializing_cuda.load(std::memory_order_acquire) ||
 	    !enable_mock_after_initialized.load(std::memory_order_relaxed)) {
-		SPDLOG_DEBUG("Calling original dup3");
-		return orig_syscall_fn(__NR_dup3, (long)name, (long)flags);
+		SPDLOG_DEBUG("Calling original memfd_create");
+		return orig_syscall_fn(__NR_memfd_create, (long)name,
+				       (long)flags);
 	}
 	try_startup();
 	return bpftime_add_memfd_handler(name, flags);

--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -1059,24 +1059,30 @@ int syscall_context::handle_epoll_wait(int epfd, epoll_event *evt,
 
 int syscall_context::handle_munmap(void *addr, size_t size)
 {
+	auto handle_mocked_munmap = [&]() {
+		if (auto itr = mocked_mmap_values.find((uintptr_t)addr);
+		    itr != mocked_mmap_values.end()) {
+			try {
+				SPDLOG_DEBUG(
+					"Handling munmap of mocked addr: {:x}, size {}",
+					(uintptr_t)addr, size);
+			} catch (...) {
+			}
+			mocked_mmap_values.erase(itr);
+			return true;
+		}
+		return false;
+	};
+	if (handle_mocked_munmap())
+		return 0;
 	if (!enable_mock.load(std::memory_order_relaxed) || run_with_kernel ||
 	    initializing_cuda.load(std::memory_order_acquire) ||
 	    !enable_mock_after_initialized.load(std::memory_order_relaxed))
 		return orig_munmap_fn(addr, size);
 	try_startup();
-	if (auto itr = mocked_mmap_values.find((uintptr_t)addr);
-	    itr != mocked_mmap_values.end()) {
-		try {
-			SPDLOG_DEBUG(
-				"Handling munmap of mocked addr: {:x}, size {}",
-				(uintptr_t)addr, size);
-		} catch (...) {
-		}
-		mocked_mmap_values.erase(itr);
+	if (handle_mocked_munmap())
 		return 0;
-	} else {
-		return orig_munmap_fn(addr, size);
-	}
+	return orig_munmap_fn(addr, size);
 }
 
 FILE *syscall_context::handle_fopen(const char *pathname, const char *flags)

--- a/runtime/syscall-server/syscall_context.cpp
+++ b/runtime/syscall-server/syscall_context.cpp
@@ -71,18 +71,6 @@ using namespace bpftime_epoll;
 namespace fmt_lib = spdlog::fmt_lib;
 
 namespace {
-[[noreturn]] void
-exit_for_startup_allocation_failure(const std::exception &error)
-{
-	auto config = bpftime::construct_runtime_config_from_env();
-	SPDLOG_CRITICAL(
-		"Unable to initialize bpftime shared memory ({} MiB, {} fd slots): {}",
-		config.shm_memory_size, config.max_fd_count, error.what());
-	SPDLOG_CRITICAL(
-		"Increase BPFTIME_SHM_MEMORY_MB or decrease BPFTIME_MAX_FD_COUNT");
-	std::exit(EXIT_FAILURE);
-}
-
 int get_bpf_obj_info_by_fd(int fd, void *info, uint32_t *info_len,
 			   long (*syscall_fn)(long, ...))
 {
@@ -185,12 +173,14 @@ void syscall_context::initialize_cuda()
 void syscall_context::try_startup()
 {
 	enable_mock.store(false, std::memory_order_relaxed);
-	try {
-		start_up(*this);
-	} catch (const boost::interprocess::bad_alloc &e) {
-		exit_for_startup_allocation_failure(e);
-	}
-	enable_mock.store(true, std::memory_order_relaxed);
+	struct enable_mock_guard {
+		std::atomic<bool> &enable_mock;
+		~enable_mock_guard()
+		{
+			enable_mock.store(true, std::memory_order_relaxed);
+		}
+	} guard{ enable_mock };
+	start_up(*this);
 }
 
 int syscall_context::handle_close(int fd)

--- a/runtime/syscall-server/syscall_context.hpp
+++ b/runtime/syscall-server/syscall_context.hpp
@@ -5,7 +5,6 @@
  */
 #ifndef _SYSCALL_CONTEXT_HPP
 #define _SYSCALL_CONTEXT_HPP
-#include <cassert>
 #include <set>
 #include <unordered_map>
 #if defined(__linux__)
@@ -22,6 +21,8 @@
 #include <pthread.h>
 #include <atomic>
 #include <future>
+#include <stdexcept>
+#include <string>
 #include <thread>
 // #include "pos/include/common.h"
 // #include "pos/include/utils/command_caller.h"
@@ -94,38 +95,36 @@ class syscall_context {
 		mocked_files;
 	void init_original_functions()
 	{
+		auto require_symbol = [](const char *name) {
+			void *symbol = dlsym(RTLD_NEXT, name);
+			if (symbol == nullptr)
+				throw std::runtime_error(
+					std::string(
+						"Unable to resolve original ") +
+					name);
+			return symbol;
+		};
+
 		orig_epoll_wait_fn =
-			(epoll_wait_fn)dlsym(RTLD_NEXT, "epoll_wait");
-		assert(orig_epoll_wait_fn != nullptr);
-		orig_epoll_ctl_fn = (epoll_ctl_fn)dlsym(RTLD_NEXT, "epoll_ctl");
-		assert(orig_epoll_ctl_fn != nullptr);
+			(epoll_wait_fn)require_symbol("epoll_wait");
+		orig_epoll_ctl_fn = (epoll_ctl_fn)require_symbol("epoll_ctl");
 		orig_epoll_create1_fn =
-			(epoll_craete1_fn)dlsym(RTLD_NEXT, "epoll_create1");
-		assert(orig_epoll_create1_fn != nullptr);
-		orig_ioctl_fn = (ioctl_fn)dlsym(RTLD_NEXT, "ioctl");
-		assert(orig_ioctl_fn != nullptr);
-		orig_syscall_fn = (syscall_fn)dlsym(RTLD_NEXT, "syscall");
-		assert(orig_syscall_fn != nullptr);
-		// orig_mmap64_fn = (mmap64_fn)dlsym(RTLD_NEXT, "mmap64");
-		// assert(orig_mmap64_fn != nullptr);
-		orig_close_fn = (close_fn)dlsym(RTLD_NEXT, "close");
-		assert(orig_close_fn != nullptr);
-		orig_munmap_fn = (munmap_fn)dlsym(RTLD_NEXT, "munmap");
-		assert(orig_munmap_fn != nullptr);
-		orig_mmap64_fn = orig_mmap_fn =
-			(mmap_fn)dlsym(RTLD_NEXT, "mmap");
-		assert(orig_mmap_fn != nullptr);
-		assert(orig_mmap64_fn != nullptr);
-		orig_openat_fn = (openat_fn)dlsym(RTLD_NEXT, "openat");
-		assert(orig_openat_fn != nullptr);
-		orig_open_fn = (open_fn)dlsym(RTLD_NEXT, "open");
-		assert(orig_open_fn != nullptr);
-		orig_read_fn = (read_fn)dlsym(RTLD_NEXT, "read");
-		assert(orig_read_fn != nullptr);
+			(epoll_craete1_fn)require_symbol("epoll_create1");
+		orig_ioctl_fn = (ioctl_fn)require_symbol("ioctl");
+		orig_syscall_fn = (syscall_fn)require_symbol("syscall");
+		orig_close_fn = (close_fn)require_symbol("close");
+		orig_munmap_fn = (munmap_fn)require_symbol("munmap");
+		orig_mmap_fn = (mmap_fn)require_symbol("mmap");
+		orig_mmap64_fn = (mmap64_fn)orig_mmap_fn;
+		orig_openat_fn = (openat_fn)require_symbol("openat");
+		orig_open_fn = (open_fn)require_symbol("open");
+		orig_read_fn = (read_fn)require_symbol("read");
 		orig_fopen_fn = (fopen_fn)dlsym(RTLD_NEXT, "fopen");
 		if (orig_fopen_fn == nullptr)
 			orig_fopen_fn = (fopen_fn)dlsym(RTLD_NEXT, "fopen64");
-		assert(orig_fopen_fn != nullptr);
+		if (orig_fopen_fn == nullptr)
+			throw std::runtime_error(
+				"Unable to resolve original fopen");
 
 		// To avoid polluting other child processes,
 		// unset the LD_PRELOAD env var after syscall context being

--- a/runtime/syscall-server/syscall_server_main.cpp
+++ b/runtime/syscall-server/syscall_server_main.cpp
@@ -256,6 +256,29 @@ auto handle_exceptions(F &&f, Fallback &&fallback) noexcept -> decltype(f())
 	}
 }
 
+template <typename F, typename Fallback>
+auto call_with_context(F &&f, Fallback &&fallback) noexcept
+	-> decltype(fallback())
+{
+	if (!initialize_ctx())
+		return fallback();
+	return handle_exceptions(std::forward<F>(f),
+				 std::forward<Fallback>(fallback));
+}
+
+template <typename F, typename Fallback, typename... Args>
+auto call_with_context_debug(spdlog::format_string_t<Args...> fmt, F &&f,
+			     Fallback &&fallback, Args &&...args) noexcept
+	-> decltype(fallback())
+{
+	return call_with_context(
+		[&]() {
+			safe_spdlog_debug(fmt, std::forward<Args>(args)...);
+			return f();
+		},
+		std::forward<Fallback>(fallback));
+}
+
 extern "C" int epoll_wait(int epfd, epoll_event *evt, int maxevents,
 			  int timeout)
 {
@@ -263,15 +286,11 @@ extern "C" int epoll_wait(int epfd, epoll_event *evt, int maxevents,
 		return call_next_symbol(next_epoll_wait_symbol, "epoll_wait",
 					-1, epfd, evt, maxevents, timeout);
 	};
-	if (!initialize_ctx())
-		return call_original();
-	safe_spdlog_debug("epoll_wait {}", epfd);
-	return handle_exceptions(
-		[&]() {
-			return context->handle_epoll_wait(epfd, evt, maxevents,
-							  timeout);
-		},
-		call_original);
+	return call_with_context_debug(
+		"epoll_wait {}",
+		[&]() { return context->handle_epoll_wait(epfd, evt, maxevents,
+							  timeout); },
+		call_original, epfd);
 }
 
 extern "C" int epoll_ctl(int epfd, int op, int fd, epoll_event *evt)
@@ -280,13 +299,10 @@ extern "C" int epoll_ctl(int epfd, int op, int fd, epoll_event *evt)
 		return call_next_symbol(next_epoll_ctl_symbol, "epoll_ctl",
 					-1, epfd, op, fd, evt);
 	};
-	if (!initialize_ctx())
-		return call_original();
-	safe_spdlog_debug("epoll_ctl {} {} {} {}", epfd, op, fd,
-			  (uintptr_t)evt);
-	return handle_exceptions(
+	return call_with_context_debug(
+		"epoll_ctl {} {} {} {}",
 		[&]() { return context->handle_epoll_ctl(epfd, op, fd, evt); },
-		call_original);
+		call_original, epfd, op, fd, (uintptr_t)evt);
 }
 
 extern "C" int epoll_create1(int flags)
@@ -295,12 +311,10 @@ extern "C" int epoll_create1(int flags)
 		return call_next_symbol(next_epoll_create1_symbol,
 					"epoll_create1", -1, flags);
 	};
-	if (!initialize_ctx())
-		return call_original();
-	safe_spdlog_debug("epoll_create1 {}", flags);
-	return handle_exceptions(
+	return call_with_context_debug(
+		"epoll_create1 {}",
 		[&]() { return context->handle_epoll_create1(flags); },
-		call_original);
+		call_original, flags);
 }
 
 extern "C" int ioctl(int fd, unsigned long req, ...)
@@ -313,12 +327,10 @@ extern "C" int ioctl(int fd, unsigned long req, ...)
 		return call_next_symbol(next_ioctl_symbol, "ioctl", -1, fd,
 					req, arg3);
 	};
-	if (!initialize_ctx())
-		return call_original();
-	safe_spdlog_debug("ioctl {} {} {}", fd, req, arg3);
-	return handle_exceptions(
+	return call_with_context_debug(
+		"ioctl {} {} {}",
 		[&]() { return context->handle_ioctl(fd, req, arg3); },
-		call_original);
+		call_original, fd, req, arg3);
 }
 
 extern "C" void *mmap64(void *addr, size_t length, int prot, int flags, int fd,
@@ -327,15 +339,11 @@ extern "C" void *mmap64(void *addr, size_t length, int prot, int flags, int fd,
 	auto call_original = [&]() {
 		return fallback_mmap64(addr, length, prot, flags, fd, offset);
 	};
-	if (!initialize_ctx())
-		return call_original();
-	safe_spdlog_debug("mmap64 {:x}", (uintptr_t)addr);
-	return handle_exceptions(
-		[&]() {
-			return context->handle_mmap64(addr, length, prot, flags,
-						      fd, offset);
-		},
-		call_original);
+	return call_with_context_debug(
+		"mmap64 {:x}",
+		[&]() { return context->handle_mmap64(addr, length, prot, flags,
+						      fd, offset); },
+		call_original, (uintptr_t)addr);
 }
 
 extern "C" void *mmap(void *addr, size_t length, int prot, int flags, int fd,
@@ -346,15 +354,11 @@ extern "C" void *mmap(void *addr, size_t length, int prot, int flags, int fd,
 					addr, length, prot, flags, fd,
 					offset);
 	};
-	if (!initialize_ctx())
-		return call_original();
-	safe_spdlog_debug("mmap {:x}", (uintptr_t)addr);
-	return handle_exceptions(
-		[&]() {
-			return context->handle_mmap(addr, length, prot, flags,
-						    fd, offset);
-		},
-		call_original);
+	return call_with_context_debug(
+		"mmap {:x}",
+		[&]() { return context->handle_mmap(addr, length, prot, flags,
+						    fd, offset); },
+		call_original, (uintptr_t)addr);
 }
 
 extern "C" int munmap(void *addr, size_t size)
@@ -363,12 +367,10 @@ extern "C" int munmap(void *addr, size_t size)
 		return call_next_symbol(next_munmap_symbol, "munmap", -1,
 					addr, size);
 	};
-	if (!initialize_ctx())
-		return call_original();
-	safe_spdlog_debug("munmap {:x} {}", (uintptr_t)addr, size);
-	return handle_exceptions(
+	return call_with_context_debug(
+		"munmap {:x} {}",
 		[&]() { return context->handle_munmap(addr, size); },
-		call_original);
+		call_original, (uintptr_t)addr, size);
 }
 
 extern "C" int close(int fd)
@@ -376,11 +378,10 @@ extern "C" int close(int fd)
 	auto call_original = [&]() {
 		return call_next_symbol(next_close_symbol, "close", -1, fd);
 	};
-	if (!initialize_ctx())
-		return call_original();
-	safe_spdlog_debug("Closing fd {}", fd);
-	return handle_exceptions([&]() { return context->handle_close(fd); },
-				 call_original);
+	return call_with_context_debug(
+		"Closing fd {}",
+		[&]() { return context->handle_close(fd); },
+		call_original, fd);
 }
 
 extern "C" int openat(int fd, const char *file, int oflag, ...)
@@ -392,19 +393,14 @@ extern "C" int openat(int fd, const char *file, int oflag, ...)
 	if (has_mode)
 		mode = va_arg(args, mode_t);
 	va_end(args);
-	if (!initialize_ctx())
-		return fallback_openat(fd, file, oflag, mode, has_mode);
 	auto call_original = [&]() {
 		return fallback_openat(fd, file, oflag, mode, has_mode);
 	};
-	safe_spdlog_debug("openat {} {} {} {}", fd, safe_ptr_str(file), oflag,
-			  mode);
-	return handle_exceptions(
-		[&]() {
-			return context->handle_openat(fd, file, oflag,
-						      (unsigned short)mode);
-		},
-		call_original);
+	return call_with_context_debug(
+		"openat {} {} {} {}",
+		[&]() { return context->handle_openat(fd, file, oflag,
+						      (unsigned short)mode); },
+		call_original, fd, safe_ptr_str(file), oflag, mode);
 }
 extern "C" int open(const char *file, int oflag, ...)
 {
@@ -415,18 +411,14 @@ extern "C" int open(const char *file, int oflag, ...)
 	if (has_mode)
 		mode = va_arg(args, mode_t);
 	va_end(args);
-	if (!initialize_ctx())
-		return fallback_open(file, oflag, mode, has_mode);
 	auto call_original = [&]() {
 		return fallback_open(file, oflag, mode, has_mode);
 	};
-	safe_spdlog_debug("open {} {} {}", safe_ptr_str(file), oflag, mode);
-	return handle_exceptions(
-		[&]() {
-			return context->handle_open(file, oflag,
-						    (unsigned short)mode);
-		},
-		call_original);
+	return call_with_context_debug(
+		"open {} {} {}",
+		[&]() { return context->handle_open(file, oflag,
+						    (unsigned short)mode); },
+		call_original, safe_ptr_str(file), oflag, mode);
 }
 extern "C" ssize_t read(int fd, void *buf, size_t count)
 {
@@ -434,9 +426,7 @@ extern "C" ssize_t read(int fd, void *buf, size_t count)
 		return call_next_symbol(next_read_symbol, "read", (ssize_t)-1,
 					fd, buf, count);
 	};
-	if (!initialize_ctx())
-		return call_original();
-	return handle_exceptions(
+	return call_with_context(
 		[&]() { return context->handle_read(fd, buf, count); },
 		call_original);
 }
@@ -447,13 +437,10 @@ extern "C" FILE *fopen(const char *pathname, const char *flags)
 		return call_next_symbol(next_fopen_symbol, "fopen",
 					(FILE *)nullptr, pathname, flags);
 	};
-	if (!initialize_ctx())
-		return call_original();
-	safe_spdlog_debug("fopen {} {}", safe_ptr_str(pathname),
-			  safe_ptr_str(flags));
-	return handle_exceptions(
+	return call_with_context_debug(
+		"fopen {} {}",
 		[&]() { return context->handle_fopen(pathname, flags); },
-		call_original);
+		call_original, safe_ptr_str(pathname), safe_ptr_str(flags));
 }
 extern "C" FILE *fopen64(const char *pathname, const char *flags)
 {
@@ -461,13 +448,10 @@ extern "C" FILE *fopen64(const char *pathname, const char *flags)
 		return call_next_symbol(next_fopen64_symbol, "fopen64",
 					(FILE *)nullptr, pathname, flags);
 	};
-	if (!initialize_ctx())
-		return call_original();
-	safe_spdlog_debug("fopen64 {} {}", safe_ptr_str(pathname),
-			  safe_ptr_str(flags));
-	return handle_exceptions(
+	return call_with_context_debug(
+		"fopen64 {} {}",
 		[&]() { return context->handle_fopen(pathname, flags); },
-		call_original);
+		call_original, safe_ptr_str(pathname), safe_ptr_str(flags));
 }
 extern "C" FILE *_IO_new_fopen(const char *pathname, const char *flags)
 {
@@ -475,13 +459,10 @@ extern "C" FILE *_IO_new_fopen(const char *pathname, const char *flags)
 		return call_next_symbol(next_fopen_symbol, "fopen",
 					(FILE *)nullptr, pathname, flags);
 	};
-	if (!initialize_ctx())
-		return call_original();
-	safe_spdlog_debug("_IO_new_fopen {} {}", safe_ptr_str(pathname),
-			  safe_ptr_str(flags));
-	return handle_exceptions(
+	return call_with_context_debug(
+		"_IO_new_fopen {} {}",
 		[&]() { return context->handle_fopen(pathname, flags); },
-		call_original);
+		call_original, safe_ptr_str(pathname), safe_ptr_str(flags));
 }
 #if __linux__
 extern "C" long syscall(long sysno, ...)

--- a/runtime/syscall-server/syscall_server_main.cpp
+++ b/runtime/syscall-server/syscall_server_main.cpp
@@ -20,6 +20,7 @@
 #include <cstring>
 #include <exception>
 #include <fcntl.h>
+#include <atomic>
 #include <spdlog/spdlog.h>
 #include <unistd.h>
 #include <spdlog/cfg/env.h>
@@ -45,10 +46,13 @@ inline const char *safe_ptr_str(const char *ptr)
 // called by spdlog itself)
 template <typename... Args>
 inline void safe_spdlog_debug(spdlog::format_string_t<Args...> fmt,
-			      Args &&...args)
+			      Args &&...args) noexcept
 {
 	if (spdlog::default_logger_raw()) {
-		spdlog::debug(fmt, std::forward<Args>(args)...);
+		try {
+			spdlog::debug(fmt, std::forward<Args>(args)...);
+		} catch (...) {
+		}
 	}
 }
 
@@ -84,6 +88,26 @@ using open_fn = int (*)(const char *, int, ...);
 using read_fn = ssize_t (*)(int, void *, size_t);
 using fopen_fn = FILE *(*)(const char *, const char *);
 
+template <typename Fn> struct cached_next_symbol {
+	std::atomic<Fn> value{ nullptr };
+	std::atomic<bool> initialized{ false };
+};
+
+static cached_next_symbol<raw_syscall_fn> next_syscall_symbol;
+static cached_next_symbol<close_fn> next_close_symbol;
+static cached_next_symbol<mmap64_fn> next_mmap64_symbol;
+static cached_next_symbol<mmap_fn> next_mmap_symbol;
+static cached_next_symbol<ioctl_fn> next_ioctl_symbol;
+static cached_next_symbol<epoll_create1_fn> next_epoll_create1_symbol;
+static cached_next_symbol<epoll_ctl_fn> next_epoll_ctl_symbol;
+static cached_next_symbol<epoll_wait_fn> next_epoll_wait_symbol;
+static cached_next_symbol<munmap_fn> next_munmap_symbol;
+static cached_next_symbol<openat_fn> next_openat_symbol;
+static cached_next_symbol<open_fn> next_open_symbol;
+static cached_next_symbol<read_fn> next_read_symbol;
+static cached_next_symbol<fopen_fn> next_fopen_symbol;
+static cached_next_symbol<fopen_fn> next_fopen64_symbol;
+
 static bool open_flags_have_mode(int flags) noexcept
 {
 	if ((flags & O_CREAT) != 0)
@@ -95,11 +119,25 @@ static bool open_flags_have_mode(int flags) noexcept
 	return false;
 }
 
+template <typename Fn>
+static Fn resolve_cached_next_symbol(cached_next_symbol<Fn> &symbol,
+				     const char *name) noexcept
+{
+	if (!symbol.initialized.load(std::memory_order_acquire)) {
+		auto fn = resolve_next_symbol<Fn>(name);
+		symbol.value.store(fn, std::memory_order_release);
+		symbol.initialized.store(true, std::memory_order_release);
+		return fn;
+	}
+	return symbol.value.load(std::memory_order_acquire);
+}
+
 template <typename Fn, typename Ret, typename... Args>
-static Ret call_next_symbol(const char *name, Ret failure,
+static Ret call_next_symbol(cached_next_symbol<Fn> &symbol, const char *name,
+			    Ret failure,
 			    Args... args) noexcept
 {
-	auto fn = resolve_next_symbol<Fn>(name);
+	auto fn = resolve_cached_next_symbol(symbol, name);
 	if (!fn) {
 		errno = ENOSYS;
 		return failure;
@@ -110,17 +148,17 @@ static Ret call_next_symbol(const char *name, Ret failure,
 static void *fallback_mmap64(void *addr, size_t length, int prot, int flags,
 			     int fd, off64_t offset) noexcept
 {
-	auto fn64 = resolve_next_symbol<mmap64_fn>("mmap64");
+	auto fn64 = resolve_cached_next_symbol(next_mmap64_symbol, "mmap64");
 	if (fn64)
 		return fn64(addr, length, prot, flags, fd, offset);
-	return call_next_symbol<mmap_fn>("mmap", MAP_FAILED, addr, length, prot,
-					 flags, fd, (off_t)offset);
+	return call_next_symbol(next_mmap_symbol, "mmap", MAP_FAILED, addr,
+				length, prot, flags, fd, (off_t)offset);
 }
 
 static int fallback_openat(int fd, const char *file, int oflag, mode_t mode,
 			   bool has_mode) noexcept
 {
-	auto fn = resolve_next_symbol<openat_fn>("openat");
+	auto fn = resolve_cached_next_symbol(next_openat_symbol, "openat");
 	if (!fn) {
 		errno = ENOSYS;
 		return -1;
@@ -131,7 +169,7 @@ static int fallback_openat(int fd, const char *file, int oflag, mode_t mode,
 static int fallback_open(const char *file, int oflag, mode_t mode,
 			 bool has_mode) noexcept
 {
-	auto fn = resolve_next_symbol<open_fn>("open");
+	auto fn = resolve_cached_next_symbol(next_open_symbol, "open");
 	if (!fn) {
 		errno = ENOSYS;
 		return -1;
@@ -142,7 +180,7 @@ static int fallback_open(const char *file, int oflag, mode_t mode,
 static long fallback_syscall(long sysno, long arg1, long arg2, long arg3,
 			     long arg4, long arg5, long arg6) noexcept
 {
-	auto fn = resolve_next_symbol<raw_syscall_fn>("syscall");
+	auto fn = resolve_cached_next_symbol(next_syscall_symbol, "syscall");
 	if (!fn) {
 		errno = ENOSYS;
 		return -1;
@@ -222,8 +260,8 @@ extern "C" int epoll_wait(int epfd, epoll_event *evt, int maxevents,
 			  int timeout)
 {
 	auto call_original = [&]() {
-		return call_next_symbol<epoll_wait_fn>(
-			"epoll_wait", -1, epfd, evt, maxevents, timeout);
+		return call_next_symbol(next_epoll_wait_symbol, "epoll_wait",
+					-1, epfd, evt, maxevents, timeout);
 	};
 	if (!initialize_ctx())
 		return call_original();
@@ -239,8 +277,8 @@ extern "C" int epoll_wait(int epfd, epoll_event *evt, int maxevents,
 extern "C" int epoll_ctl(int epfd, int op, int fd, epoll_event *evt)
 {
 	auto call_original = [&]() {
-		return call_next_symbol<epoll_ctl_fn>("epoll_ctl", -1, epfd,
-						      op, fd, evt);
+		return call_next_symbol(next_epoll_ctl_symbol, "epoll_ctl",
+					-1, epfd, op, fd, evt);
 	};
 	if (!initialize_ctx())
 		return call_original();
@@ -254,8 +292,8 @@ extern "C" int epoll_ctl(int epfd, int op, int fd, epoll_event *evt)
 extern "C" int epoll_create1(int flags)
 {
 	auto call_original = [&]() {
-		return call_next_symbol<epoll_create1_fn>("epoll_create1", -1,
-							  flags);
+		return call_next_symbol(next_epoll_create1_symbol,
+					"epoll_create1", -1, flags);
 	};
 	if (!initialize_ctx())
 		return call_original();
@@ -272,7 +310,8 @@ extern "C" int ioctl(int fd, unsigned long req, ...)
 	unsigned long arg3 = va_arg(args, long);
 	va_end(args);
 	auto call_original = [&]() {
-		return call_next_symbol<ioctl_fn>("ioctl", -1, fd, req, arg3);
+		return call_next_symbol(next_ioctl_symbol, "ioctl", -1, fd,
+					req, arg3);
 	};
 	if (!initialize_ctx())
 		return call_original();
@@ -303,9 +342,9 @@ extern "C" void *mmap(void *addr, size_t length, int prot, int flags, int fd,
 		      off_t offset)
 {
 	auto call_original = [&]() {
-		return call_next_symbol<mmap_fn>("mmap", MAP_FAILED, addr,
-						 length, prot, flags, fd,
-						 offset);
+		return call_next_symbol(next_mmap_symbol, "mmap", MAP_FAILED,
+					addr, length, prot, flags, fd,
+					offset);
 	};
 	if (!initialize_ctx())
 		return call_original();
@@ -321,7 +360,8 @@ extern "C" void *mmap(void *addr, size_t length, int prot, int flags, int fd,
 extern "C" int munmap(void *addr, size_t size)
 {
 	auto call_original = [&]() {
-		return call_next_symbol<munmap_fn>("munmap", -1, addr, size);
+		return call_next_symbol(next_munmap_symbol, "munmap", -1,
+					addr, size);
 	};
 	if (!initialize_ctx())
 		return call_original();
@@ -334,7 +374,7 @@ extern "C" int munmap(void *addr, size_t size)
 extern "C" int close(int fd)
 {
 	auto call_original = [&]() {
-		return call_next_symbol<close_fn>("close", -1, fd);
+		return call_next_symbol(next_close_symbol, "close", -1, fd);
 	};
 	if (!initialize_ctx())
 		return call_original();
@@ -391,8 +431,8 @@ extern "C" int open(const char *file, int oflag, ...)
 extern "C" ssize_t read(int fd, void *buf, size_t count)
 {
 	auto call_original = [&]() {
-		return call_next_symbol<read_fn>("read", (ssize_t)-1, fd, buf,
-						 count);
+		return call_next_symbol(next_read_symbol, "read", (ssize_t)-1,
+					fd, buf, count);
 	};
 	if (!initialize_ctx())
 		return call_original();
@@ -404,8 +444,8 @@ extern "C" ssize_t read(int fd, void *buf, size_t count)
 extern "C" FILE *fopen(const char *pathname, const char *flags)
 {
 	auto call_original = [&]() {
-		return call_next_symbol<fopen_fn>("fopen", (FILE *)nullptr,
-						  pathname, flags);
+		return call_next_symbol(next_fopen_symbol, "fopen",
+					(FILE *)nullptr, pathname, flags);
 	};
 	if (!initialize_ctx())
 		return call_original();
@@ -418,8 +458,8 @@ extern "C" FILE *fopen(const char *pathname, const char *flags)
 extern "C" FILE *fopen64(const char *pathname, const char *flags)
 {
 	auto call_original = [&]() {
-		return call_next_symbol<fopen_fn>("fopen64", (FILE *)nullptr,
-						  pathname, flags);
+		return call_next_symbol(next_fopen64_symbol, "fopen64",
+					(FILE *)nullptr, pathname, flags);
 	};
 	if (!initialize_ctx())
 		return call_original();
@@ -432,9 +472,8 @@ extern "C" FILE *fopen64(const char *pathname, const char *flags)
 extern "C" FILE *_IO_new_fopen(const char *pathname, const char *flags)
 {
 	auto call_original = [&]() {
-		return call_next_symbol<fopen_fn>("_IO_new_fopen",
-						  (FILE *)nullptr, pathname,
-						  flags);
+		return call_next_symbol(next_fopen_symbol, "fopen",
+					(FILE *)nullptr, pathname, flags);
 	};
 	if (!initialize_ctx())
 		return call_original();

--- a/runtime/syscall-server/syscall_server_main.cpp
+++ b/runtime/syscall-server/syscall_server_main.cpp
@@ -15,26 +15,139 @@
 #include "linux/bpf.h"
 #include <asm-generic/errno-base.h>
 #endif
+#include <cerrno>
 #include <cstdlib>
 #include <cstring>
+#include <exception>
+#include <fcntl.h>
 #include <spdlog/spdlog.h>
 #include <unistd.h>
 #include <spdlog/cfg/env.h>
 #include <cstdarg>
 #include <sched.h>
+#include <sys/epoll.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <utility>
+
+// 0 = uninitialized, 1 = in progress, 2 = done, 3 = disabled
+static int ctx_initialized = 0;
+static __thread int tls_initializing = 0;
 
 // Helper function for safe logging with pointer parameters
-inline const char* safe_ptr_str(const char* ptr) {
+inline const char *safe_ptr_str(const char *ptr)
+{
 	return ptr ? ptr : "<null>";
 }
 
 // Safe debug logging that checks if logger is initialized
-// This prevents crashes during logger initialization (e.g., when fopen is called by spdlog itself)
-template<typename... Args>
-inline void safe_spdlog_debug(spdlog::format_string_t<Args...> fmt, Args&&... args) {
+// This prevents crashes during logger initialization (e.g., when fopen is
+// called by spdlog itself)
+template <typename... Args>
+inline void safe_spdlog_debug(spdlog::format_string_t<Args...> fmt,
+			      Args &&...args)
+{
 	if (spdlog::default_logger_raw()) {
 		spdlog::debug(fmt, std::forward<Args>(args)...);
 	}
+}
+
+template <typename... Args>
+inline void safe_spdlog_error(spdlog::format_string_t<Args...> fmt,
+			      Args &&...args) noexcept
+{
+	if (__atomic_load_n(&ctx_initialized, __ATOMIC_ACQUIRE) == 2 &&
+	    spdlog::default_logger_raw()) {
+		try {
+			spdlog::error(fmt, std::forward<Args>(args)...);
+		} catch (...) {
+		}
+	}
+}
+
+template <typename T> static T resolve_next_symbol(const char *name) noexcept
+{
+	return (T)dlsym(RTLD_NEXT, name);
+}
+
+using raw_syscall_fn = long (*)(long, ...);
+using close_fn = int (*)(int);
+using mmap64_fn = void *(*)(void *, size_t, int, int, int, off64_t);
+using mmap_fn = void *(*)(void *, size_t, int, int, int, off_t);
+using ioctl_fn = int (*)(int, unsigned long, ...);
+using epoll_create1_fn = int (*)(int);
+using epoll_ctl_fn = int (*)(int, int, int, epoll_event *);
+using epoll_wait_fn = int (*)(int, epoll_event *, int, int);
+using munmap_fn = int (*)(void *, size_t);
+using openat_fn = int (*)(int, const char *, int, ...);
+using open_fn = int (*)(const char *, int, ...);
+using read_fn = ssize_t (*)(int, void *, size_t);
+using fopen_fn = FILE *(*)(const char *, const char *);
+
+static bool open_flags_have_mode(int flags) noexcept
+{
+	if ((flags & O_CREAT) != 0)
+		return true;
+#ifdef O_TMPFILE
+	if ((flags & O_TMPFILE) == O_TMPFILE)
+		return true;
+#endif
+	return false;
+}
+
+template <typename Fn, typename Ret, typename... Args>
+static Ret call_next_symbol(const char *name, Ret failure,
+			    Args... args) noexcept
+{
+	auto fn = resolve_next_symbol<Fn>(name);
+	if (!fn) {
+		errno = ENOSYS;
+		return failure;
+	}
+	return fn(args...);
+}
+
+static void *fallback_mmap64(void *addr, size_t length, int prot, int flags,
+			     int fd, off64_t offset) noexcept
+{
+	auto fn64 = resolve_next_symbol<mmap64_fn>("mmap64");
+	if (fn64)
+		return fn64(addr, length, prot, flags, fd, offset);
+	return call_next_symbol<mmap_fn>("mmap", MAP_FAILED, addr, length, prot,
+					 flags, fd, (off_t)offset);
+}
+
+static int fallback_openat(int fd, const char *file, int oflag, mode_t mode,
+			   bool has_mode) noexcept
+{
+	auto fn = resolve_next_symbol<openat_fn>("openat");
+	if (!fn) {
+		errno = ENOSYS;
+		return -1;
+	}
+	return has_mode ? fn(fd, file, oflag, mode) : fn(fd, file, oflag);
+}
+
+static int fallback_open(const char *file, int oflag, mode_t mode,
+			 bool has_mode) noexcept
+{
+	auto fn = resolve_next_symbol<open_fn>("open");
+	if (!fn) {
+		errno = ENOSYS;
+		return -1;
+	}
+	return has_mode ? fn(file, oflag, mode) : fn(file, oflag);
+}
+
+static long fallback_syscall(long sysno, long arg1, long arg2, long arg3,
+			     long arg4, long arg5, long arg6) noexcept
+{
+	auto fn = resolve_next_symbol<raw_syscall_fn>("syscall");
+	if (!fn) {
+		errno = ENOSYS;
+		return -1;
+	}
+	return fn(sysno, arg1, arg2, arg3, arg4, arg5, arg6);
 }
 
 // global context for bpf syscall server
@@ -52,168 +165,288 @@ union syscall_server_ctx_union {
 	}
 };
 static syscall_server_ctx_union context;
-// 0 = uninitialized, 1 = in progress, 2 = done
-static int ctx_initialized = 0;
-static __thread int tls_initializing = 0;
-static void initialize_ctx()
+static bool initialize_ctx() noexcept
 {
 	if (tls_initializing)
-		return;
+		return false;
+	int state = __atomic_load_n(&ctx_initialized, __ATOMIC_ACQUIRE);
+	if (state == 2)
+		return true;
+	if (state == 3)
+		return false;
 	int expected = 0;
 	if (__atomic_compare_exchange_n(&ctx_initialized, &expected, 1, false,
 					__ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST)) {
 		tls_initializing = 1;
-		new (&context.ctx) syscall_context;
+		try {
+			new (&context.ctx) syscall_context;
+		} catch (...) {
+			tls_initializing = 0;
+			__atomic_store_n(&ctx_initialized, 3, __ATOMIC_RELEASE);
+			return false;
+		}
 		tls_initializing = 0;
 		__atomic_store_n(&ctx_initialized, 2, __ATOMIC_RELEASE);
+		return true;
 	} else {
-		while (__atomic_load_n(&ctx_initialized, __ATOMIC_ACQUIRE) != 2) {
+		while ((state = __atomic_load_n(&ctx_initialized,
+						__ATOMIC_ACQUIRE)) == 1) {
 			sched_yield();
 		}
+		return state == 2;
 	}
 }
-template <typename F, typename... Args>
-auto handle_exceptions(F &&f, Args &&...args) noexcept
-	-> decltype(f(std::forward<Args>(args)...))
+
+template <typename F, typename Fallback>
+auto handle_exceptions(F &&f, Fallback &&fallback) noexcept -> decltype(f())
 {
 	try {
-		return f(std::forward<Args>(args)...);
+		return f();
 	} catch (const boost::interprocess::bad_alloc &e) {
-		SPDLOG_ERROR("Boost interprocess bad_alloc: {}", e.what());
-		SPDLOG_ERROR("Consider increasing the shared memory size by "
-			     "setting the BPFTIME_SHM_MEMORY_MB env var.");
-		std::exit(1);
-		// Terminate the program after logging the exception
+		safe_spdlog_error("Boost interprocess bad_alloc: {}", e.what());
+		safe_spdlog_error(
+			"Falling back to the original host operation");
+		return fallback();
+	} catch (const std::exception &e) {
+		safe_spdlog_error("bpftime syscall interposer failed: {}",
+				  e.what());
+		return fallback();
+	} catch (...) {
+		safe_spdlog_error(
+			"bpftime syscall interposer failed with an unknown exception");
+		return fallback();
 	}
-	// More exceptions can be added here
 }
 
 extern "C" int epoll_wait(int epfd, epoll_event *evt, int maxevents,
 			  int timeout)
 {
-	initialize_ctx();
+	auto call_original = [&]() {
+		return call_next_symbol<epoll_wait_fn>(
+			"epoll_wait", -1, epfd, evt, maxevents, timeout);
+	};
+	if (!initialize_ctx())
+		return call_original();
 	safe_spdlog_debug("epoll_wait {}", epfd);
-	return handle_exceptions([&]() {
-		return context->handle_epoll_wait(epfd, evt, maxevents,
-						  timeout);
-	});
+	return handle_exceptions(
+		[&]() {
+			return context->handle_epoll_wait(epfd, evt, maxevents,
+							  timeout);
+		},
+		call_original);
 }
 
 extern "C" int epoll_ctl(int epfd, int op, int fd, epoll_event *evt)
 {
-	initialize_ctx();
-	safe_spdlog_debug("epoll_ctl {} {} {} {}", epfd, op, fd, (uintptr_t)evt);
+	auto call_original = [&]() {
+		return call_next_symbol<epoll_ctl_fn>("epoll_ctl", -1, epfd,
+						      op, fd, evt);
+	};
+	if (!initialize_ctx())
+		return call_original();
+	safe_spdlog_debug("epoll_ctl {} {} {} {}", epfd, op, fd,
+			  (uintptr_t)evt);
 	return handle_exceptions(
-		[&]() { return context->handle_epoll_ctl(epfd, op, fd, evt); });
+		[&]() { return context->handle_epoll_ctl(epfd, op, fd, evt); },
+		call_original);
 }
 
 extern "C" int epoll_create1(int flags)
 {
-	initialize_ctx();
+	auto call_original = [&]() {
+		return call_next_symbol<epoll_create1_fn>("epoll_create1", -1,
+							  flags);
+	};
+	if (!initialize_ctx())
+		return call_original();
 	safe_spdlog_debug("epoll_create1 {}", flags);
 	return handle_exceptions(
-		[&]() { return context->handle_epoll_create1(flags); });
+		[&]() { return context->handle_epoll_create1(flags); },
+		call_original);
 }
 
 extern "C" int ioctl(int fd, unsigned long req, ...)
 {
-	initialize_ctx();
 	va_list args;
 	va_start(args, req);
 	unsigned long arg3 = va_arg(args, long);
 	va_end(args);
+	auto call_original = [&]() {
+		return call_next_symbol<ioctl_fn>("ioctl", -1, fd, req, arg3);
+	};
+	if (!initialize_ctx())
+		return call_original();
 	safe_spdlog_debug("ioctl {} {} {}", fd, req, arg3);
 	return handle_exceptions(
-		[&]() { return context->handle_ioctl(fd, req, arg3); });
+		[&]() { return context->handle_ioctl(fd, req, arg3); },
+		call_original);
 }
 
 extern "C" void *mmap64(void *addr, size_t length, int prot, int flags, int fd,
 			off64_t offset)
 {
-	initialize_ctx();
+	auto call_original = [&]() {
+		return fallback_mmap64(addr, length, prot, flags, fd, offset);
+	};
+	if (!initialize_ctx())
+		return call_original();
 	safe_spdlog_debug("mmap64 {:x}", (uintptr_t)addr);
-	return handle_exceptions([&]() {
-		return context->handle_mmap64(addr, length, prot, flags, fd,
-					      offset);
-	});
+	return handle_exceptions(
+		[&]() {
+			return context->handle_mmap64(addr, length, prot, flags,
+						      fd, offset);
+		},
+		call_original);
 }
 
 extern "C" void *mmap(void *addr, size_t length, int prot, int flags, int fd,
 		      off_t offset)
 {
-	initialize_ctx();
+	auto call_original = [&]() {
+		return call_next_symbol<mmap_fn>("mmap", MAP_FAILED, addr,
+						 length, prot, flags, fd,
+						 offset);
+	};
+	if (!initialize_ctx())
+		return call_original();
 	safe_spdlog_debug("mmap {:x}", (uintptr_t)addr);
-	return handle_exceptions([&]() {
-		return context->handle_mmap(addr, length, prot, flags, fd,
-					    offset);
-	});
+	return handle_exceptions(
+		[&]() {
+			return context->handle_mmap(addr, length, prot, flags,
+						    fd, offset);
+		},
+		call_original);
 }
 
 extern "C" int munmap(void *addr, size_t size)
 {
-	initialize_ctx();
+	auto call_original = [&]() {
+		return call_next_symbol<munmap_fn>("munmap", -1, addr, size);
+	};
+	if (!initialize_ctx())
+		return call_original();
 	safe_spdlog_debug("munmap {:x} {}", (uintptr_t)addr, size);
 	return handle_exceptions(
-		[&]() { return context->handle_munmap(addr, size); });
+		[&]() { return context->handle_munmap(addr, size); },
+		call_original);
 }
 
 extern "C" int close(int fd)
 {
-	initialize_ctx();
+	auto call_original = [&]() {
+		return call_next_symbol<close_fn>("close", -1, fd);
+	};
+	if (!initialize_ctx())
+		return call_original();
 	safe_spdlog_debug("Closing fd {}", fd);
-	return handle_exceptions([&]() { return context->handle_close(fd); });
+	return handle_exceptions([&]() { return context->handle_close(fd); },
+				 call_original);
 }
 
 extern "C" int openat(int fd, const char *file, int oflag, ...)
 {
-	initialize_ctx();
+	bool has_mode = open_flags_have_mode(oflag);
+	mode_t mode = 0;
 	va_list args;
 	va_start(args, oflag);
-	long arg4 = va_arg(args, long);
+	if (has_mode)
+		mode = va_arg(args, mode_t);
 	va_end(args);
-	safe_spdlog_debug("openat {} {} {} {}", fd, safe_ptr_str(file), oflag, arg4);
-	unsigned short mode = (unsigned short)arg4;
-	return context->handle_openat(fd, file, oflag, mode);
+	if (!initialize_ctx())
+		return fallback_openat(fd, file, oflag, mode, has_mode);
+	auto call_original = [&]() {
+		return fallback_openat(fd, file, oflag, mode, has_mode);
+	};
+	safe_spdlog_debug("openat {} {} {} {}", fd, safe_ptr_str(file), oflag,
+			  mode);
+	return handle_exceptions(
+		[&]() {
+			return context->handle_openat(fd, file, oflag,
+						      (unsigned short)mode);
+		},
+		call_original);
 }
 extern "C" int open(const char *file, int oflag, ...)
 {
-	initialize_ctx();
+	bool has_mode = open_flags_have_mode(oflag);
+	mode_t mode = 0;
 	va_list args;
 	va_start(args, oflag);
-	long arg3 = va_arg(args, long);
+	if (has_mode)
+		mode = va_arg(args, mode_t);
 	va_end(args);
-	safe_spdlog_debug("open {} {} {}", safe_ptr_str(file), oflag, arg3);
-	unsigned short mode = (unsigned short)arg3;
-	return context->handle_open(file, oflag, mode);
+	if (!initialize_ctx())
+		return fallback_open(file, oflag, mode, has_mode);
+	auto call_original = [&]() {
+		return fallback_open(file, oflag, mode, has_mode);
+	};
+	safe_spdlog_debug("open {} {} {}", safe_ptr_str(file), oflag, mode);
+	return handle_exceptions(
+		[&]() {
+			return context->handle_open(file, oflag,
+						    (unsigned short)mode);
+		},
+		call_original);
 }
 extern "C" ssize_t read(int fd, void *buf, size_t count)
 {
-	initialize_ctx();
-	return context->handle_read(fd, buf, count);
+	auto call_original = [&]() {
+		return call_next_symbol<read_fn>("read", (ssize_t)-1, fd, buf,
+						 count);
+	};
+	if (!initialize_ctx())
+		return call_original();
+	return handle_exceptions(
+		[&]() { return context->handle_read(fd, buf, count); },
+		call_original);
 }
 
 extern "C" FILE *fopen(const char *pathname, const char *flags)
 {
-	initialize_ctx();
-	safe_spdlog_debug("fopen {} {}", safe_ptr_str(pathname), safe_ptr_str(flags));
-	return context->handle_fopen(pathname, flags);
+	auto call_original = [&]() {
+		return call_next_symbol<fopen_fn>("fopen", (FILE *)nullptr,
+						  pathname, flags);
+	};
+	if (!initialize_ctx())
+		return call_original();
+	safe_spdlog_debug("fopen {} {}", safe_ptr_str(pathname),
+			  safe_ptr_str(flags));
+	return handle_exceptions(
+		[&]() { return context->handle_fopen(pathname, flags); },
+		call_original);
 }
 extern "C" FILE *fopen64(const char *pathname, const char *flags)
 {
-	initialize_ctx();
-	safe_spdlog_debug("fopen64 {} {}", safe_ptr_str(pathname), safe_ptr_str(flags));
-	return context->handle_fopen(pathname, flags);
+	auto call_original = [&]() {
+		return call_next_symbol<fopen_fn>("fopen64", (FILE *)nullptr,
+						  pathname, flags);
+	};
+	if (!initialize_ctx())
+		return call_original();
+	safe_spdlog_debug("fopen64 {} {}", safe_ptr_str(pathname),
+			  safe_ptr_str(flags));
+	return handle_exceptions(
+		[&]() { return context->handle_fopen(pathname, flags); },
+		call_original);
 }
 extern "C" FILE *_IO_new_fopen(const char *pathname, const char *flags)
 {
-	initialize_ctx();
-	safe_spdlog_debug("_IO_new_fopen {} {}", safe_ptr_str(pathname), safe_ptr_str(flags));
-	return context->handle_fopen(pathname, flags);
+	auto call_original = [&]() {
+		return call_next_symbol<fopen_fn>("_IO_new_fopen",
+						  (FILE *)nullptr, pathname,
+						  flags);
+	};
+	if (!initialize_ctx())
+		return call_original();
+	safe_spdlog_debug("_IO_new_fopen {} {}", safe_ptr_str(pathname),
+			  safe_ptr_str(flags));
+	return handle_exceptions(
+		[&]() { return context->handle_fopen(pathname, flags); },
+		call_original);
 }
 #if __linux__
 extern "C" long syscall(long sysno, ...)
 {
-	initialize_ctx();
 	// glibc directly reads the arguments without considering
 	// the underlying argument number. So did us
 	va_list args;
@@ -225,43 +458,58 @@ extern "C" long syscall(long sysno, ...)
 	long arg5 = va_arg(args, long);
 	long arg6 = va_arg(args, long);
 	va_end(args);
+	if (!initialize_ctx())
+		return fallback_syscall(sysno, arg1, arg2, arg3, arg4, arg5,
+					arg6);
+	auto call_original = [&]() {
+		return context->orig_syscall_fn(sysno, arg1, arg2, arg3, arg4,
+						arg5, arg6);
+	};
 	if (sysno == __NR_bpf) {
-	safe_spdlog_debug("SYS_BPF {} {} {} {} {} {}", arg1, arg2, arg3,
-			     arg4, arg5, arg6);
+		safe_spdlog_debug("SYS_BPF {} {} {} {} {} {}", arg1, arg2, arg3,
+				  arg4, arg5, arg6);
 		int cmd = (int)arg1;
 		auto attr = (union bpf_attr *)(uintptr_t)arg2;
 		auto size = (size_t)arg3;
-		return handle_exceptions([&]() {
-			return context->handle_sysbpf(cmd, attr, size);
-		});
+		return handle_exceptions(
+			[&]() {
+				return context->handle_sysbpf(cmd, attr, size);
+			},
+			call_original);
 	} else if (sysno == __NR_perf_event_open) {
-	safe_spdlog_debug("SYS_PERF_EVENT_OPEN {} {} {} {} {} {}", arg1,
-			     arg2, arg3, arg4, arg5, arg6);
-		return handle_exceptions([&]() {
-			return context->handle_perfevent(
-				(perf_event_attr *)(uintptr_t)arg1, (pid_t)arg2,
-				(int)arg3, (int)arg4, (unsigned long)arg5);
-		});
+		safe_spdlog_debug("SYS_PERF_EVENT_OPEN {} {} {} {} {} {}", arg1,
+				  arg2, arg3, arg4, arg5, arg6);
+		return handle_exceptions(
+			[&]() {
+				return context->handle_perfevent(
+					(perf_event_attr *)(uintptr_t)arg1,
+					(pid_t)arg2, (int)arg3, (int)arg4,
+					(unsigned long)arg5);
+			},
+			call_original);
 	} else if (sysno == __NR_ioctl) {
-	safe_spdlog_debug("SYS_IOCTL {} {} {} {} {} {}", arg1, arg2, arg3,
-			     arg4, arg5, arg6);
+		safe_spdlog_debug("SYS_IOCTL {} {} {} {} {} {}", arg1, arg2,
+				  arg3, arg4, arg5, arg6);
 	} else if (sysno == __NR_dup3) {
-	safe_spdlog_debug("SYS_DUP3 oldfd={} newfd={} flags={}", arg1, arg2,
-			     arg3);
-		return handle_exceptions([&]() {
-			return context->handle_dup3((int)arg1, (int)arg2,
-						    (int)arg3);
-		});
+		safe_spdlog_debug("SYS_DUP3 oldfd={} newfd={} flags={}", arg1,
+				  arg2, arg3);
+		return handle_exceptions(
+			[&]() {
+				return context->handle_dup3(
+					(int)arg1, (int)arg2, (int)arg3);
+			},
+			call_original);
 	} else if (sysno == __NR_memfd_create) {
-	safe_spdlog_debug("SYS_MEMFD_CREATE name={} flags={}",
-			     safe_ptr_str((const char *)arg1), arg2);
-		return handle_exceptions([&]() {
-			return context->handle_memfd_create((const char *)arg1,
-							    (int)arg2);
-		});
+		safe_spdlog_debug("SYS_MEMFD_CREATE name={} flags={}",
+				  safe_ptr_str((const char *)arg1), arg2);
+		return handle_exceptions(
+			[&]() {
+				return context->handle_memfd_create(
+					(const char *)arg1, (int)arg2);
+			},
+			call_original);
 	}
-	return context->orig_syscall_fn(sysno, arg1, arg2, arg3, arg4, arg5,
-					arg6);
+	return call_original();
 }
 #endif
 
@@ -269,8 +517,15 @@ extern "C" long syscall(long sysno, ...)
 extern "C" int bpftime_syscall_server__poll_gpu_ringbuf_map(
 	int mapfd, void *ctx, void (*fn)(const void *, uint64_t, void *))
 {
-	return handle_exceptions([&]() {
-		return context->poll_gpu_ringbuf_map(mapfd, ctx, fn);
-	});
+	if (!initialize_ctx()) {
+		errno = ENOSYS;
+		return -1;
+	}
+	return handle_exceptions(
+		[&]() { return context->poll_gpu_ringbuf_map(mapfd, ctx, fn); },
+		[&]() {
+			errno = EIO;
+			return -1;
+		});
 }
 #endif

--- a/runtime/syscall-server/syscall_server_utils.cpp
+++ b/runtime/syscall-server/syscall_server_utils.cpp
@@ -10,6 +10,7 @@
 #include "cuda.h"
 #endif
 #include "syscall_context.hpp"
+#include <exception>
 #include <fcntl.h>
 #include <filesystem>
 #include <memory>
@@ -26,6 +27,7 @@
 namespace bpftime
 {
 static std::once_flag g_startup_once;
+static std::exception_ptr g_startup_exception;
 using namespace bpftime;
 // Why not use string_view? because parse_uint_from_file requires a c-string
 static const std::string UPROBE_TYPE_FILE_NAME =
@@ -40,63 +42,72 @@ static const std::string KRETPROBE_BIT_FILE_NAME =
 void start_up(syscall_context &ctx)
 {
 	std::call_once(g_startup_once, [&ctx]() {
-		SPDLOG_INFO("Starting syscall server..");
-		auto runtime_config = construct_runtime_config_from_env();
-		SPDLOG_INFO("Initialize syscall server");
+		try {
+			SPDLOG_INFO("Starting syscall server..");
+			auto runtime_config = construct_runtime_config_from_env();
+			SPDLOG_INFO("Initialize syscall server");
 
-		bpftime_initialize_global_shm(
-			shm_open_type::SHM_CREATE_OR_OPEN);
+			bpftime_initialize_global_shm(
+				shm_open_type::SHM_CREATE_OR_OPEN);
 #if defined(BPFTIME_ENABLE_CUDA_ATTACH)
-		ctx.initialize_cuda();
+			ctx.initialize_cuda();
 #endif
-		shm_holder.global_shared_memory.begin_new_session();
-		shm_holder.global_shared_memory.set_mock_setter([&](bool flg) {
-			ctx.enable_mock_after_initialized.store(
-				flg, std::memory_order_relaxed);
-			SPDLOG_INFO(
-				"syscall server: Set enable_mock_after_initialized to {}",
-				flg);
-		});
+			shm_holder.global_shared_memory.begin_new_session();
+			shm_holder.global_shared_memory.set_mock_setter(
+				[&](bool flg) {
+					ctx.enable_mock_after_initialized.store(
+						flg, std::memory_order_relaxed);
+					SPDLOG_INFO(
+						"syscall server: Set enable_mock_after_initialized to {}",
+						flg);
+				});
 #ifdef ENABLE_BPFTIME_VERIFIER
-		std::vector<int32_t> helper_ids;
-		std::map<int32_t, bpftime::verifier::BpftimeHelperProrotype>
-			non_kernel_helpers;
-		if (runtime_config.enable_kernel_helper_group) {
-			for (auto x :
-			     bpftime_helper_group::get_kernel_utils_helper_group()
-				     .get_helper_ids()) {
-				helper_ids.push_back(x);
+			std::vector<int32_t> helper_ids;
+			std::map<int32_t,
+				 bpftime::verifier::BpftimeHelperProrotype>
+				non_kernel_helpers;
+			if (runtime_config.enable_kernel_helper_group) {
+				for (auto x : bpftime_helper_group::
+					     get_kernel_utils_helper_group()
+						     .get_helper_ids()) {
+					helper_ids.push_back(x);
+				}
 			}
-		}
-		if (runtime_config.enable_shm_maps_helper_group) {
-			for (auto x :
-			     bpftime_helper_group::get_shm_maps_helper_group()
-				     .get_helper_ids()) {
-				helper_ids.push_back(x);
+			if (runtime_config.enable_shm_maps_helper_group) {
+				for (auto x : bpftime_helper_group::
+					     get_shm_maps_helper_group()
+						     .get_helper_ids()) {
+					helper_ids.push_back(x);
+				}
 			}
-		}
-		if (runtime_config.enable_ufunc_helper_group) {
-			for (auto x :
-			     bpftime_helper_group::get_shm_maps_helper_group()
-				     .get_helper_ids()) {
-				helper_ids.push_back(x);
+			if (runtime_config.enable_ufunc_helper_group) {
+				for (auto x : bpftime_helper_group::
+					     get_shm_maps_helper_group()
+						     .get_helper_ids()) {
+					helper_ids.push_back(x);
+				}
+				// non_kernel_helpers =
+				for (const auto &[k, v] :
+				     get_ufunc_helper_protos()) {
+					non_kernel_helpers[k] = v;
+				}
 			}
-			// non_kernel_helpers =
-			for (const auto &[k, v] : get_ufunc_helper_protos()) {
-				non_kernel_helpers[k] = v;
-			}
-		}
-		verifier::set_available_helpers(helper_ids);
-		SPDLOG_INFO("Enabling {} helpers", helper_ids.size());
-		verifier::set_non_kernel_helpers(non_kernel_helpers);
+			verifier::set_available_helpers(helper_ids);
+			SPDLOG_INFO("Enabling {} helpers", helper_ids.size());
+			verifier::set_non_kernel_helpers(non_kernel_helpers);
 #endif
-		bpftime_set_runtime_config(std::move(runtime_config));
-		// Set a variable to indicate the program that it's controlled
-		// by bpftime
-		setenv("BPFTIME_USED", "1", 0);
-		SPDLOG_DEBUG("Set environment variable BPFTIME_USED");
-		SPDLOG_INFO("bpftime-syscall-server started");
+			bpftime_set_runtime_config(std::move(runtime_config));
+			// Set a variable to indicate the program that it's
+			// controlled by bpftime
+			setenv("BPFTIME_USED", "1", 0);
+			SPDLOG_DEBUG("Set environment variable BPFTIME_USED");
+			SPDLOG_INFO("bpftime-syscall-server started");
+		} catch (...) {
+			g_startup_exception = std::current_exception();
+		}
 	});
+	if (g_startup_exception)
+		std::rethrow_exception(g_startup_exception);
 }
 
 /*

--- a/runtime/unit-test/CMakeLists.txt
+++ b/runtime/unit-test/CMakeLists.txt
@@ -61,12 +61,13 @@ if(UNIX AND NOT APPLE)
     set_property(TARGET bpftime-shm-allocation-test-helper PROPERTY C_STANDARD 99)
     set_property(TARGET bpftime-runtime-options-test-helper PROPERTY C_STANDARD 99)
     add_dependencies(bpftime_runtime_tests
+        bpftime-agent
         bpftime-syscall-server
         bpftime-runtime-options-test-helper
         bpftime-shm-allocation-test-helper)
     file(GENERATE
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/shm_allocation_test_paths.hpp"
-        CONTENT "#define BPFTIME_SHM_ALLOCATION_TEST_HELPER \"$<TARGET_FILE:bpftime-shm-allocation-test-helper>\"\n#define BPFTIME_SYSCALL_SERVER_LIBRARY \"$<TARGET_FILE:bpftime-syscall-server>\"\n")
+        CONTENT "#define BPFTIME_SHM_ALLOCATION_TEST_HELPER \"$<TARGET_FILE:bpftime-shm-allocation-test-helper>\"\n#define BPFTIME_SYSCALL_SERVER_LIBRARY \"$<TARGET_FILE:bpftime-syscall-server>\"\n#define BPFTIME_AGENT_LIBRARY \"$<TARGET_FILE:bpftime-agent>\"\n")
     target_include_directories(bpftime_runtime_tests PRIVATE
         "${CMAKE_CURRENT_BINARY_DIR}")
 endif()

--- a/runtime/unit-test/assets/shm_allocation_test_helper.c
+++ b/runtime/unit-test/assets/shm_allocation_test_helper.c
@@ -17,7 +17,7 @@ static int trigger_startup(void)
 	/* The interposer should fall back to the host libc path when bpftime
 	 * startup cannot allocate its shared memory.
 	 */
-	int fd = open("/dev/null", O_RDONLY, 0);
+	int fd = open("/dev/null", O_RDONLY);
 	if (fd < 0) {
 		return 101;
 	}

--- a/runtime/unit-test/assets/shm_allocation_test_helper.c
+++ b/runtime/unit-test/assets/shm_allocation_test_helper.c
@@ -14,14 +14,24 @@
 
 static int trigger_startup(void)
 {
-	/* open() is intentionally not wrapped by handle_exceptions(), so this
-	 * verifies that try_startup() itself converts bad_alloc into exit(1).
+	/* The interposer should fall back to the host libc path when bpftime
+	 * startup cannot allocate its shared memory.
 	 */
 	int fd = open("/dev/null", O_RDONLY, 0);
 	if (fd < 0) {
 		return 101;
 	}
+	char byte;
+	if (read(fd, &byte, 0) != 0) {
+		close(fd);
+		return 102;
+	}
 	close(fd);
+	FILE *file = fopen("/dev/null", "r");
+	if (file == NULL) {
+		return 103;
+	}
+	fclose(file);
 	return 100;
 }
 
@@ -43,8 +53,8 @@ static int trigger_perf_mmap(void)
 	size_t length = (size_t)getpagesize() + 8 * 1024 * 1024;
 	/* The interposer must not leak the caller's stale errno on failure. */
 	errno = E2BIG;
-	void *buffer = mmap(NULL, length, PROT_READ | PROT_WRITE,
-			    MAP_SHARED, fd, 0);
+	void *buffer =
+		mmap(NULL, length, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
 	if (buffer != MAP_FAILED || errno != ENOMEM) {
 		fprintf(stderr, "mmap=%p errno=%d\n", buffer, errno);
 		return 3;

--- a/runtime/unit-test/assets/shm_allocation_test_helper.c
+++ b/runtime/unit-test/assets/shm_allocation_test_helper.c
@@ -6,6 +6,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <linux/perf_event.h>
+#include <signal.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/mman.h>
@@ -67,6 +68,15 @@ static int trigger_perf_mmap(void)
 	return 0;
 }
 
+static int check_sigusr1_default(void)
+{
+	struct sigaction action;
+	if (sigaction(SIGUSR1, NULL, &action) != 0) {
+		return 105;
+	}
+	return action.sa_handler == SIG_DFL ? 100 : 106;
+}
+
 int main(int argc, char **argv)
 {
 	if (argc != 2) {
@@ -77,6 +87,9 @@ int main(int argc, char **argv)
 	}
 	if (strcmp(argv[1], "perf-mmap") == 0) {
 		return trigger_perf_mmap();
+	}
+	if (strcmp(argv[1], "check-sigusr1") == 0) {
+		return check_sigusr1_default();
 	}
 	return 64;
 }

--- a/runtime/unit-test/assets/shm_allocation_test_helper.c
+++ b/runtime/unit-test/assets/shm_allocation_test_helper.c
@@ -27,6 +27,11 @@ static int trigger_startup(void)
 		return 102;
 	}
 	close(fd);
+	fd = syscall(__NR_memfd_create, "bpftime-shm-allocation-test", 0);
+	if (fd < 0) {
+		return 104;
+	}
+	close(fd);
 	FILE *file = fopen("/dev/null", "r");
 	if (file == NULL) {
 		return 103;

--- a/runtime/unit-test/test_shm_allocation_failure.cpp
+++ b/runtime/unit-test/test_shm_allocation_failure.cpp
@@ -150,6 +150,17 @@ helper_result run_agent_preload_without_shm()
 	boost::interprocess::shared_memory_object::remove(shm_name.c_str());
 	return { status, std::move(output) };
 }
+
+size_t count_occurrences(const std::string &text, const std::string &needle)
+{
+	size_t count = 0;
+	size_t pos = 0;
+	while ((pos = text.find(needle, pos)) != std::string::npos) {
+		count++;
+		pos += needle.size();
+	}
+	return count;
+}
 } // namespace
 
 TEST_CASE("Syscall server falls back when startup shared memory is too small",
@@ -160,6 +171,7 @@ TEST_CASE("Syscall server falls back when startup shared memory is too small",
 	REQUIRE(WIFEXITED(result.status));
 	REQUIRE(WEXITSTATUS(result.status) == 100);
 	REQUIRE_FALSE(result.output.empty());
+	REQUIRE(count_occurrences(result.output, "Starting syscall server") == 1);
 }
 
 TEST_CASE("Syscall server perf mmap reports shared memory exhaustion",

--- a/runtime/unit-test/test_shm_allocation_failure.cpp
+++ b/runtime/unit-test/test_shm_allocation_failure.cpp
@@ -99,13 +99,13 @@ helper_result run_allocation_helper(const char *mode, const char *memory_mb,
 }
 } // namespace
 
-TEST_CASE("Syscall server exits cleanly when startup shared memory is too small",
+TEST_CASE("Syscall server falls back when startup shared memory is too small",
 	  "[allocation][syscall_server]")
 {
 	auto result =
 		run_allocation_helper("startup", "64", "1048576", "console");
 	REQUIRE(WIFEXITED(result.status));
-	REQUIRE(WEXITSTATUS(result.status) == 1);
+	REQUIRE(WEXITSTATUS(result.status) == 100);
 	REQUIRE_FALSE(result.output.empty());
 }
 
@@ -123,7 +123,7 @@ TEST_CASE("Syscall server keeps logger sink failures off host stdio",
 	auto result =
 		run_allocation_helper("startup", "64", "1048576", "/dev/full");
 	REQUIRE(WIFEXITED(result.status));
-	REQUIRE(WEXITSTATUS(result.status) == 1);
+	REQUIRE(WEXITSTATUS(result.status) == 100);
 	REQUIRE(result.output.empty());
 }
 
@@ -133,7 +133,7 @@ TEST_CASE("Syscall server keeps default logging off host stdio",
 	auto result =
 		run_allocation_helper("startup", "64", "1048576", nullptr);
 	REQUIRE(WIFEXITED(result.status));
-	REQUIRE(WEXITSTATUS(result.status) == 1);
+	REQUIRE(WEXITSTATUS(result.status) == 100);
 	REQUIRE(result.output.empty());
 }
 
@@ -143,7 +143,7 @@ TEST_CASE("Global log level cannot enable default host stdio",
 	auto result = run_allocation_helper("startup", "64", "1048576", nullptr,
 					    "info");
 	REQUIRE(WIFEXITED(result.status));
-	REQUIRE(WEXITSTATUS(result.status) == 1);
+	REQUIRE(WEXITSTATUS(result.status) == 100);
 	REQUIRE(result.output.empty());
 }
 
@@ -154,7 +154,7 @@ TEST_CASE("File logger is installed before syscall startup",
 				     std::to_string(getpid()) + ".log";
 	unlink(log_path.c_str());
 	auto result = run_allocation_helper("perf-mmap", "4", "128",
-				    log_path.c_str());
+					    log_path.c_str());
 	std::ifstream log(log_path);
 	std::string contents{ std::istreambuf_iterator<char>(log), {} };
 	unlink(log_path.c_str());
@@ -173,7 +173,7 @@ TEST_CASE("Syscall server preserves the console logger level name",
 	auto result = run_allocation_helper("startup", "64", "1048576",
 					    "console", "stderr=off");
 	REQUIRE(WIFEXITED(result.status));
-	REQUIRE(WEXITSTATUS(result.status) == 1);
+	REQUIRE(WEXITSTATUS(result.status) == 100);
 	REQUIRE(result.output.empty());
 }
 #endif

--- a/runtime/unit-test/test_shm_allocation_failure.cpp
+++ b/runtime/unit-test/test_shm_allocation_failure.cpp
@@ -97,6 +97,59 @@ helper_result run_allocation_helper(const char *mode, const char *memory_mb,
 	boost::interprocess::shared_memory_object::remove(shm_name.c_str());
 	return { status, std::move(output) };
 }
+
+helper_result run_agent_preload_without_shm()
+{
+	const std::string shm_name = "bpftime-agent-missing-shm-test-" +
+				     std::to_string(getpid());
+	boost::interprocess::shared_memory_object::remove(shm_name.c_str());
+	int output_pipe[2];
+	REQUIRE(pipe(output_pipe) == 0);
+
+	pid_t pid = fork();
+	REQUIRE(pid >= 0);
+	if (pid == 0) {
+		close(output_pipe[0]);
+		if (dup2(output_pipe[1], STDOUT_FILENO) == -1 ||
+		    dup2(output_pipe[1], STDERR_FILENO) == -1) {
+			_exit(125);
+		}
+		close(output_pipe[1]);
+		if (unsetenv("BPFTIME_LOG_OUTPUT") != 0 ||
+		    unsetenv("SPDLOG_LEVEL") != 0 ||
+		    setenv("HOME", "/proc/bpftime-unwritable-home", 1) != 0 ||
+		    setenv("BPFTIME_GLOBAL_SHM_NAME", shm_name.c_str(), 1) !=
+			    0 ||
+		    setenv("LD_PRELOAD", BPFTIME_AGENT_LIBRARY, 1) != 0) {
+			_exit(126);
+		}
+		execl("/bin/true", "true", nullptr);
+		_exit(127);
+	}
+
+	close(output_pipe[1]);
+	std::string output;
+	char buffer[4096];
+	for (;;) {
+		ssize_t count = read(output_pipe[0], buffer, sizeof(buffer));
+		if (count > 0) {
+			output.append(buffer, static_cast<size_t>(count));
+			continue;
+		}
+		if (count == -1 && errno == EINTR)
+			continue;
+		REQUIRE(count == 0);
+		break;
+	}
+	close(output_pipe[0]);
+
+	int status = 0;
+	while (waitpid(pid, &status, 0) == -1) {
+		REQUIRE(errno == EINTR);
+	}
+	boost::interprocess::shared_memory_object::remove(shm_name.c_str());
+	return { status, std::move(output) };
+}
 } // namespace
 
 TEST_CASE("Syscall server falls back when startup shared memory is too small",
@@ -174,6 +227,15 @@ TEST_CASE("Syscall server preserves the console logger level name",
 					    "console", "stderr=off");
 	REQUIRE(WIFEXITED(result.status));
 	REQUIRE(WEXITSTATUS(result.status) == 100);
+	REQUIRE(result.output.empty());
+}
+
+TEST_CASE("Agent preload keeps missing shared memory off host stdio",
+	  "[allocation][agent][logging]")
+{
+	auto result = run_agent_preload_without_shm();
+	REQUIRE(WIFEXITED(result.status));
+	REQUIRE(WEXITSTATUS(result.status) == 0);
 	REQUIRE(result.output.empty());
 }
 #endif

--- a/runtime/unit-test/test_shm_allocation_failure.cpp
+++ b/runtime/unit-test/test_shm_allocation_failure.cpp
@@ -123,7 +123,9 @@ helper_result run_agent_preload_without_shm()
 		    setenv("LD_PRELOAD", BPFTIME_AGENT_LIBRARY, 1) != 0) {
 			_exit(126);
 		}
-		execl("/bin/true", "true", nullptr);
+		execl(BPFTIME_SHM_ALLOCATION_TEST_HELPER,
+		      BPFTIME_SHM_ALLOCATION_TEST_HELPER, "check-sigusr1",
+		      nullptr);
 		_exit(127);
 	}
 
@@ -247,7 +249,7 @@ TEST_CASE("Agent preload keeps missing shared memory off host stdio",
 {
 	auto result = run_agent_preload_without_shm();
 	REQUIRE(WIFEXITED(result.status));
-	REQUIRE(WEXITSTATUS(result.status) == 0);
+	REQUIRE(WEXITSTATUS(result.status) == 100);
 	REQUIRE(result.output.empty());
 }
 #endif


### PR DESCRIPTION
Fixes part of #605.

## Summary
- make syscall-server initialization no-throw at the interposition boundary and disable the shim when construction fails
- fall back to the original libc/syscall operation when startup or interception code throws
- stop agent exported/CUDA/syscall-trace boundaries from writing directly to stderr or throwing back into the host
- update shared-memory exhaustion regression tests to require host continuation and default stdio silence

## Validation
- `cmake -Bbuild -DBPFTIME_ENABLE_UNIT_TESTING=1 -DCMAKE_BUILD_TYPE:STRING=Debug -DENABLE_PROBE_WRITE_CHECK=1 -DENABLE_PROBE_READ_CHECK=1`
- `cmake --build build --config Debug --target bpftime_runtime_tests -j2`
- `cmake --build build --config Debug --target bpftime-agent -j2`
- `./build/runtime/unit-test/bpftime_runtime_tests "[allocation][syscall_server]"`
- manual LD_PRELOAD smoke with undersized shm: `status=100`, `stdout_bytes=0`, `stderr_bytes=0`

Full local runtime suite note: `BPFTIME_VM_NAME=llvm ./build/runtime/unit-test/bpftime_runtime_tests` reached 83/85 passing locally. The two failures were `Test shm progs attach` (`filesystem error: cannot check file equivalence: No such file or directory []`) and `Test tail calling from userspace to kernel` (`map_fd == -1`), which appear environment-dependent and are outside this patch scope.