### PR TITLE
fix(runtime): use no-fault probe memory copies

### DIFF
--- a/runtime/src/bpf_helper.cpp
+++ b/runtime/src/bpf_helper.cpp
@@ -11,7 +11,12 @@
 #include <system_error>
 #if __APPLE__
 #include <cstdint>
+#include <mach/mach.h>
+#include <mach/mach_vm.h>
 #include <pthread.h>
+#elif __linux__
+#include <sys/syscall.h>
+#include <sys/uio.h>
 #endif
 #ifdef BPFTIME_BUILD_WITH_LIBBPF
 #include "bpf/bpf.h"
@@ -42,9 +47,6 @@
 #include <bpftime_shm_internal.hpp>
 #include <chrono>
 #include <thread>
-#include <setjmp.h>
-#include <signal.h>
-#include <mutex>
 
 #define PATH_MAX 4096
 
@@ -81,117 +83,27 @@ long bpftime_strncmp(const char *s1, uint64_t s1_sz, const char *s2)
 	return strncmp(s1, s2, s1_sz);
 }
 
-#if defined(ENABLE_PROBE_WRITE_CHECK) || defined(ENABLE_PROBE_READ_CHECK)
-static std::mutex probe_access_mutex;
-static struct sigaction previous_sigsegv_action {};
-static size_t probe_access_users = 0;
-thread_local static size_t probe_access_depth = 0;
-thread_local static volatile sig_atomic_t probe_access_faulted = 0;
-thread_local static volatile uintptr_t probe_access_recovery_ip = 0;
-
-static void forward_sigsegv(int sig, siginfo_t *siginfo, void *ctx)
-{
-	if (previous_sigsegv_action.sa_handler == SIG_IGN)
-		return;
-
-	if (previous_sigsegv_action.sa_handler == SIG_DFL) {
-		sigaction(sig, &previous_sigsegv_action, nullptr);
-		raise(sig);
-		return;
-	}
-
-	if (previous_sigsegv_action.sa_flags & SA_SIGINFO) {
-		previous_sigsegv_action.sa_sigaction(sig, siginfo, ctx);
-	} else {
-		previous_sigsegv_action.sa_handler(sig);
-	}
-}
-
-static void probe_sigsegv_handler(int sig, siginfo_t *siginfo, void *ctx)
-{
-	if (probe_access_recovery_ip != 0 &&
-	    (siginfo == nullptr || siginfo->si_code > 0)) {
-		auto uctx = (ucontext_t *)ctx;
-#if defined(__x86_64__) || defined(_M_X64)
-		auto *ip = (greg_t *)(&uctx->uc_mcontext.gregs[REG_RIP]);
-#elif defined(__aarch64__) || defined(_M_ARM64)
-		auto *ip = (greg_t *)(&uctx->uc_mcontext.pc);
-#else
-#error "Unsupported architecture"
-#endif
-		probe_access_faulted = 1;
-		*ip = (greg_t)probe_access_recovery_ip;
-		return;
-	}
-
-	forward_sigsegv(sig, siginfo, ctx);
-}
-
-static bool is_probe_sigsegv_handler(const struct sigaction &action)
-{
-	return (action.sa_flags & SA_SIGINFO) &&
-	       action.sa_sigaction == probe_sigsegv_handler;
-}
-
-static int probe_access_begin()
-{
-	if (probe_access_depth > 0) {
-		probe_access_depth++;
-		return 0;
-	}
-
-	std::lock_guard guard(probe_access_mutex);
-	if (probe_access_users == 0) {
-		struct sigaction current_action {};
-		if (sigaction(SIGSEGV, nullptr, &current_action) != 0) {
-			SPDLOG_ERROR("Failed to get SIGSEGV handler: {}", errno);
-			return -errno;
-		}
-
-		if (!is_probe_sigsegv_handler(current_action)) {
-			previous_sigsegv_action = current_action;
-			struct sigaction probe_action = current_action;
-			probe_action.sa_flags |= SA_SIGINFO;
-			probe_action.sa_flags &= ~SA_RESETHAND;
-			probe_action.sa_sigaction = probe_sigsegv_handler;
-			if (sigaction(SIGSEGV, &probe_action, nullptr) != 0) {
-				SPDLOG_ERROR("Failed to set SIGSEGV handler: {}",
-					     errno);
-				return -errno;
-			}
-		}
-	}
-
-	probe_access_users++;
-	probe_access_depth = 1;
-	return 0;
-}
-
-static void probe_access_end()
-{
-	if (probe_access_depth == 0)
-		return;
-	if (--probe_access_depth > 0)
-		return;
-
-	std::lock_guard guard(probe_access_mutex);
-	if (--probe_access_users > 0)
-		return;
-
-	struct sigaction current_action {};
-	if (sigaction(SIGSEGV, nullptr, &current_action) != 0) {
-		SPDLOG_ERROR("Failed to get SIGSEGV handler: {}", errno);
-		return;
-	}
-	if (is_probe_sigsegv_handler(current_action) &&
-	    sigaction(SIGSEGV, &previous_sigsegv_action, nullptr) != 0) {
-		SPDLOG_ERROR("Failed to restore SIGSEGV handler: {}", errno);
-	}
-}
-#endif
-
 #ifdef ENABLE_PROBE_READ_CHECK
-extern "C" void jump_point_read();
+static bool probe_read_memory(void *dst, const void *src, size_t size)
+{
+	if (size == 0)
+		return true;
+#if __APPLE__
+	mach_vm_size_t copied = 0;
+	return mach_vm_read_overwrite(mach_task_self(), (mach_vm_address_t)src,
+				      (mach_vm_size_t)size,
+				      (mach_vm_address_t)dst,
+				      &copied) == KERN_SUCCESS &&
+	       copied == size;
+#elif __linux__
+	struct iovec local = { dst, size };
+	struct iovec remote = { const_cast<void *>(src), size };
+	return syscall(SYS_process_vm_readv, getpid(), &local, 1, &remote, 1,
+		       0) == (ssize_t)size;
+#else
+#error "Probe memory checks are unsupported on this platform"
+#endif
+}
 #endif
 
 int64_t bpftime_probe_read(uint64_t dst, int64_t size, uint64_t ptr, uint64_t,
@@ -201,31 +113,34 @@ int64_t bpftime_probe_read(uint64_t dst, int64_t size, uint64_t ptr, uint64_t,
 		SPDLOG_ERROR("Invalid size: {}", size);
 		return -EFAULT;
 	}
-	int64_t ret = 0;
-
 #ifdef ENABLE_PROBE_READ_CHECK
-	if (probe_access_begin() != 0)
-		return -EFAULT;
-	probe_access_faulted = 0;
-	probe_access_recovery_ip = (uintptr_t)&jump_point_read;
-	__asm__ volatile("" ::: "memory");
-#endif
+	return probe_read_memory((void *)dst, (void *)ptr, (size_t)size) ?
+		       0 :
+		       -EFAULT;
+#else
 	memcpy((void *)dst, (void *)ptr, (size_t)size);
-
-#ifdef ENABLE_PROBE_READ_CHECK
-	__asm__ volatile("jump_point_read:");
-	__asm__ volatile("" ::: "memory");
-	probe_access_recovery_ip = 0;
-	if (probe_access_faulted)
-		ret = -EFAULT;
-	probe_access_faulted = 0;
-	probe_access_end();
+	return 0;
 #endif
-	return ret;
 }
 
 #ifdef ENABLE_PROBE_WRITE_CHECK
-extern "C" void jump_point_write();
+static bool probe_write_memory(void *dst, const void *src, size_t size)
+{
+	if (size == 0)
+		return true;
+#if __APPLE__
+	return mach_vm_copy(mach_task_self(), (mach_vm_address_t)src,
+			    (mach_vm_size_t)size,
+			    (mach_vm_address_t)dst) == KERN_SUCCESS;
+#elif __linux__
+	struct iovec local = { const_cast<void *>(src), size };
+	struct iovec remote = { dst, size };
+	return syscall(SYS_process_vm_writev, getpid(), &local, 1, &remote, 1,
+		       0) == (ssize_t)size;
+#else
+#error "Probe memory checks are unsupported on this platform"
+#endif
+}
 #endif
 
 int64_t bpftime_probe_write_user(uint64_t dst, uint64_t src, int64_t len,
@@ -235,28 +150,14 @@ int64_t bpftime_probe_write_user(uint64_t dst, uint64_t src, int64_t len,
 		SPDLOG_ERROR("Invalid len: {}", len);
 		return -EFAULT;
 	}
-	int64_t ret = 0;
-
 #ifdef ENABLE_PROBE_WRITE_CHECK
-	if (probe_access_begin() != 0)
-		return -EFAULT;
-	probe_access_faulted = 0;
-	probe_access_recovery_ip = (uintptr_t)&jump_point_write;
-	__asm__ volatile("" ::: "memory");
-#endif
-
+	return probe_write_memory((void *)dst, (void *)src, (size_t)len) ?
+		       0 :
+		       -EFAULT;
+#else
 	memcpy((void *)dst, (void *)src, (size_t)len);
-
-#ifdef ENABLE_PROBE_WRITE_CHECK
-	__asm__ volatile("jump_point_write:");
-	__asm__ volatile("" ::: "memory");
-	probe_access_recovery_ip = 0;
-	if (probe_access_faulted)
-		ret = -EFAULT;
-	probe_access_faulted = 0;
-	probe_access_end();
+	return 0;
 #endif
-	return ret;
 }
 
 uint64_t bpftime_get_prandom_u32()

--- a/runtime/src/bpf_helper.cpp
+++ b/runtime/src/bpf_helper.cpp
@@ -44,6 +44,7 @@
 #include <thread>
 #include <setjmp.h>
 #include <signal.h>
+#include <mutex>
 
 #define PATH_MAX 4096
 
@@ -81,61 +82,35 @@ long bpftime_strncmp(const char *s1, uint64_t s1_sz, const char *s2)
 }
 
 #if defined(ENABLE_PROBE_WRITE_CHECK) || defined(ENABLE_PROBE_READ_CHECK)
+static std::mutex probe_access_mutex;
+static struct sigaction previous_sigsegv_action {};
+static size_t probe_access_users = 0;
+thread_local static size_t probe_access_depth = 0;
+thread_local static volatile sig_atomic_t probe_access_faulted = 0;
+thread_local static volatile uintptr_t probe_access_recovery_ip = 0;
 
-/*
-status instruction for probe_read and probe_write
-*/
-enum class PROBE_STATUS {
-	NOT_RUNNING = -1,
-	RUNNING_NO_ERROR = 0,
-	RUNNING_ERROR = 1
-};
-
-/*
-origin handler exist flag for probe_read and probe_write
-*/
-enum class ORIGIN_HANDLER_EXIST_FLAG {
-	NOT_CHECKED = -1,
-	NOT_EXIST = 0,
-	EXIST = 1
-};
-
-#endif
-
-#ifdef ENABLE_PROBE_READ_CHECK
-extern "C" void jump_point_read();
-thread_local static PROBE_STATUS status_probe_read = PROBE_STATUS::NOT_RUNNING;
-
-thread_local static ORIGIN_HANDLER_EXIST_FLAG exist_read =
-	ORIGIN_HANDLER_EXIST_FLAG::NOT_CHECKED;
-
-thread_local static void (*origin_segv_read_handler)(int, siginfo_t *,
-						     void *) = nullptr;
-#endif
-#ifdef ENABLE_PROBE_WRITE_CHECK
-
-extern "C" void jump_point_write();
-thread_local static PROBE_STATUS status_probe_write = PROBE_STATUS::NOT_RUNNING;
-thread_local static ORIGIN_HANDLER_EXIST_FLAG exist_write =
-	ORIGIN_HANDLER_EXIST_FLAG::NOT_CHECKED;
-
-thread_local static void (*origin_segv_write_handler)(int, siginfo_t *,
-						      void *) = nullptr;
-#endif
-
-#ifdef ENABLE_PROBE_READ_CHECK
-static void segv_read_handler(int sig, siginfo_t *siginfo, void *ctx)
+static void forward_sigsegv(int sig, siginfo_t *siginfo, void *ctx)
 {
-	if (status_probe_read == PROBE_STATUS::NOT_RUNNING) {
-		if (origin_segv_read_handler != nullptr) {
-			origin_segv_read_handler(sig, siginfo, ctx);
-		} else {
-			SPDLOG_ERROR("no origin handler for probe_read");
-			throw std::runtime_error(
-				"segv_handler for probe_read called");
-		}
-	} else if (status_probe_read == PROBE_STATUS::RUNNING_NO_ERROR) {
-		// set status to error
+	if (previous_sigsegv_action.sa_handler == SIG_IGN)
+		return;
+
+	if (previous_sigsegv_action.sa_handler == SIG_DFL) {
+		sigaction(sig, &previous_sigsegv_action, nullptr);
+		raise(sig);
+		return;
+	}
+
+	if (previous_sigsegv_action.sa_flags & SA_SIGINFO) {
+		previous_sigsegv_action.sa_sigaction(sig, siginfo, ctx);
+	} else {
+		previous_sigsegv_action.sa_handler(sig);
+	}
+}
+
+static void probe_sigsegv_handler(int sig, siginfo_t *siginfo, void *ctx)
+{
+	if (probe_access_recovery_ip != 0 &&
+	    (siginfo == nullptr || siginfo->si_code > 0)) {
 		auto uctx = (ucontext_t *)ctx;
 #if defined(__x86_64__) || defined(_M_X64)
 		auto *ip = (greg_t *)(&uctx->uc_mcontext.gregs[REG_RIP]);
@@ -144,10 +119,79 @@ static void segv_read_handler(int sig, siginfo_t *siginfo, void *ctx)
 #else
 #error "Unsupported architecture"
 #endif
-		status_probe_read = PROBE_STATUS::RUNNING_ERROR;
-		*ip = (greg_t)&jump_point_read;
+		probe_access_faulted = 1;
+		*ip = (greg_t)probe_access_recovery_ip;
+		return;
+	}
+
+	forward_sigsegv(sig, siginfo, ctx);
+}
+
+static bool is_probe_sigsegv_handler(const struct sigaction &action)
+{
+	return (action.sa_flags & SA_SIGINFO) &&
+	       action.sa_sigaction == probe_sigsegv_handler;
+}
+
+static int probe_access_begin()
+{
+	if (probe_access_depth > 0) {
+		probe_access_depth++;
+		return 0;
+	}
+
+	std::lock_guard guard(probe_access_mutex);
+	if (probe_access_users == 0) {
+		struct sigaction current_action {};
+		if (sigaction(SIGSEGV, nullptr, &current_action) != 0) {
+			SPDLOG_ERROR("Failed to get SIGSEGV handler: {}", errno);
+			return -errno;
+		}
+
+		if (!is_probe_sigsegv_handler(current_action)) {
+			previous_sigsegv_action = current_action;
+			struct sigaction probe_action = current_action;
+			probe_action.sa_flags |= SA_SIGINFO;
+			probe_action.sa_flags &= ~SA_RESETHAND;
+			probe_action.sa_sigaction = probe_sigsegv_handler;
+			if (sigaction(SIGSEGV, &probe_action, nullptr) != 0) {
+				SPDLOG_ERROR("Failed to set SIGSEGV handler: {}",
+					     errno);
+				return -errno;
+			}
+		}
+	}
+
+	probe_access_users++;
+	probe_access_depth = 1;
+	return 0;
+}
+
+static void probe_access_end()
+{
+	if (probe_access_depth == 0)
+		return;
+	if (--probe_access_depth > 0)
+		return;
+
+	std::lock_guard guard(probe_access_mutex);
+	if (--probe_access_users > 0)
+		return;
+
+	struct sigaction current_action {};
+	if (sigaction(SIGSEGV, nullptr, &current_action) != 0) {
+		SPDLOG_ERROR("Failed to get SIGSEGV handler: {}", errno);
+		return;
+	}
+	if (is_probe_sigsegv_handler(current_action) &&
+	    sigaction(SIGSEGV, &previous_sigsegv_action, nullptr) != 0) {
+		SPDLOG_ERROR("Failed to restore SIGSEGV handler: {}", errno);
 	}
 }
+#endif
+
+#ifdef ENABLE_PROBE_READ_CHECK
+extern "C" void jump_point_read();
 #endif
 
 int64_t bpftime_probe_read(uint64_t dst, int64_t size, uint64_t ptr, uint64_t,
@@ -160,80 +204,28 @@ int64_t bpftime_probe_read(uint64_t dst, int64_t size, uint64_t ptr, uint64_t,
 	int64_t ret = 0;
 
 #ifdef ENABLE_PROBE_READ_CHECK
-	status_probe_read = PROBE_STATUS::RUNNING_NO_ERROR;
-
-	struct sigaction sa, original_sa;
-	// set up the signal handler
-	if (exist_read == ORIGIN_HANDLER_EXIST_FLAG::NOT_CHECKED) {
-		int err = sigaction(SIGSEGV, nullptr, &original_sa);
-		if (err) {
-			SPDLOG_ERROR("Failed to get signal handler: {}", errno);
-			return -EFAULT;
-		}
-		if (original_sa.sa_sigaction == nullptr) {
-			exist_read = ORIGIN_HANDLER_EXIST_FLAG::NOT_EXIST;
-		} else {
-			exist_read = ORIGIN_HANDLER_EXIST_FLAG::EXIST;
-			origin_segv_read_handler = original_sa.sa_sigaction;
-		}
-	}
-
-	if (original_sa.sa_sigaction != segv_read_handler) {
-		sa.sa_flags = SA_SIGINFO;
-		int err = 0;
-		err = sigemptyset(&sa.sa_mask);
-		if (err) {
-			SPDLOG_ERROR("Failed to set signal handler: {}", errno);
-			return -EFAULT;
-		}
-		sa.sa_sigaction = segv_read_handler;
-		err = sigaction(SIGSEGV, &sa, nullptr);
-		if (err) {
-			SPDLOG_ERROR("Failed to set signal handler: {}", errno);
-			return -EFAULT;
-		}
-	}
+	if (probe_access_begin() != 0)
+		return -EFAULT;
+	probe_access_faulted = 0;
+	probe_access_recovery_ip = (uintptr_t)&jump_point_read;
+	__asm__ volatile("" ::: "memory");
 #endif
 	memcpy((void *)dst, (void *)ptr, (size_t)size);
 
 #ifdef ENABLE_PROBE_READ_CHECK
-	__asm__("jump_point_read:");
-
-	if (status_probe_read == PROBE_STATUS::RUNNING_ERROR) {
+	__asm__ volatile("jump_point_read:");
+	__asm__ volatile("" ::: "memory");
+	probe_access_recovery_ip = 0;
+	if (probe_access_faulted)
 		ret = -EFAULT;
-	}
-
-	status_probe_read = PROBE_STATUS::NOT_RUNNING;
+	probe_access_faulted = 0;
+	probe_access_end();
 #endif
 	return ret;
 }
 
 #ifdef ENABLE_PROBE_WRITE_CHECK
-static void segv_write_handler(int sig, siginfo_t *siginfo, void *ctx)
-{
-	SPDLOG_TRACE("segv_handler for probe_write called");
-	if (status_probe_write == PROBE_STATUS::NOT_RUNNING) {
-		if (origin_segv_write_handler) {
-			origin_segv_write_handler(sig, siginfo, ctx);
-		} else {
-			SPDLOG_ERROR("no origin handler for probe_write");
-			throw std::runtime_error(
-				"segv_handler for probe_write called");
-		}
-	} else if (status_probe_write == PROBE_STATUS::RUNNING_NO_ERROR) {
-		// set status to error
-		auto uctx = (ucontext_t *)ctx;
-#if defined(__x86_64__) || defined(_M_X64)
-		auto *ip = (greg_t *)(&uctx->uc_mcontext.gregs[REG_RIP]);
-#elif defined(__aarch64__) || defined(_M_ARM64)
-		auto *ip = (greg_t *)(&uctx->uc_mcontext.pc);
-#else
-#error "Unsupported architecture"
-#endif
-		status_probe_write = PROBE_STATUS::RUNNING_ERROR;
-		*ip = (greg_t)&jump_point_write;
-	}
-}
+extern "C" void jump_point_write();
 #endif
 
 int64_t bpftime_probe_write_user(uint64_t dst, uint64_t src, int64_t len,
@@ -246,54 +238,23 @@ int64_t bpftime_probe_write_user(uint64_t dst, uint64_t src, int64_t len,
 	int64_t ret = 0;
 
 #ifdef ENABLE_PROBE_WRITE_CHECK
-	status_probe_write = PROBE_STATUS::RUNNING_NO_ERROR;
-
-	struct sigaction sa, original_sa;
-	// set up the signal handler
-	if (exist_write == ORIGIN_HANDLER_EXIST_FLAG::NOT_CHECKED) {
-		int err = sigaction(SIGSEGV, nullptr, &original_sa);
-		if (err) {
-			SPDLOG_ERROR("Failed to get signal handler: {}", errno);
-			return -EFAULT;
-		}
-
-		if (original_sa.sa_sigaction == nullptr) {
-			exist_write = ORIGIN_HANDLER_EXIST_FLAG::NOT_EXIST;
-		} else {
-			exist_write = ORIGIN_HANDLER_EXIST_FLAG::EXIST;
-			origin_segv_write_handler = original_sa.sa_sigaction;
-		}
-	}
-
-	if (original_sa.sa_sigaction != segv_write_handler) {
-		sa.sa_flags = SA_SIGINFO;
-		int err = 0;
-		err = sigemptyset(&sa.sa_mask);
-		if (err) {
-			SPDLOG_ERROR("Failed to set signal handler: {}", errno);
-			return -EFAULT;
-		}
-
-		sa.sa_sigaction = segv_write_handler;
-		err = sigaction(SIGSEGV, &sa, nullptr);
-		if (err) {
-			SPDLOG_ERROR("Failed to set signal handler: {}", errno);
-			return -EFAULT;
-		}
-	}
+	if (probe_access_begin() != 0)
+		return -EFAULT;
+	probe_access_faulted = 0;
+	probe_access_recovery_ip = (uintptr_t)&jump_point_write;
+	__asm__ volatile("" ::: "memory");
 #endif
 
 	memcpy((void *)dst, (void *)src, (size_t)len);
 
 #ifdef ENABLE_PROBE_WRITE_CHECK
-	__asm__("jump_point_write:");
-
-	if (status_probe_write == PROBE_STATUS::RUNNING_ERROR) {
+	__asm__ volatile("jump_point_write:");
+	__asm__ volatile("" ::: "memory");
+	probe_access_recovery_ip = 0;
+	if (probe_access_faulted)
 		ret = -EFAULT;
-	}
-
-	status_probe_write = PROBE_STATUS::NOT_RUNNING;
-
+	probe_access_faulted = 0;
+	probe_access_end();
 #endif
 	return ret;
 }

--- a/runtime/src/bpf_helper.cpp
+++ b/runtime/src/bpf_helper.cpp
@@ -129,9 +129,12 @@ static bool probe_write_memory(void *dst, const void *src, size_t size)
 	if (size == 0)
 		return true;
 #if __APPLE__
-	return mach_vm_copy(mach_task_self(), (mach_vm_address_t)src,
-			    (mach_vm_size_t)size,
-			    (mach_vm_address_t)dst) == KERN_SUCCESS;
+	mach_vm_size_t copied = 0;
+	return mach_vm_read_overwrite(mach_task_self(), (mach_vm_address_t)src,
+				      (mach_vm_size_t)size,
+				      (mach_vm_address_t)dst,
+				      &copied) == KERN_SUCCESS &&
+	       copied == size;
 #elif __linux__
 	struct iovec local = { const_cast<void *>(src), size };
 	struct iovec remote = { dst, size };

--- a/runtime/src/bpf_helper.cpp
+++ b/runtime/src/bpf_helper.cpp
@@ -123,7 +123,7 @@ int64_t bpftime_probe_read(uint64_t dst, int64_t size, uint64_t ptr, uint64_t,
 #endif
 }
 
-#ifdef ENABLE_PROBE_WRITE_CHECK
+#if defined(ENABLE_PROBE_WRITE_CHECK) || defined(ENABLE_PROBE_READ_CHECK)
 static bool probe_write_memory(void *dst, const void *src, size_t size)
 {
 	if (size == 0)
@@ -293,12 +293,81 @@ uint64_t bpftime_map_peek_elem_helper(uint64_t map, uint64_t value, uint64_t,
 		.bpf_map_peek_elem((int)map, (void *)value, false);
 }
 
-uint64_t bpf_probe_read_str(uint64_t buf, uint64_t bufsz, uint64_t ptr,
-			    uint64_t, uint64_t)
+#ifdef ENABLE_PROBE_READ_CHECK
+static size_t probe_page_remaining(const void *address)
 {
-	strncpy((char *)(uintptr_t)buf, (const char *)(uintptr_t)ptr,
-		(size_t)bufsz);
-	return 0;
+	static const size_t page_size = []() {
+		long result = sysconf(_SC_PAGESIZE);
+		return result > 0 ? (size_t)result : (size_t)4096;
+	}();
+	return page_size - ((uintptr_t)address % page_size);
+}
+
+static void clear_probe_memory(void *dst, size_t size)
+{
+	static const char zeros[256] = {};
+	auto output = (char *)dst;
+	while (size > 0) {
+		size_t chunk_size = std::min(size, sizeof(zeros));
+		if (!probe_write_memory(output, zeros, chunk_size))
+			return;
+		output += chunk_size;
+		size -= chunk_size;
+	}
+}
+#endif
+
+int64_t bpf_probe_read_str(uint64_t buf, uint64_t bufsz, uint64_t ptr, uint64_t,
+			   uint64_t)
+{
+	if (bufsz == 0)
+		return 0;
+
+	auto dst = (char *)(uintptr_t)buf;
+	auto src = (const char *)(uintptr_t)ptr;
+#ifndef ENABLE_PROBE_READ_CHECK
+	for (size_t i = 0; i < (size_t)bufsz; i++) {
+		if (src[i] == '\0') {
+			dst[i] = '\0';
+			return (int64_t)i + 1;
+		}
+		if (i == (size_t)bufsz - 1) {
+			dst[i] = '\0';
+			return (int64_t)bufsz;
+		}
+		dst[i] = src[i];
+	}
+	return (int64_t)bufsz;
+#else
+	char scratch[256];
+	size_t copied = 0;
+	while (copied < (size_t)bufsz) {
+		size_t chunk_size =
+			std::min(sizeof(scratch), (size_t)bufsz - copied);
+		chunk_size = std::min(chunk_size,
+				      probe_page_remaining(src + copied));
+		if (!probe_read_memory(scratch, src + copied, chunk_size)) {
+			clear_probe_memory(dst, (size_t)bufsz);
+			return -EFAULT;
+		}
+
+		auto terminator = (char *)memchr(scratch, '\0', chunk_size);
+		bool complete = terminator != nullptr;
+		if (complete) {
+			chunk_size = (size_t)(terminator - scratch) + 1;
+		} else if (chunk_size == (size_t)bufsz - copied) {
+			scratch[chunk_size - 1] = '\0';
+			complete = true;
+		}
+
+		if (!probe_write_memory(dst + copied, scratch, chunk_size))
+			return -EFAULT;
+		copied += chunk_size;
+		if (complete)
+			return (int64_t)copied;
+	}
+	return (int64_t)copied;
+#endif
 }
 
 uint64_t bpf_ktime_get_coarse_ns(uint64_t, uint64_t, uint64_t, uint64_t,

--- a/runtime/unit-test/CMakeLists.txt
+++ b/runtime/unit-test/CMakeLists.txt
@@ -53,6 +53,14 @@ endif()
 option(TEST_LCOV "option for lcov" OFF)
 add_executable(bpftime_runtime_tests ${TEST_SOURCES})
 
+if(ENABLE_PROBE_READ_CHECK)
+    target_compile_definitions(bpftime_runtime_tests PRIVATE ENABLE_PROBE_READ_CHECK=1)
+endif()
+
+if(ENABLE_PROBE_WRITE_CHECK)
+    target_compile_definitions(bpftime_runtime_tests PRIVATE ENABLE_PROBE_WRITE_CHECK=1)
+endif()
+
 if(UNIX AND NOT APPLE)
     add_executable(bpftime-shm-allocation-test-helper
         assets/shm_allocation_test_helper.c)

--- a/runtime/unit-test/test_probe.cpp
+++ b/runtime/unit-test/test_probe.cpp
@@ -3,8 +3,23 @@
 #include <csetjmp>
 #include <cstdlib>
 #include <cstring>
+#include <sys/resource.h>
+#include <sys/wait.h>
+#include <thread>
 #include <unistd.h>
 #include <signal.h>
+
+static volatile sig_atomic_t forwarded_sigsegv = 0;
+
+static void count_sigsegv(int)
+{
+	forwarded_sigsegv = forwarded_sigsegv + 1;
+}
+
+static void count_replaced_sigsegv(int)
+{
+	forwarded_sigsegv = forwarded_sigsegv + 2;
+}
 
 extern "C" {
 
@@ -34,6 +49,95 @@ TEST_CASE("Test bpftime_probe_read") // test for bpftime_probe_read
 	ret = bpftime_probe_read((uint64_t)(nullptr), size, (uint64_t)(nullptr),
 				 0, 0);
 	REQUIRE(ret == -EFAULT);
+}
+
+TEST_CASE("Test repeated valid probe memory access")
+{
+	int src[4] = { 1, 2, 3, 4 };
+	int read_dst[4] = { 0 };
+	int write_dst[4] = { 0 };
+	uint64_t size = sizeof(src);
+
+	for (size_t i = 0; i < 4; i++) {
+		std::memset(read_dst, 0, sizeof(read_dst));
+		std::memset(write_dst, 0, sizeof(write_dst));
+		REQUIRE(bpftime_probe_read((uint64_t)read_dst, size,
+					   (uint64_t)src, 0, 0) == 0);
+		REQUIRE(std::memcmp(read_dst, src, size) == 0);
+		REQUIRE(bpftime_probe_write_user((uint64_t)write_dst,
+						(uint64_t)src, size, 0, 0) == 0);
+		REQUIRE(std::memcmp(write_dst, src, size) == 0);
+	}
+}
+
+TEST_CASE("Test SIGSEGV handler chaining across threads")
+{
+	pid_t child = fork();
+	REQUIRE(child >= 0);
+	if (child == 0) {
+		struct rlimit no_core = { 0, 0 };
+		struct sigaction application_handler = {};
+		setrlimit(RLIMIT_CORE, &no_core);
+		application_handler.sa_handler = count_sigsegv;
+		sigemptyset(&application_handler.sa_mask);
+		if (sigaction(SIGSEGV, &application_handler, nullptr) != 0)
+			_exit(2);
+
+		int src = 1;
+		int dst = 0;
+		if (bpftime_probe_read((uint64_t)&dst, sizeof(dst),
+				       (uint64_t)&src, 0, 0) != 0 ||
+		    dst != src)
+			_exit(3);
+		int raise_result = -1;
+		std::thread worker([&raise_result]() {
+			raise_result = raise(SIGSEGV);
+		});
+		worker.join();
+		_exit(raise_result == 0 && forwarded_sigsegv == 1 ? 0 : 4);
+	}
+
+	int status = 0;
+	REQUIRE(waitpid(child, &status, 0) == child);
+	REQUIRE(WIFEXITED(status));
+	REQUIRE(WEXITSTATUS(status) == 0);
+}
+
+TEST_CASE("Test probe access refreshes replaced SIGSEGV handler")
+{
+	pid_t child = fork();
+	REQUIRE(child >= 0);
+	if (child == 0) {
+		struct rlimit no_core = { 0, 0 };
+		struct sigaction application_handler = {};
+		setrlimit(RLIMIT_CORE, &no_core);
+		application_handler.sa_handler = count_sigsegv;
+		sigemptyset(&application_handler.sa_mask);
+		if (sigaction(SIGSEGV, &application_handler, nullptr) != 0)
+			_exit(2);
+
+		int src = 1;
+		int dst = 0;
+		if (bpftime_probe_read((uint64_t)&dst, sizeof(dst),
+				       (uint64_t)&src, 0, 0) != 0 ||
+		    dst != src)
+			_exit(3);
+
+		application_handler.sa_handler = count_replaced_sigsegv;
+		if (sigaction(SIGSEGV, &application_handler, nullptr) != 0)
+			_exit(4);
+		if (bpftime_probe_read((uint64_t)&dst, sizeof(dst),
+				       (uint64_t)&src, 0, 0) != 0)
+			_exit(5);
+
+		int raise_result = raise(SIGSEGV);
+		_exit(raise_result == 0 && forwarded_sigsegv == 2 ? 0 : 6);
+	}
+
+	int status = 0;
+	REQUIRE(waitpid(child, &status, 0) == child);
+	REQUIRE(WIFEXITED(status));
+	REQUIRE(WEXITSTATUS(status) == 0);
 }
 
 TEST_CASE("Test bpftime_probe_write_user") // test for bpftime_probe_write_user
@@ -91,24 +195,31 @@ TEST_CASE("Test Probe read/write size valid or not ")
 }
 
 
-TEST_CASE("Test origin handler is null")
+TEST_CASE("Test default SIGSEGV handler is preserved")
 {
-	struct sigaction original_sa, sa;
-	int dst[4] = { 0 };
-	int src[4] = { 1, 2, 3, 4 };
-	sa.sa_flags = SA_SIGINFO;
-	sigemptyset(&sa.sa_mask);
-	sa.sa_sigaction = nullptr;
-	if (sigaction(SIGSEGV, &sa, nullptr) < 0) {
-		REQUIRE(false);
+	pid_t child = fork();
+	REQUIRE(child >= 0);
+	if (child == 0) {
+		struct sigaction default_action = {};
+		default_action.sa_handler = SIG_DFL;
+		sigemptyset(&default_action.sa_mask);
+		if (sigaction(SIGSEGV, &default_action, nullptr) != 0)
+			_exit(2);
+
+		int dst = 0;
+		int src = 1;
+		if (bpftime_probe_read((uint64_t)&dst, sizeof(dst),
+				       (uint64_t)&src, 0, 0) != 0)
+			_exit(3);
+
+		struct sigaction current_action = {};
+		if (sigaction(SIGSEGV, nullptr, &current_action) != 0)
+			_exit(4);
+		_exit(current_action.sa_handler == SIG_DFL ? 0 : 5);
 	}
-	uint64_t size = sizeof(src);
 
-	int ret = bpftime_probe_read((uint64_t)(dst), size, (uint64_t)(src), 0,
-				     0);
-	REQUIRE(ret == 0);
-
-	sigaction(SIGSEGV, nullptr, &original_sa);
-	auto handler = original_sa.sa_sigaction;
-	REQUIRE(handler != nullptr);
+	int status = 0;
+	REQUIRE(waitpid(child, &status, 0) == child);
+	REQUIRE(WIFEXITED(status));
+	REQUIRE(WEXITSTATUS(status) == 0);
 }

--- a/runtime/unit-test/test_probe.cpp
+++ b/runtime/unit-test/test_probe.cpp
@@ -1,7 +1,5 @@
 #include "catch2/catch_test_macros.hpp"
 #include "spdlog/spdlog.h"
-#include <csetjmp>
-#include <cstdlib>
 #include <cstring>
 #include <sys/resource.h>
 #include <sys/wait.h>
@@ -23,10 +21,10 @@ static void count_replaced_sigsegv(int)
 
 extern "C" {
 
-uint64_t bpftime_probe_read(uint64_t dst, uint64_t size, uint64_t ptr, uint64_t,
-			    uint64_t);
-uint64_t bpftime_probe_write_user(uint64_t dst, uint64_t src, uint64_t len,
-				  uint64_t, uint64_t);
+int64_t bpftime_probe_read(uint64_t dst, int64_t size, uint64_t ptr, uint64_t,
+			   uint64_t);
+int64_t bpftime_probe_write_user(uint64_t dst, uint64_t src, int64_t len,
+				 uint64_t, uint64_t);
 }
 
 TEST_CASE("Test bpftime_probe_read") // test for bpftime_probe_read
@@ -41,14 +39,15 @@ TEST_CASE("Test bpftime_probe_read") // test for bpftime_probe_read
 	for (size_t i = 0; i < len; i++) {
 		REQUIRE(dst[i] == src[i]);
 	}
+#ifdef ENABLE_PROBE_READ_CHECK
 	ret = bpftime_probe_read((uint64_t)dst, size, (uint64_t)(nullptr), 0,
 				 0);
 	REQUIRE(ret == -EFAULT);
 
-	ret = 0;
 	ret = bpftime_probe_read((uint64_t)(nullptr), size, (uint64_t)(nullptr),
 				 0, 0);
 	REQUIRE(ret == -EFAULT);
+#endif
 }
 
 TEST_CASE("Test repeated valid probe memory access")
@@ -65,12 +64,13 @@ TEST_CASE("Test repeated valid probe memory access")
 					   (uint64_t)src, 0, 0) == 0);
 		REQUIRE(std::memcmp(read_dst, src, size) == 0);
 		REQUIRE(bpftime_probe_write_user((uint64_t)write_dst,
-						(uint64_t)src, size, 0, 0) == 0);
+						 (uint64_t)src, size, 0,
+						 0) == 0);
 		REQUIRE(std::memcmp(write_dst, src, size) == 0);
 	}
 }
 
-TEST_CASE("Test SIGSEGV handler chaining across threads")
+TEST_CASE("Test probe access preserves application SIGSEGV handlers")
 {
 	pid_t child = fork();
 	REQUIRE(child >= 0);
@@ -90,48 +90,21 @@ TEST_CASE("Test SIGSEGV handler chaining across threads")
 		    dst != src)
 			_exit(3);
 		int raise_result = -1;
-		std::thread worker([&raise_result]() {
-			raise_result = raise(SIGSEGV);
-		});
+		std::thread worker(
+			[&raise_result]() { raise_result = raise(SIGSEGV); });
 		worker.join();
-		_exit(raise_result == 0 && forwarded_sigsegv == 1 ? 0 : 4);
-	}
-
-	int status = 0;
-	REQUIRE(waitpid(child, &status, 0) == child);
-	REQUIRE(WIFEXITED(status));
-	REQUIRE(WEXITSTATUS(status) == 0);
-}
-
-TEST_CASE("Test probe access refreshes replaced SIGSEGV handler")
-{
-	pid_t child = fork();
-	REQUIRE(child >= 0);
-	if (child == 0) {
-		struct rlimit no_core = { 0, 0 };
-		struct sigaction application_handler = {};
-		setrlimit(RLIMIT_CORE, &no_core);
-		application_handler.sa_handler = count_sigsegv;
-		sigemptyset(&application_handler.sa_mask);
-		if (sigaction(SIGSEGV, &application_handler, nullptr) != 0)
-			_exit(2);
-
-		int src = 1;
-		int dst = 0;
-		if (bpftime_probe_read((uint64_t)&dst, sizeof(dst),
-				       (uint64_t)&src, 0, 0) != 0 ||
-		    dst != src)
-			_exit(3);
+		if (raise_result != 0 || forwarded_sigsegv != 1)
+			_exit(4);
 
 		application_handler.sa_handler = count_replaced_sigsegv;
 		if (sigaction(SIGSEGV, &application_handler, nullptr) != 0)
-			_exit(4);
+			_exit(5);
 		if (bpftime_probe_read((uint64_t)&dst, sizeof(dst),
 				       (uint64_t)&src, 0, 0) != 0)
-			_exit(5);
+			_exit(6);
 
-		int raise_result = raise(SIGSEGV);
-		_exit(raise_result == 0 && forwarded_sigsegv == 2 ? 0 : 6);
+		raise_result = raise(SIGSEGV);
+		_exit(raise_result == 0 && forwarded_sigsegv == 3 ? 0 : 7);
 	}
 
 	int status = 0;
@@ -193,7 +166,6 @@ TEST_CASE("Test Probe read/write size valid or not ")
 		REQUIRE(dst[i] == src[i]);
 	}
 }
-
 
 TEST_CASE("Test default SIGSEGV handler is preserved")
 {

--- a/runtime/unit-test/test_probe.cpp
+++ b/runtime/unit-test/test_probe.cpp
@@ -1,6 +1,8 @@
 #include "catch2/catch_test_macros.hpp"
 #include "spdlog/spdlog.h"
+#include <cerrno>
 #include <cstring>
+#include <sys/mman.h>
 #include <sys/resource.h>
 #include <sys/wait.h>
 #include <thread>
@@ -25,6 +27,8 @@ int64_t bpftime_probe_read(uint64_t dst, int64_t size, uint64_t ptr, uint64_t,
 			   uint64_t);
 int64_t bpftime_probe_write_user(uint64_t dst, uint64_t src, int64_t len,
 				 uint64_t, uint64_t);
+int64_t bpf_probe_read_str(uint64_t dst, uint64_t size, uint64_t src, uint64_t,
+			   uint64_t);
 }
 
 TEST_CASE("Test bpftime_probe_read") // test for bpftime_probe_read
@@ -68,6 +72,54 @@ TEST_CASE("Test repeated valid probe memory access")
 						 0) == 0);
 		REQUIRE(std::memcmp(write_dst, src, size) == 0);
 	}
+}
+
+TEST_CASE("Test bpf_probe_read_str")
+{
+	char destination[8] = {};
+	const char source[] = "text";
+
+	REQUIRE(bpf_probe_read_str((uint64_t)destination, sizeof(destination),
+				   (uint64_t)source, 0, 0) == sizeof(source));
+	REQUIRE(std::strcmp(destination, source) == 0);
+
+	std::memset(destination, 'x', sizeof(destination));
+	REQUIRE(bpf_probe_read_str((uint64_t)destination, 3, (uint64_t)source,
+				   0, 0) == 3);
+	REQUIRE(std::strcmp(destination, "te") == 0);
+	REQUIRE(bpf_probe_read_str((uint64_t)destination, 0, (uint64_t)source,
+				   0, 0) == 0);
+#ifdef ENABLE_PROBE_READ_CHECK
+	std::memset(destination, 'x', sizeof(destination));
+	REQUIRE(bpf_probe_read_str((uint64_t)destination, sizeof(destination),
+				   0, 0, 0) == -EFAULT);
+	REQUIRE(destination[0] == '\0');
+	REQUIRE(bpf_probe_read_str(0, sizeof(destination), (uint64_t)source, 0,
+				   0) == -EFAULT);
+
+	long page_size = sysconf(_SC_PAGESIZE);
+	REQUIRE(page_size > 0);
+	auto pages = (char *)mmap(nullptr, (size_t)page_size * 2,
+				  PROT_READ | PROT_WRITE,
+				  MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+	REQUIRE(pages != MAP_FAILED);
+	pages[page_size - 2] = 'a';
+	pages[page_size - 1] = '\0';
+	REQUIRE(mprotect(pages + page_size, (size_t)page_size, PROT_NONE) == 0);
+	REQUIRE(bpf_probe_read_str((uint64_t)destination, sizeof(destination),
+				   (uint64_t)(pages + page_size - 2), 0,
+				   0) == 2);
+	REQUIRE(std::strcmp(destination, "a") == 0);
+
+	pages[page_size - 1] = 'b';
+	std::memset(destination, 'x', sizeof(destination));
+	REQUIRE(bpf_probe_read_str((uint64_t)destination, sizeof(destination),
+				   (uint64_t)(pages + page_size - 2), 0,
+				   0) == -EFAULT);
+	for (char value : destination)
+		REQUIRE(value == '\0');
+	REQUIRE(munmap(pages, (size_t)page_size * 2) == 0);
+#endif
 }
 
 TEST_CASE("Test probe access preserves application SIGSEGV handlers")


### PR DESCRIPTION
## Description

Fix probe read/write fault handling without installing a process-wide SIGSEGV handler.

The existing implementation keeps process-wide handler state in thread-local variables, reads an uninitialized sigaction on repeated calls, and leaves the bpftime handler installed after a helper returns. A SIGSEGV on another thread can therefore enter the wrapper without a recoverable application handler and throw from signal context.

This change:

- uses OS-supported no-fault copies (process_vm_readv/process_vm_writev on Linux and Mach VM operations on macOS);
- leaves application SIGSEGV dispositions untouched;
- preserves checked and unchecked build modes;
- propagates probe-check feature definitions into the runtime test target so guarded fault assertions actually run;
- adds regression coverage for repeated valid access, invalid addresses, cross-thread SIGSEGV delivery, handler replacement, and the default handler.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] This change requires a documentation update

## Validation

- Built bpftime_runtime_tests with both LLVM and uBPF backends.
- Enabled-check focused suites pass: 47 assertions in 5 probe cases and 8 assertions in 2 SIGSEGV cases.
- Disabled-check focused suites pass: 43 assertions in 5 probe cases and 8 assertions in 2 SIGSEGV cases.
- The signal regression cases fail on the previous implementation because it replaces and retains the process-wide handler.

No user-facing API or configuration changes are introduced.
