### PR TITLE
fix: correct Frida probe and tail-call runtime behavior

### DIFF
--- a/attach/frida_uprobe_attach_impl/include/frida_internal_attach_entry.hpp
+++ b/attach/frida_uprobe_attach_impl/include/frida_internal_attach_entry.hpp
@@ -16,7 +16,8 @@ class frida_internal_attach_entry {
 	void *function;
 	GumInterceptor *interceptor;
 	std::vector<frida_attach_entry *> user_attaches;
-	GumInvocationListener *frida_gum_invocation_listener = nullptr;
+	GumInvocationListener *uprobe_listener = nullptr;
+	GumInvocationListener *uretprobe_listener = nullptr;
 
 	friend class frida_attach_impl;
 
@@ -31,6 +32,7 @@ class frida_internal_attach_entry {
 
 	bool has_override() const;
 	bool has_uprobe_or_uretprobe() const;
+	void ensure_listener(int attach_type);
 	void run_filter_callback(const pt_regs &regs) const;
 	void iterate_uprobe_callbacks(const pt_regs &regs) const;
 	void iterate_uretprobe_callbacks(const pt_regs &regs) const;

--- a/attach/frida_uprobe_attach_impl/src/frida_internal_attach_entry.cpp
+++ b/attach/frida_uprobe_attach_impl/src/frida_internal_attach_entry.cpp
@@ -6,10 +6,14 @@
 #include <spdlog/spdlog.h>
 #include <frida_register_conversion.hpp>
 using namespace bpftime::attach;
-GType uprobe_listener_get_type();
 
 extern "C" uint64_t __bpftime_frida_attach_manager__replace_handler();
 extern "C" void *__bpftime_frida_attach_manager__override_handler();
+
+static void uprobe_listener_on_enter(GumInvocationContext *context,
+				     gpointer user_data);
+static void uprobe_listener_on_leave(GumInvocationContext *context,
+				     gpointer user_data);
 
 namespace
 {
@@ -108,40 +112,47 @@ std::string build_frida_attach_failure_message(const char *operation,
 
 } // namespace
 
+void frida_internal_attach_entry::ensure_listener(int attach_type)
+{
+	if (attach_type != ATTACH_UPROBE && attach_type != ATTACH_URETPROBE)
+		return;
+	auto **slot = attach_type == ATTACH_UPROBE ? &uprobe_listener :
+						     &uretprobe_listener;
+	if (*slot != nullptr)
+		return;
+	*slot = attach_type == ATTACH_UPROBE ?
+			gum_make_probe_listener(uprobe_listener_on_enter, this,
+						nullptr) :
+			gum_make_call_listener(nullptr, uprobe_listener_on_leave,
+					       this, nullptr);
+	if (*slot == nullptr)
+		throw std::runtime_error("Unable to create Frida listener");
+	gum_interceptor_begin_transaction(interceptor);
+	if (int err = gum_interceptor_attach(interceptor, function, *slot,
+					     nullptr);
+	    err < 0) {
+		auto message = build_frida_attach_failure_message(
+			"gum_interceptor_attach", function, attach_type, err);
+		g_object_unref(*slot);
+		*slot = nullptr;
+		gum_interceptor_end_transaction(interceptor);
+		SPDLOG_ERROR("{}", message);
+		throw std::runtime_error(message);
+	}
+	gum_interceptor_end_transaction(interceptor);
+}
+
 frida_internal_attach_entry::frida_internal_attach_entry(
 	void *function, int basic_attach_type, GumInterceptor *interceptor)
 	: function(function)
 {
-	struct interceptor_transaction {
-		GumInterceptor *interceptor;
-		interceptor_transaction(GumInterceptor *interceptor)
-			: interceptor(interceptor)
-		{
-			gum_interceptor_begin_transaction(interceptor);
-		}
-		~interceptor_transaction()
-		{
-			gum_interceptor_end_transaction(interceptor);
-		}
-	} _transaction(interceptor);
+	this->interceptor = interceptor;
 	override_return_callback = nullptr;
 	if (basic_attach_type == ATTACH_UPROBE ||
 	    basic_attach_type == ATTACH_URETPROBE) {
-		frida_gum_invocation_listener =
-			(GumInvocationListener *)g_object_new(
-				uprobe_listener_get_type(), NULL);
-
-		if (int err = gum_interceptor_attach(
-			    interceptor, function,
-			    frida_gum_invocation_listener, this);
-		    err < 0) {
-			auto message = build_frida_attach_failure_message(
-				"gum_interceptor_attach", function,
-				basic_attach_type, err);
-			SPDLOG_ERROR("{}", message);
-			throw std::runtime_error(message);
-		}
+		ensure_listener(basic_attach_type);
 	} else if (basic_attach_type == ATTACH_UPROBE_OVERRIDE) {
+		gum_interceptor_begin_transaction(interceptor);
 		if (int err = gum_interceptor_replace(
 			    interceptor, function,
 			    (void *)__bpftime_frida_attach_manager__override_handler,
@@ -150,9 +161,11 @@ frida_internal_attach_entry::frida_internal_attach_entry(
 			auto message = build_frida_attach_failure_message(
 				"gum_interceptor_replace", function,
 				basic_attach_type, err);
+			gum_interceptor_end_transaction(interceptor);
 			SPDLOG_ERROR("{}", message);
 			throw std::runtime_error(message);
 		}
+		gum_interceptor_end_transaction(interceptor);
 		override_return_callback = override_return_set_callback(
 			[&](uint64_t ctx, uint64_t v) {
 				SPDLOG_DEBUG(
@@ -169,12 +182,13 @@ frida_internal_attach_entry::frida_internal_attach_entry(
 frida_internal_attach_entry::~frida_internal_attach_entry()
 {
 	SPDLOG_DEBUG("Destroy internal attach at {:x}", (uintptr_t)function);
-	if (frida_gum_invocation_listener) {
-		gum_interceptor_detach(interceptor,
-				       frida_gum_invocation_listener);
-		g_object_unref(frida_gum_invocation_listener);
-		SPDLOG_DEBUG("Detached listener");
-	} else {
+	for (auto *listener : { uprobe_listener, uretprobe_listener }) {
+		if (listener != nullptr) {
+			gum_interceptor_detach(interceptor, listener);
+			g_object_unref(listener);
+		}
+	}
+	if (!uprobe_listener && !uretprobe_listener) {
 		gum_interceptor_revert(interceptor, function);
 		SPDLOG_DEBUG("Reverted function replace");
 	}
@@ -276,31 +290,12 @@ extern "C" void *__bpftime_frida_attach_manager__override_handler()
 	}
 }
 
-static void uprobe_listener_iface_init(gpointer g_iface, gpointer iface_data);
-
-typedef struct _UprobeListener UprobeListener;
-
-struct _UprobeListener {
-	GObject parent;
-};
-
-#define EXAMPLE_TYPE_LISTENER (uprobe_listener_get_type())
-G_DECLARE_FINAL_TYPE(UprobeListener, uprobe_listener, EXAMPLE, LISTENER,
-		     GObject)
-G_DEFINE_TYPE_EXTENDED(UprobeListener, uprobe_listener, G_TYPE_OBJECT, 0,
-		       G_IMPLEMENT_INTERFACE(GUM_TYPE_INVOCATION_LISTENER,
-					     uprobe_listener_iface_init))
-
-static void uprobe_listener_on_enter(GumInvocationListener *listener,
-				     GumInvocationContext *ic)
+static void uprobe_listener_on_enter(GumInvocationContext *ctx,
+				     gpointer user_data)
 {
-	UprobeListener *self = EXAMPLE_LISTENER(listener);
-	auto *hook_entry = (frida_internal_attach_entry *)
-		gum_invocation_context_get_listener_function_data(ic);
+	auto *hook_entry = static_cast<frida_internal_attach_entry *>(user_data);
 	SPDLOG_TRACE("Handle uprobe at uprobe_listener_on_enter");
-	GumInvocationContext *ctx;
 	bpftime::pt_regs regs;
-	ctx = gum_interceptor_get_current_invocation();
 	convert_gum_cpu_context_to_pt_regs(*ctx->cpu_context, regs);
 
 	SPDLOG_DEBUG("Setting current thread gum cpu context");
@@ -312,33 +307,12 @@ static void uprobe_listener_on_enter(GumInvocationListener *listener,
 	current_thread_gum_cpu_context.reset();
 }
 
-static void uprobe_listener_on_leave(GumInvocationListener *listener,
-				     GumInvocationContext *ic)
+static void uprobe_listener_on_leave(GumInvocationContext *ctx,
+				     gpointer user_data)
 {
-	auto *hook_entry = (frida_internal_attach_entry *)
-		gum_invocation_context_get_listener_function_data(ic);
+	auto *hook_entry = static_cast<frida_internal_attach_entry *>(user_data);
 	SPDLOG_TRACE("Handle uretprobe at uprobe_listener_on_leave");
 	bpftime::pt_regs regs;
-	GumInvocationContext *ctx;
-	ctx = gum_interceptor_get_current_invocation();
 	convert_gum_cpu_context_to_pt_regs(*ctx->cpu_context, regs);
 	hook_entry->iterate_uretprobe_callbacks(regs);
-}
-
-static void uprobe_listener_class_init(UprobeListenerClass *klass)
-{
-	(void)EXAMPLE_IS_LISTENER;
-}
-
-static void uprobe_listener_iface_init(gpointer g_iface, gpointer iface_data)
-{
-	GumInvocationListenerInterface *iface =
-		(GumInvocationListenerInterface *)g_iface;
-
-	iface->on_enter = uprobe_listener_on_enter;
-	iface->on_leave = uprobe_listener_on_leave;
-}
-
-static void uprobe_listener_init(UprobeListener *self)
-{
 }

--- a/attach/frida_uprobe_attach_impl/src/frida_uprobe_attach_impl.cpp
+++ b/attach/frida_uprobe_attach_impl/src/frida_uprobe_attach_impl.cpp
@@ -80,6 +80,7 @@ int frida_attach_impl::attach_at(void *func_addr,
 	}
 
 	auto &inner_attach = itr->second;
+	inner_attach->ensure_listener(current_attach_type);
 	int used_id = this->allocate_id();
 	frida_attach_entry ent(used_id, std::move(cb), func_addr);
 	int result = ent.self_id;

--- a/runtime/include/bpf_attach_ctx.hpp
+++ b/runtime/include/bpf_attach_ctx.hpp
@@ -190,6 +190,7 @@ public:
 			return {};
 		}
 	}
+	bpftime_prog *find_instantiated_prog(int handler_id) const;
 
 #ifdef BPFTIME_ENABLE_CUDA_ATTACH
 	std::optional<attach::nv_attach_impl *> find_nv_attach_impl() const;
@@ -256,6 +257,8 @@ private:
 	create_map_basic_info(int filled_size);
 #endif
 };
+
+int load_prog_and_helpers(bpftime_prog *prog, const runtime_config &config);
 
 } // namespace bpftime
 

--- a/runtime/include/bpftime_prog.hpp
+++ b/runtime/include/bpftime_prog.hpp
@@ -15,6 +15,7 @@ namespace bpftime
 {
 
 extern thread_local std::optional<uint64_t> current_thread_bpf_cookie;
+extern thread_local std::optional<uint64_t> current_thread_tail_call_ret;
 #ifdef BPFTIME_ENABLE_CUDA_ATTACH
 std::optional<std::vector<char>> compile_ptx_to_elf(const std::string &ptx_code,
 						    const char *cpu_target);

--- a/runtime/src/attach/bpf_attach_ctx.cpp
+++ b/runtime/src/attach/bpf_attach_ctx.cpp
@@ -37,7 +37,7 @@ extern "C" uint64_t bpftime_set_retval(uint64_t value);
 namespace bpftime
 {
 
-static int load_prog_and_helpers(bpftime_prog *prog, const runtime_config &config)
+int load_prog_and_helpers(bpftime_prog *prog, const runtime_config &config)
 {
 #if defined(__linux__)
 	if (config.enable_kernel_helper_group) {
@@ -182,6 +182,13 @@ bpf_attach_ctx::bpf_attach_ctx()
 			"CUDA shared communication memory not available; CUDA attach will be disabled for this process");
 	}
 #endif
+}
+
+bpftime_prog *bpf_attach_ctx::find_instantiated_prog(int handler_id) const
+{
+	auto program = instantiated_progs.find(handler_id);
+	return program == instantiated_progs.end() ? nullptr :
+						    program->second.get();
 }
 
 int bpf_attach_ctx::instantiate_handler_at(const handler_manager *manager,

--- a/runtime/src/bpf_helper.cpp
+++ b/runtime/src/bpf_helper.cpp
@@ -15,6 +15,7 @@
 #include <mach/mach_vm.h>
 #include <pthread.h>
 #elif __linux__
+#include <pthread.h>
 #include <sys/syscall.h>
 #include <sys/uio.h>
 #endif
@@ -61,6 +62,13 @@ __attribute__((weak)) bpftime::bpf_attach_ctx &get_global_attach_ctx()
 }
 extern "C" {
 
+#if __linux__ && \
+	(defined(ENABLE_PROBE_READ_CHECK) || defined(ENABLE_PROBE_WRITE_CHECK))
+static pid_t probe_access_pid = getpid();
+static const int probe_access_atfork_status = pthread_atfork(
+	nullptr, nullptr, [] { probe_access_pid = getpid(); });
+#endif
+
 uint64_t bpftime_override_return(uint64_t ctx, uint64_t value);
 uint64_t bpftime_set_retval(uint64_t retval);
 
@@ -98,8 +106,9 @@ static bool probe_read_memory(void *dst, const void *src, size_t size)
 #elif __linux__
 	struct iovec local = { dst, size };
 	struct iovec remote = { const_cast<void *>(src), size };
-	return syscall(SYS_process_vm_readv, getpid(), &local, 1, &remote, 1,
-		       0) == (ssize_t)size;
+	return syscall(SYS_process_vm_readv,
+		       probe_access_atfork_status == 0 ? probe_access_pid : getpid(),
+		       &local, 1, &remote, 1, 0) == (ssize_t)size;
 #else
 #error "Probe memory checks are unsupported on this platform"
 #endif
@@ -138,8 +147,9 @@ static bool probe_write_memory(void *dst, const void *src, size_t size)
 #elif __linux__
 	struct iovec local = { const_cast<void *>(src), size };
 	struct iovec remote = { dst, size };
-	return syscall(SYS_process_vm_writev, getpid(), &local, 1, &remote, 1,
-		       0) == (ssize_t)size;
+	return syscall(SYS_process_vm_writev,
+		       probe_access_atfork_status == 0 ? probe_access_pid : getpid(),
+		       &local, 1, &remote, 1, 0) == (ssize_t)size;
 #else
 #error "Probe memory checks are unsupported on this platform"
 #endif
@@ -199,7 +209,7 @@ uint64_t bpftime_get_current_pid_tgid(uint64_t, uint64_t, uint64_t, uint64_t,
 #if __linux__
 	static thread_local int tid = -1;
 	if (tid == -1) {
-		tid = gettid();
+		tid = static_cast<int>(syscall(SYS_gettid));
 	}
 #elif __APPLE__
 	static thread_local uint64_t tid = UINT64_MAX; // cannot use int because
@@ -537,35 +547,24 @@ uint64_t bpftime_tail_call(uint64_t ctx, uint64_t prog_array, uint64_t index)
 			}
 		} guard(tail_call_depth);
 
-		const auto &handler = std::get<bpftime::bpf_prog_handler>(
-			bpftime::shm_holder.global_shared_memory.get_handler(
-				to_call_fd));
-		bpftime::runtime_config config =
-			bpftime::bpftime_get_runtime_config();
-		bpftime::bpftime_prog prog(handler.insns.data(),
-					   handler.insns.size(),
-					   handler.name.c_str());
-
-		if (config.enable_kernel_helper_group &&
-		    bpftime::bpftime_helper_group::get_kernel_utils_helper_group()
-				    .add_helper_group_to_prog(&prog) < 0) {
-			return -1;
-		}
-		if (config.enable_ufunc_helper_group &&
-		    bpftime::bpftime_helper_group::get_ufunc_helper_group()
-				    .add_helper_group_to_prog(&prog) < 0) {
-			return -1;
-		}
-		if (config.enable_shm_maps_helper_group &&
-		    bpftime::bpftime_helper_group::get_shm_maps_helper_group()
-				    .add_helper_group_to_prog(&prog) < 0) {
-			return -1;
-		}
-		if (prog.bpftime_prog_load(false) < 0) {
-			SPDLOG_ERROR(
-				"Failed to load userspace tail call target fd {}",
+		bpftime::bpftime_prog *prog = nullptr;
+		try {
+			prog = get_global_attach_ctx().find_instantiated_prog(
 				to_call_fd);
-			return -1;
+		} catch (const std::exception &) {
+		}
+		std::optional<bpftime::bpftime_prog> fallback;
+		if (prog == nullptr) {
+			const auto &handler = std::get<bpftime::bpf_prog_handler>(
+				bpftime::shm_holder.global_shared_memory.get_handler(
+					to_call_fd));
+			fallback.emplace(handler.insns.data(), handler.insns.size(),
+					 handler.name.c_str());
+			prog = &*fallback;
+			if (bpftime::load_prog_and_helpers(
+				    prog,
+				    bpftime::bpftime_get_runtime_config()) < 0)
+				return -1;
 		}
 
 		char context[64];
@@ -576,15 +575,16 @@ uint64_t bpftime_tail_call(uint64_t ctx, uint64_t prog_array, uint64_t index)
 			memset(context, 0, sizeof(context));
 		}
 		uint64_t retval = 0;
-		int err = prog.bpftime_prog_exec(context, sizeof(context),
-						 &retval);
+		int err = prog->bpftime_prog_exec(context, sizeof(context),
+						  &retval);
 		if (err < 0) {
 			SPDLOG_ERROR(
 				"Failed to execute userspace tail call target fd {}",
 				to_call_fd);
 			return -1;
 		}
-		return retval;
+		bpftime::current_thread_tail_call_ret = retval;
+		return 0;
 	}
 
 #if __linux__ && defined(BPFTIME_BUILD_WITH_LIBBPF)
@@ -606,7 +606,8 @@ uint64_t bpftime_tail_call(uint64_t ctx, uint64_t prog_array, uint64_t index)
 		return -1;
 	}
 	close(to_call_fd);
-	return run_opts.retval;
+	bpftime::current_thread_tail_call_ret = run_opts.retval;
+	return 0;
 #else
 	SPDLOG_ERROR(
 		"tail_call to kernel program fd {} requires libbpf support",

--- a/runtime/src/bpftime_prog.cpp
+++ b/runtime/src/bpftime_prog.cpp
@@ -102,6 +102,7 @@ std::optional<std::vector<char>> compile_ptx_to_elf(const std::string &ptx_code,
 }
 #endif
 thread_local std::optional<uint64_t> current_thread_bpf_cookie;
+thread_local std::optional<uint64_t> current_thread_tail_call_ret;
 
 bpftime_prog::bpftime_prog(const struct ebpf_inst *insn, size_t insn_cnt,
 			   const char *name)
@@ -253,7 +254,8 @@ int bpftime_prog::bpftime_prog_exec(void *memory, size_t memory_size,
 			SPDLOG_ERROR("ebpf_exec returned error: {}", res);
 		}
 	}
-	*return_val = val;
+	*return_val = current_thread_tail_call_ret.value_or(val);
+	current_thread_tail_call_ret.reset();
 	// set share memory read only
 	bpftime_protect_enable();
 	return res;

--- a/runtime/unit-test/tailcall/test_user_to_kernel_tailcall.cpp
+++ b/runtime/unit-test/tailcall/test_user_to_kernel_tailcall.cpp
@@ -105,10 +105,8 @@ TEST_CASE("Test tail calling from userspace to kernel")
 		// call 0x0c
 		BPF_EMIT_CALL(0x0c), BPF_EXIT_INSN()
 	};
-	bpftime::runtime_config config;
-	config.set_vm_name("llvm");
 	bpftime_prog prog((const ebpf_inst *)user_insn, std::size(user_insn),
-			  "user_prog",std::move(config));
+			  "user_prog");
 	REQUIRE(bpftime_helper_group::get_kernel_utils_helper_group()
 			.add_helper_group_to_prog(&prog) == 0);
 	REQUIRE(prog.bpftime_prog_load(false) == 0);

--- a/runtime/unit-test/tailcall/test_user_to_user_tailcall.cpp
+++ b/runtime/unit-test/tailcall/test_user_to_user_tailcall.cpp
@@ -52,12 +52,9 @@ TEST_CASE("Test tail calling from userspace to userspace")
 		BPF_EXIT_INSN(),
 	};
 
-	bpftime::runtime_config config;
-	config.set_vm_name("llvm");
 	bpftime_prog prog((const ebpf_inst *)caller_insn,
 			  sizeof(caller_insn) / sizeof(caller_insn[0]),
-			  "tail_call_caller",
-			  std::move(config));
+			  "tail_call_caller");
 	REQUIRE(bpftime_helper_group::get_kernel_utils_helper_group()
 			.add_helper_group_to_prog(&prog) == 0);
 	REQUIRE(prog.bpftime_prog_load(false) == 0);

--- a/runtime/unit-test/test_probe.cpp
+++ b/runtime/unit-test/test_probe.cpp
@@ -124,6 +124,11 @@ TEST_CASE("Test bpf_probe_read_str")
 
 TEST_CASE("Test probe access preserves application SIGSEGV handlers")
 {
+	int parent_src = 1;
+	int parent_dst = 0;
+	REQUIRE(bpftime_probe_read((uint64_t)&parent_dst, sizeof(parent_dst),
+				   (uint64_t)&parent_src, 0, 0) == 0);
+
 	pid_t child = fork();
 	REQUIRE(child >= 0);
 	if (child == 0) {

--- a/vm/compat/ubpf-vm/compat_ubpf.cpp
+++ b/vm/compat/ubpf-vm/compat_ubpf.cpp
@@ -54,8 +54,11 @@ int bpftime_ubpf_vm::register_external_function(size_t index,
 	// Allocate one more id
 	size_t next_id = next_helper_id++;
 	helper_id_map[index] = next_id;
-	return ubpf_register(ubpf_vm, next_id, name.c_str(),
-			     (external_function_t)fn);
+	int err = ubpf_register(ubpf_vm, next_id, name.c_str(),
+				(external_function_t)fn);
+	if (!err && name == "bpf_tail_call")
+		err = ubpf_set_unwind_function_index(ubpf_vm, next_id);
+	return err;
 }
 
 int bpftime_ubpf_vm::load_code(const void *code, size_t code_len)


### PR DESCRIPTION
## Summary

Fix several runtime correctness issues around Frida probes, BPF tail calls, and probe memory access across `fork()`.

- split Frida uprobe and uretprobe listeners and lazily attach the listener required by each attach type
- preserve tail-call semantics by treating successful tail calls as non-returning from the caller and propagating the target program's return value
- reuse instantiated userspace programs for tail calls when available, with fallback loading through the shared helper-registration path
- refresh probe-access PID state after `fork()` on Linux and use `SYS_gettid` explicitly
- mark the uBPF `bpf_tail_call` helper as the VM unwind function
- adjust tail-call and probe tests for the corrected runtime behavior

## Why

The existing Frida listener couples entry and return callbacks even when only one probe type is needed, and adding another probe type to an already-attached function does not install the corresponding listener. Tail calls also need to terminate the current BPF program after a successful jump; returning the target value directly from the helper allows instructions after the helper call to execute. Probe-memory access also needs process identity to be refreshed in forked children.

## Validation

- reconstructed the supplied patch byte-for-byte and verified its SHA-256 before applying it
- `git apply --check`
- `git diff --check`
- final branch is exactly one commit ahead of `master`
- final diff changes only the 12 intended runtime, Frida, VM, and test files
