### PR TITLE
feat: support NVIDIA GB300 (sm_103) and CUDA 13

### DIFF
--- a/attach/nv_attach_impl/nv_attach_impl.cpp
+++ b/attach/nv_attach_impl/nv_attach_impl.cpp
@@ -1216,7 +1216,11 @@ int nv_attach_impl::run_attach_entry_on_gpu(int attach_id, int run_count,
 		CUDA_SAFE_CALL(cuInit(0));
 		CUDA_SAFE_CALL(cuDeviceGet(&cuDevice, 0));
 
+#if CUDA_VERSION >= 13000
+		CUDA_SAFE_CALL(cuCtxCreate(&context, NULL, 0, cuDevice));
+#else
 		CUDA_SAFE_CALL(cuCtxCreate(&context, 0, cuDevice));
+#endif
 		CUDA_SAFE_CALL(cuModuleLoadDataEx(&module, output_elf.data(), 0,
 						  0, 0));
 		// fill data into it

--- a/attach/nv_attach_impl/nv_attach_utils.cpp
+++ b/attach/nv_attach_impl/nv_attach_utils.cpp
@@ -29,7 +29,7 @@ std::string rewrite_ptx_target(std::string ptx,
 
 	// Rewrite .version based on SM arch (sm_120+ needs 8.7, sm_100+ needs 8.5)
 	int sm_num = (sm_arch.size() > 3) ? std::atoi(sm_arch.c_str() + 3) : 0;
-	const char *ptx_ver = (sm_num >= 120) ? "8.7" : (sm_num >= 100) ? "8.5" : nullptr;
+	const char *ptx_ver = (sm_num >= 120) ? "8.7" : (sm_num >= 103) ? "8.8" : (sm_num >= 100) ? "8.5" : nullptr;
 	if (ptx_ver) {
 		auto vpos = ptx.find(".version");
 		if (vpos != std::string::npos) {

--- a/runtime/src/handler/map_handler.cpp
+++ b/runtime/src/handler/map_handler.cpp
@@ -1005,7 +1005,11 @@ int bpf_map_handler::map_init(managed_shared_memory &memory)
 		shm_holder.global_shared_memory.set_enable_mock(false);
 		if (!device) {
 			cuDeviceGet(&device, 0);
+#if CUDA_VERSION >= 13000
+			cuCtxCreate(&context, nullptr, 0, device);
+#else
 			cuCtxCreate(&context, 0, device);
+#endif
 			SPDLOG_INFO(
 				"CUDA context for thread {} has been set to {:x}",
 				gettid(), (uintptr_t)context);
@@ -1024,7 +1028,11 @@ int bpf_map_handler::map_init(managed_shared_memory &memory)
 		shm_holder.global_shared_memory.set_enable_mock(false);
 		if (!device) {
 			cuDeviceGet(&device, 0);
+#if CUDA_VERSION >= 13000
+			cuCtxCreate(&context, nullptr, 0, device);
+#else
 			cuCtxCreate(&context, 0, device);
+#endif
 			SPDLOG_INFO(
 				"CUDA context for thread {} has been set to {:x}",
 				gettid(), (uintptr_t)context);


### PR DESCRIPTION
Fixes #645. Follow-up to #541.

## What this does

Lets bpftime build and compile injected PTX on an NVIDIA GB300 (Blackwell Ultra, `sm_103`) with CUDA 13. Two small fixes:

1. **PTX version for `sm_103`.** `rewrite_ptx_target()` set PTX `.version 8.5` for `sm_num >= 100`. `sm_103` needs `8.8` (CUDA 12.9), so `ptxas` rejected the injected PTX. Added an `sm_103 -> 8.8` case.
2. **CUDA 13 `cuCtxCreate`.** In CUDA 13 `cuCtxCreate` takes 4 args (`cuCtxCreate_v4`). Three call sites used the old 3-arg form and did not compile. Guarded them with `#if CUDA_VERSION >= 13000`.

## How I tested

On a GB300 (Grace/aarch64, CUDA 13.2): it builds, and `example/gpu/cuda-counter` now compiles the injected PTX for `sm_103` (`ptxas ... for 'sm_103'` succeeds) and loads the patched module. Before the fix, `ptxas` rejected the PTX at version 8.5.

## Notes

- On Grace/SBSA the CUDA libs live under `targets/sbsa-linux/`, not the `targets/aarch64-linux/` that `cmake/cuda.cmake` looks for. I used a symlink to build; a `cuda.cmake` change could be a follow-up.
- A separate runtime bug remains: at launch the kernel stub resolves to `_fini`, so the patched kernel is not run. Filed as #646.

Happy to add a small unit test for `rewrite_ptx_target` if you'd like.

## Checklist

- [x] I agree to the CLA (per CONTRIBUTING).
- [x] One root cause; checked all three `cuCtxCreate` call sites.
