### PR TITLE
ci: fetch release tags without submodules

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -77,7 +77,7 @@ jobs:
         id: release-version
         if: "github.event_name == 'workflow_dispatch'"
         run: |
-          git fetch --tags --force
+          git fetch --no-recurse-submodules --force origin '+refs/tags/*:refs/tags/*'
 
           version=$(sed -n 's/^[[:space:]]*VERSION[[:space:]]\+\([0-9]\+\.[0-9]\+\.[0-9]\+\).*/\1/p' CMakeLists.txt | head -n1)
           if [ -z "$version" ]; then


### PR DESCRIPTION
## Summary
- Fetch only tag refs when resolving the workflow-dispatch release version
- Disable submodule recursion for that tag fetch
- Keep tag-push releases, Docker tag generation, and version bump semantics unchanged

## Why
The manual release dispatch run for v0.9.0 failed while resolving the release version:
https://github.com/eunomia-bpf/bpftime/actions/runs/31842530112

The failing step used `git fetch --tags --force` after a recursive-submodule checkout. In that environment, the broad fetch failed with:

```text
error: expected submodule path 'third_party/libbpf' not to be a symbolic link
```

The resolver only needs local tag refs to avoid reusing an existing release tag, so this narrows the fetch to `refs/tags/*` and explicitly disables submodule recursion.

## Validation
- `git diff --check`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docker.yml"); puts "yaml ok"'`
- `git fetch --no-recurse-submodules --force origin '+refs/tags/*:refs/tags/*'`
- Local resolver simulation with existing `v0.9.0` tag produced `v0.9.1`

## Release impact
This does not change the already-published v0.9.0 tag or release. It only fixes future manual workflow-dispatch releases.
