### PR TITLE
Fix hash lookup after deleting colliding keys

### DIFF
--- a/runtime/src/bpf_map/bpftime_hash_map.hpp
+++ b/runtime/src/bpf_map/bpftime_hash_map.hpp
@@ -51,9 +51,9 @@ public:
 // with open addressing and linear probing.
 class bpftime_hash_map {
     private:
-	static constexpr uint32_t bucket_empty = 0;
-	static constexpr uint32_t bucket_filled = 1;
-	static constexpr uint32_t bucket_deleted = 2;
+	static constexpr uint32_t BUCKET_EMPTY = 0;
+	static constexpr uint32_t BUCKET_FILLED = 1;
+	static constexpr uint32_t BUCKET_DELETED = 2;
 
 	inline size_t get_elem_offset(size_t index) const
 	{
@@ -98,25 +98,25 @@ class bpftime_hash_map {
 
 	inline bool is_empty(size_t index) const
 	{
-		return get_bucket_state(index) != bucket_filled;
+		return get_bucket_state(index) != BUCKET_FILLED;
 	}
 
 	inline void set_empty(size_t index)
 	{
 		*(uint32_t *)(uintptr_t)&data_buffer[get_elem_offset(index)] =
-			bucket_empty;
+			BUCKET_EMPTY;
 	}
 
 	inline void set_filled(size_t index)
 	{
 		*(uint32_t *)(uintptr_t)&data_buffer[get_elem_offset(index)] =
-			bucket_filled;
+			BUCKET_FILLED;
 	}
 
 	inline void set_deleted(size_t index)
 	{
 		*(uint32_t *)(uintptr_t)&data_buffer[get_elem_offset(index)] =
-			bucket_deleted;
+			BUCKET_DELETED;
 	}
 
 	inline void *get_key(size_t index)
@@ -145,10 +145,10 @@ class bpftime_hash_map {
 		size_t start_index = index;
 		do {
 			const auto state = get_bucket_state(index);
-			if (state == bucket_empty) {
+			if (state == BUCKET_EMPTY) {
 				return nullptr;
 			}
-			if (state == bucket_filled &&
+			if (state == BUCKET_FILLED &&
 			    std::memcmp(get_key(index), key, _key_size) == 0) {
 				return get_value(index);
 			}
@@ -166,7 +166,7 @@ class bpftime_hash_map {
 		// Iterate over the hash map using linear probing
 		do {
 			const auto state = get_bucket_state(index);
-			if (state == bucket_empty) {
+			if (state == BUCKET_EMPTY) {
 				// If the current bucket is empty, insert the
 				// new element
 				if (_count >= _max_element_count) {
@@ -183,7 +183,7 @@ class bpftime_hash_map {
 				_count++; // Increase the count for the new
 					  // element
 				return true;
-			} else if (state == bucket_deleted) {
+			} else if (state == BUCKET_DELETED) {
 				if (first_deleted == _num_buckets)
 					first_deleted = index;
 			} else if (std::memcmp(get_key(index), key,
@@ -218,10 +218,10 @@ class bpftime_hash_map {
 		size_t start_index = index;
 		do {
 			const auto state = get_bucket_state(index);
-			if (state == bucket_empty) {
+			if (state == BUCKET_EMPTY) {
 				return false; // Key not found
 			}
-			if (state == bucket_filled &&
+			if (state == BUCKET_FILLED &&
 			    std::memcmp(get_key(index), key, _key_size) == 0) {
 				set_deleted(index);
 				// Decrease count if deleting an element

--- a/runtime/src/bpf_map/bpftime_hash_map.hpp
+++ b/runtime/src/bpf_map/bpftime_hash_map.hpp
@@ -51,6 +51,10 @@ public:
 // with open addressing and linear probing.
 class bpftime_hash_map {
     private:
+	static constexpr uint32_t bucket_empty = 0;
+	static constexpr uint32_t bucket_filled = 1;
+	static constexpr uint32_t bucket_deleted = 2;
+
 	inline size_t get_elem_offset(size_t index) const
 	{
 		return index * (4 + _key_size + _value_size);
@@ -86,22 +90,33 @@ class bpftime_hash_map {
 				   0);
 	}
 
+	inline uint32_t get_bucket_state(size_t index) const
+	{
+		return *(const uint32_t *)(uintptr_t)&data_buffer[get_elem_offset(
+			index)];
+	}
+
 	inline bool is_empty(size_t index) const
 	{
-		return *(uint32_t *)(uintptr_t)&data_buffer[get_elem_offset(
-			       index)] == 0;
+		return get_bucket_state(index) != bucket_filled;
 	}
 
 	inline void set_empty(size_t index)
 	{
 		*(uint32_t *)(uintptr_t)&data_buffer[get_elem_offset(index)] =
-			0;
+			bucket_empty;
 	}
 
 	inline void set_filled(size_t index)
 	{
 		*(uint32_t *)(uintptr_t)&data_buffer[get_elem_offset(index)] =
-			1;
+			bucket_filled;
+	}
+
+	inline void set_deleted(size_t index)
+	{
+		*(uint32_t *)(uintptr_t)&data_buffer[get_elem_offset(index)] =
+			bucket_deleted;
 	}
 
 	inline void *get_key(size_t index)
@@ -129,10 +144,12 @@ class bpftime_hash_map {
 		size_t index = bpftime_hasher::hash_func(key, _key_size) % _num_buckets;
 		size_t start_index = index;
 		do {
-			if (is_empty(index)) {
+			const auto state = get_bucket_state(index);
+			if (state == bucket_empty) {
 				return nullptr;
 			}
-			if (std::memcmp(get_key(index), key, _key_size) == 0) {
+			if (state == bucket_filled &&
+			    std::memcmp(get_key(index), key, _key_size) == 0) {
 				return get_value(index);
 			}
 			index = (index + 1) % _num_buckets;
@@ -144,16 +161,20 @@ class bpftime_hash_map {
 	{
 		size_t index = bpftime_hasher::hash_func(key, _key_size) % _num_buckets;
 		size_t start_index = index;
+		size_t first_deleted = _num_buckets;
 
 		// Iterate over the hash map using linear probing
 		do {
-			if (is_empty(index)) {
+			const auto state = get_bucket_state(index);
+			if (state == bucket_empty) {
 				// If the current bucket is empty, insert the
 				// new element
 				if (_count >= _max_element_count) {
 					// Reject if the hash map is full
 					return false;
 				}
+				if (first_deleted != _num_buckets)
+					index = first_deleted;
 				// Insert the new element
 				std::memcpy(get_key(index), key, _key_size);
 				std::memcpy(get_value(index), value,
@@ -162,6 +183,9 @@ class bpftime_hash_map {
 				_count++; // Increase the count for the new
 					  // element
 				return true;
+			} else if (state == bucket_deleted) {
+				if (first_deleted == _num_buckets)
+					first_deleted = index;
 			} else if (std::memcmp(get_key(index), key,
 					       _key_size) == 0) {
 				// If the current bucket has a matching key,
@@ -175,6 +199,15 @@ class bpftime_hash_map {
 			index = (index + 1) % _num_buckets;
 		} while (index != start_index);
 
+		if (first_deleted != _num_buckets &&
+		    _count < _max_element_count) {
+			std::memcpy(get_key(first_deleted), key, _key_size);
+			std::memcpy(get_value(first_deleted), value, _value_size);
+			set_filled(first_deleted);
+			_count++;
+			return true;
+		}
+
 		return false; // The hash map is full and no empty or matching
 			      // slot was found
 	}
@@ -184,11 +217,13 @@ class bpftime_hash_map {
 		size_t index = bpftime_hasher::hash_func(key, _key_size) % _num_buckets;
 		size_t start_index = index;
 		do {
-			if (is_empty(index)) {
+			const auto state = get_bucket_state(index);
+			if (state == bucket_empty) {
 				return false; // Key not found
 			}
-			if (std::memcmp(get_key(index), key, _key_size) == 0) {
-				set_empty(index);
+			if (state == bucket_filled &&
+			    std::memcmp(get_key(index), key, _key_size) == 0) {
+				set_deleted(index);
 				// Decrease count if deleting an element
 				_count--;
 				return true;

--- a/runtime/unit-test/maps/test_bpftime_hash_map.cpp
+++ b/runtime/unit-test/maps/test_bpftime_hash_map.cpp
@@ -87,6 +87,36 @@ TEST_CASE("bpftime_hash_map basic operations", "[bpftime_hash_map]")
 		REQUIRE(map.elem_lookup(&key2) == nullptr);
 	}
 
+	SECTION("Delete preserves a colliding probe chain")
+	{
+		// With the 11-bucket table used by this fixture, these integer keys
+		// hash to the same initial bucket on little-endian platforms.
+		int key1 = 1;
+		int key2 = 12;
+		int key3 = 23;
+		int64_t value1 = 101;
+		int64_t value2 = 112;
+		int64_t value3 = 123;
+
+		REQUIRE(map.elem_update(&key1, &value1) == true);
+		REQUIRE(map.elem_update(&key2, &value2) == true);
+		REQUIRE(map.elem_delete(&key1) == true);
+
+		auto *second = static_cast<int64_t *>(map.elem_lookup(&key2));
+		REQUIRE(second != nullptr);
+		REQUIRE(*second == value2);
+
+		// A later insertion may reuse the tombstone without making the
+		// existing colliding key unreachable.
+		REQUIRE(map.elem_update(&key3, &value3) == true);
+		second = static_cast<int64_t *>(map.elem_lookup(&key2));
+		auto *third = static_cast<int64_t *>(map.elem_lookup(&key3));
+		REQUIRE(second != nullptr);
+		REQUIRE(*second == value2);
+		REQUIRE(third != nullptr);
+		REQUIRE(*third == value3);
+	}
+
 	SECTION("Get element count")
 	{
 		int key1 = 1234;


### PR DESCRIPTION
## What

Preserve linear-probing lookup chains after deleting a key from the fixed-size userspace hash map.

The map previously marked a deleted bucket as empty. A lookup for a colliding key stored later in the probe chain would stop at that bucket and incorrectly report the key as missing.

This change introduces an explicit tombstone state:

- lookup stops only at a never-used bucket and skips tombstones;
- delete marks the bucket as deleted instead of empty;
- insert reuses the first tombstone after checking the remaining probe chain for an existing key;
- `is_empty()` continues to mean "not currently occupied" for map iteration.

## Test

Adds a regression section that inserts colliding keys, deletes the first one, verifies the second remains reachable, and verifies the tombstone can be reused by another colliding insertion.

This is intentionally limited to the correctness fix; hash-function and bucket-count performance changes are left out.