### PR TITLE
Fix daemon PID filtering to use TGID

### DIFF
--- a/daemon/kernel/bpf_kernel_config.h
+++ b/daemon/kernel/bpf_kernel_config.h
@@ -27,12 +27,12 @@ const volatile bool submit_bpf_events = 0;
 
 static __always_inline bool filter_target(void)
 {
-	u64 pid = bpf_get_current_pid_tgid() & 0xffffffff;
-	if (target_pid && pid != target_pid) {
+	u32 tgid = bpf_get_current_pid_tgid() >> 32;
+	if (target_pid && tgid != target_pid) {
 		// filter target pid
 		return false;
 	}
-	if (current_pid && pid == current_pid) {
+	if (current_pid && tgid == current_pid) {
 		// avoid breaking current process
 		return false;
 	}


### PR DESCRIPTION
## What

Use the process TGID, rather than the thread ID, when applying `target_pid` and `current_pid` filters in the daemon's kernel-side BPF program.

`bpf_get_current_pid_tgid()` returns TGID in the upper 32 bits and TID in the lower 32 bits. The daemon config passes a process PID into `target_pid`, so comparing it with the low 32 bits causes events from non-leader threads of the target process to be filtered out.

The same issue affects the `current_pid` self-filter.

## Result

All threads belonging to the configured process are matched consistently.