### PR TITLE
Zero-initialize Frida x86 pt_regs conversion

### DIFF
--- a/attach/frida_uprobe_attach_impl/CMakeLists.txt
+++ b/attach/frida_uprobe_attach_impl/CMakeLists.txt
@@ -26,6 +26,7 @@ set(TEST_SOURCES
     test/test_attach_private_data_parsing.cpp
     test/test_base_attach_impl.cpp
     test/test_back_trace.cpp
+    test/test_register_conversion.cpp
 )
 option(TEST_LCOV "option for lcov" OFF)
 add_library(bpftime_frida_stripped_backtrace_fixture SHARED

--- a/attach/frida_uprobe_attach_impl/src/frida_register_conversion.cpp
+++ b/attach/frida_uprobe_attach_impl/src/frida_register_conversion.cpp
@@ -6,6 +6,10 @@ namespace bpftime
 void convert_gum_cpu_context_to_pt_regs(const ::_GumX64CpuContext &context,
 					pt_regs &regs)
 {
+	// Gum only exposes the general-purpose register subset. Clear fields such
+	// as orig_ax, cs, flags, and ss instead of leaking uninitialized stack data
+	// into the BPF pt_regs context.
+	regs = {};
 	regs.ip = context.rip;
 	regs.r15 = context.r15;
 	regs.r14 = context.r14;

--- a/attach/frida_uprobe_attach_impl/test/test_register_conversion.cpp
+++ b/attach/frida_uprobe_attach_impl/test/test_register_conversion.cpp
@@ -1,0 +1,31 @@
+#include "catch2/catch_test_macros.hpp"
+#include <frida-gum.h>
+#include <frida_register_conversion.hpp>
+#include <cstring>
+
+#if defined(__x86_64__) || defined(_M_X64)
+TEST_CASE("Frida x86 register conversion clears unavailable pt_regs fields")
+{
+	_GumX64CpuContext context{};
+	context.rax = 0x11;
+	context.rdi = 0x22;
+	context.rip = 0x33;
+	context.rsp = 0x44;
+
+	bpftime::pt_regs regs;
+	std::memset(&regs, 0xa5, sizeof(regs));
+	bpftime::convert_gum_cpu_context_to_pt_regs(context, regs);
+
+	REQUIRE(regs.ax == context.rax);
+	REQUIRE(regs.di == context.rdi);
+	REQUIRE(regs.ip == context.rip);
+	REQUIRE(regs.sp == context.rsp);
+
+	// GumX64CpuContext has no values for these Linux pt_regs fields. They must
+	// be deterministic instead of retaining bytes from the caller's stack.
+	REQUIRE(regs.orig_ax == 0);
+	REQUIRE(regs.cs == 0);
+	REQUIRE(regs.flags == 0);
+	REQUIRE(regs.ss == 0);
+}
+#endif


### PR DESCRIPTION
## What

Clear the destination `pt_regs` before copying the x86-64 register values exposed by Frida Gum.

`GumX64CpuContext` does not provide values for every field in bpftime's Linux-style `pt_regs` (`orig_ax`, `cs`, `flags`, and `ss`). The current call sites construct `pt_regs regs;` without initialization, so those fields can contain arbitrary stack bytes when passed to BPF programs.

This change makes unavailable fields deterministic while preserving all GPR values supplied by Gum.

## Test

Adds a regression test that pre-fills `pt_regs` with `0xa5`, performs the conversion, verifies representative GPRs are copied, and verifies the unavailable fields are cleared.