### PR TITLE
Resolve Frida map_files targets after VMA splitting

### DIFF
--- a/attach/frida_uprobe_attach_impl/include/frida_attach_utils.hpp
+++ b/attach/frida_uprobe_attach_impl/include/frida_attach_utils.hpp
@@ -1,5 +1,7 @@
 #ifndef _BPFTIME_FRIDA_ATTACH_UTILS_HPP
 #define _BPFTIME_FRIDA_ATTACH_UTILS_HPP
+#include <optional>
+#include <string>
 #include <string_view>
 #include <cstdint>
 namespace bpftime
@@ -11,6 +13,10 @@ namespace attach
 void *
 resolve_function_addr_by_module_offset(const std::string_view &module_name,
 				       uintptr_t func_offset);
+// Resolve /proc/<pid>/map_files/<start>-<end> to the underlying mapped path.
+// Other module names are returned unchanged.
+std::optional<std::string>
+resolve_mapped_module_path(const std::string_view &module_name);
 // Lookup a function address by its symbol name
 void *find_function_addr_by_name(const char *name);
 // Get the base address of a certain module

--- a/attach/frida_uprobe_attach_impl/src/frida_attach_private_data.cpp
+++ b/attach/frida_uprobe_attach_impl/src/frida_attach_private_data.cpp
@@ -4,6 +4,7 @@
 #include <spdlog/spdlog.h>
 #include <string>
 #include <string_view>
+#include <utility>
 using namespace bpftime::attach;
 
 int frida_attach_private_data::initialize_from_string(const std::string_view &sv)
@@ -25,10 +26,16 @@ int frida_attach_private_data::initialize_from_string(const std::string_view &sv
 		auto offset_part = std::string(sv.substr(pos + 1));
 		SPDLOG_DEBUG("Module part is `{}`, offset part is `{}`",
 			     module_part, offset_part);
+		auto resolved_module = resolve_mapped_module_path(module_part);
+		if (!resolved_module) {
+			SPDLOG_ERROR("Unable to resolve mapped module path `{}`",
+				     module_part);
+			return -ENOENT;
+		}
 		addr = (uintptr_t)resolve_function_addr_by_module_offset(
-			module_part, std::stoul(offset_part));
+			*resolved_module, std::stoul(offset_part));
 		SPDLOG_DEBUG("Resolved address: {:x} from string {}", addr, sv);
-		this->module_name = module_part;
+		this->module_name = std::move(*resolved_module);
 	}
 
 	return 0;

--- a/attach/frida_uprobe_attach_impl/src/frida_attach_utils.cpp
+++ b/attach/frida_uprobe_attach_impl/src/frida_attach_utils.cpp
@@ -1,8 +1,15 @@
 #include "frida_attach_utils.hpp"
 #include "frida_uprobe_attach_impl.hpp"
+#include <cstdio>
 #include <filesystem>
+#include <fstream>
+#include <optional>
 #include <spdlog/spdlog.h>
 #include <frida-gum.h>
+#include <sys/stat.h>
+#if __linux__
+#include <sys/sysmacros.h>
+#endif
 #include <unistd.h>
 #if __APPLE__
 #include <libproc.h>
@@ -34,6 +41,72 @@ namespace bpftime
 {
 namespace attach
 {
+namespace
+{
+std::string unescape_proc_path(std::string path)
+{
+	std::string result;
+	result.reserve(path.size());
+	for (size_t i = 0; i < path.size(); i++) {
+		if (path[i] == '\\' && i + 3 < path.size() &&
+		    path[i + 1] >= '0' && path[i + 1] <= '7' &&
+		    path[i + 2] >= '0' && path[i + 2] <= '7' &&
+		    path[i + 3] >= '0' && path[i + 3] <= '7') {
+			result.push_back((char)((path[i + 1] - '0') * 64 +
+					        (path[i + 2] - '0') * 8 +
+					        path[i + 3] - '0'));
+			i += 3;
+		} else {
+			result.push_back(path[i]);
+		}
+	}
+	return result;
+}
+} // namespace
+
+std::optional<std::string>
+resolve_mapped_module_path(const std::string_view &module_name)
+{
+#if __linux__
+	std::string name(module_name);
+	unsigned pid = 0;
+	unsigned long long wanted_start = 0, wanted_end = 0;
+	int consumed = 0;
+	if (sscanf(name.c_str(), "/proc/%u/map_files/%llx-%llx%n", &pid,
+		   &wanted_start, &wanted_end, &consumed) != 3 ||
+	    consumed != static_cast<int>(name.size()))
+		return name;
+	if ((pid_t)pid != getpid() || wanted_start >= wanted_end)
+		return {};
+
+	std::ifstream maps("/proc/self/maps");
+	std::string line;
+	while (std::getline(maps, line)) {
+		unsigned long long start, end, offset, inode;
+		unsigned dev_major, dev_minor;
+		char permissions[5] = {};
+		int path_offset = 0;
+		if (sscanf(line.c_str(),
+			   "%llx-%llx %4s %llx %x:%x %llu %n", &start, &end,
+			   permissions, &offset, &dev_major, &dev_minor, &inode,
+			   &path_offset) != 7 ||
+		    end <= wanted_start || start >= wanted_end)
+			continue;
+		std::string path = unescape_proc_path(line.substr(path_offset));
+		struct stat st = {};
+		if (path.empty() || path.front() != '/' ||
+		    path.ends_with(" (deleted)") || stat(path.c_str(), &st) != 0 ||
+		    (inode != 0 && st.st_ino != inode) ||
+		    major(st.st_dev) != dev_major || minor(st.st_dev) != dev_minor)
+			return {};
+		return path;
+	}
+	return {};
+#else
+	return std::string(module_name);
+#endif
+}
+
 void *
 resolve_function_addr_by_module_offset(const std::string_view &module_name,
 				       uintptr_t func_offset)

--- a/attach/frida_uprobe_attach_impl/test/test_function_address_resolve.cpp
+++ b/attach/frida_uprobe_attach_impl/test/test_function_address_resolve.cpp
@@ -3,6 +3,11 @@
 #include <catch2/catch_test_macros.hpp>
 #include <frida_uprobe_attach_impl.hpp>
 #include <cstdlib>
+#if defined(__linux__)
+#include <cstdio>
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
 using namespace bpftime::attach;
 
 extern "C" int __func_reolve_test(int a, int b)
@@ -26,3 +31,34 @@ TEST_CASE("Test external function resolve")
 	INFO("malloc addr resolved: " << (uintptr_t)addr);
 	REQUIRE(addr == (void *)&malloc);
 }
+
+#if defined(__linux__)
+TEST_CASE("Mapped module paths survive VMA splitting")
+{
+	char path[] = "/tmp/bpftime-map-files-XXXXXX";
+	const int fd = mkstemp(path);
+	REQUIRE(fd >= 0);
+	const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+	REQUIRE(page_size > 0);
+	REQUIRE(ftruncate(fd, page_size * 2) == 0);
+	void *mapping = mmap(nullptr, page_size * 2, PROT_READ, MAP_PRIVATE, fd, 0);
+	REQUIRE(mapping != MAP_FAILED);
+
+	// Split the original file mapping into two VMAs. Callers may still carry a
+	// map_files range describing the pre-split mapping.
+	REQUIRE(mprotect(static_cast<char *>(mapping) + page_size, page_size,
+			 PROT_NONE) == 0);
+
+	char module_name[128];
+	snprintf(module_name, sizeof(module_name), "/proc/%d/map_files/%lx-%lx",
+		 getpid(), reinterpret_cast<uintptr_t>(mapping),
+		 reinterpret_cast<uintptr_t>(mapping) + page_size * 2);
+	const auto resolved = resolve_mapped_module_path(module_name);
+
+	REQUIRE(munmap(mapping, page_size * 2) == 0);
+	REQUIRE(close(fd) == 0);
+	REQUIRE(unlink(path) == 0);
+	REQUIRE(resolved.has_value());
+	REQUIRE(*resolved == path);
+}
+#endif


### PR DESCRIPTION
## What

Resolve `/proc/<pid>/map_files/<start>-<end>` attach targets to their underlying mapped file before asking Frida for a module base address.

A file mapping can be split into multiple VMAs after operations such as `mprotect()`. In that case a previously captured `map_files` range may no longer exist as an exact procfs entry even though the underlying module is still mapped. Passing the synthetic procfs path to Frida then fails module lookup.

For current-process `map_files` targets, this change:

- finds an overlapping entry in `/proc/self/maps`;
- unescapes procfs path escapes;
- verifies inode and device identity against `stat()`;
- rejects deleted/non-file mappings;
- stores and resolves the real mapped path.

Non-`map_files` module names are unchanged.

## Test

Adds a Linux regression test that maps a two-page temporary file, splits the mapping with `mprotect()`, then verifies that a range spanning the original mapping still resolves to the backing file.