### PR TITLE
Fix fixed-hash map iteration over adjusted buckets

### DIFF
--- a/runtime/src/bpf_map/userspace/fix_hash_map.cpp
+++ b/runtime/src/bpf_map/userspace/fix_hash_map.cpp
@@ -19,7 +19,7 @@ fix_size_hash_map_impl::fix_size_hash_map_impl(managed_shared_memory &memory,
 					       size_t value_size)
 	: map_impl(memory, num_buckets, key_size, value_size),
 	  _key_size(key_size), _value_size(value_size),
-	  _num_buckets(num_buckets)
+	  _num_buckets(bpftime_hasher::next_prime(num_buckets))
 {
 }
 

--- a/runtime/unit-test/CMakeLists.txt
+++ b/runtime/unit-test/CMakeLists.txt
@@ -19,6 +19,7 @@ set(TEST_SOURCES
     maps/test_shm_hash_maps.cpp
     maps/test_external_map_ops.cpp
     maps/test_bpftime_hash_map.cpp
+    maps/test_fix_hash_map.cpp
     maps/kernel_unit_tests.cpp
     maps/test_stack_trace_map.cpp
     maps/test_queue_map.cpp

--- a/runtime/unit-test/maps/test_fix_hash_map.cpp
+++ b/runtime/unit-test/maps/test_fix_hash_map.cpp
@@ -1,0 +1,53 @@
+#include <bpf_map/bpftime_hash_map.hpp>
+#include <bpf_map/userspace/fix_hash_map.hpp>
+#include <boost/interprocess/managed_shared_memory.hpp>
+#include <boost/interprocess/shared_memory_object.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <cstdint>
+
+using namespace boost::interprocess;
+using namespace bpftime;
+
+namespace
+{
+struct shm_cleanup {
+	explicit shm_cleanup(const char *name) : name(name)
+	{
+		shared_memory_object::remove(name);
+	}
+	~shm_cleanup()
+	{
+		shared_memory_object::remove(name);
+	}
+	const char *name;
+};
+} // namespace
+
+TEST_CASE("Fixed hash iteration scans adjusted bucket count",
+	  "[maps][hash][iteration]")
+{
+	static const char *shm_name = "bpftime_fix_hash_iteration_test";
+	shm_cleanup cleanup(shm_name);
+	managed_shared_memory segment(create_only, shm_name, 65536);
+
+	constexpr size_t requested_buckets = 10;
+	const size_t actual_buckets =
+		bpftime_hasher::next_prime(requested_buckets);
+	REQUIRE(actual_buckets > requested_buckets);
+
+	fix_size_hash_map_impl map(segment, requested_buckets, sizeof(uint32_t),
+				   sizeof(uint64_t));
+
+	uint32_t key = 0;
+	for (;; ++key) {
+		if (bpftime_hasher::hash_func(&key, sizeof(key)) % actual_buckets ==
+		    actual_buckets - 1)
+			break;
+	}
+	uint64_t value = 0x123456789abcdef0ULL;
+	REQUIRE(map.elem_update(&key, &value, 0) == 0);
+
+	uint32_t next_key = 0;
+	REQUIRE(map.map_get_next_key(nullptr, &next_key) == 0);
+	REQUIRE(next_key == key);
+}


### PR DESCRIPTION
## What

Make `fix_size_hash_map_impl::map_get_next_key()` scan the same bucket count that its underlying `bpftime_hash_map` actually allocates.

`bpftime_hash_map` rounds the requested bucket count up to the next prime. `fix_size_hash_map_impl` previously kept the original requested count, so keys placed in one of the extra adjusted buckets were reachable by lookup but invisible to `bpf_map_get_next_key()` iteration.

This change stores the same `next_prime(num_buckets)` count used by the underlying map.

## Test

Adds a regression test with 10 requested buckets (11 actual buckets), deliberately finds a key hashing to bucket 10, inserts it, and verifies iteration can return it.