### PR TITLE
Avoid null dereference on invalid array-of-maps lookup

### DIFF
--- a/runtime/src/bpf_map/userspace/map_in_maps.hpp
+++ b/runtime/src/bpf_map/userspace/map_in_maps.hpp
@@ -21,10 +21,11 @@ class array_map_of_maps_impl : public array_map_impl {
 		: array_map_impl(memory, sizeof(int), max_entries)
 	{
 	}
-	// TODO: add verify the correctness of the key
 	void *elem_lookup(const void *key)
 	{
 		auto key_val = array_map_impl::elem_lookup(key);
+		if (key_val == nullptr)
+			return nullptr;
 		int map_id = *(int *)key_val;
 		return (void *)((u_int64_t)map_id);
 	}

--- a/runtime/unit-test/CMakeLists.txt
+++ b/runtime/unit-test/CMakeLists.txt
@@ -19,6 +19,7 @@ set(TEST_SOURCES
     maps/test_shm_hash_maps.cpp
     maps/test_external_map_ops.cpp
     maps/test_bpftime_hash_map.cpp
+    maps/test_map_in_map_bounds.cpp
     maps/kernel_unit_tests.cpp
     maps/test_stack_trace_map.cpp
     maps/test_queue_map.cpp

--- a/runtime/unit-test/maps/test_map_in_map_bounds.cpp
+++ b/runtime/unit-test/maps/test_map_in_map_bounds.cpp
@@ -1,0 +1,38 @@
+#include <bpf_map/userspace/map_in_maps.hpp>
+#include <boost/interprocess/managed_shared_memory.hpp>
+#include <boost/interprocess/shared_memory_object.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <cerrno>
+#include <cstdint>
+
+using namespace boost::interprocess;
+using namespace bpftime;
+
+namespace
+{
+struct shm_cleanup {
+	explicit shm_cleanup(const char *name) : name(name)
+	{
+		shared_memory_object::remove(name);
+	}
+	~shm_cleanup()
+	{
+		shared_memory_object::remove(name);
+	}
+	const char *name;
+};
+} // namespace
+
+TEST_CASE("Array-of-maps rejects out-of-range lookup keys",
+	  "[maps][map_in_map]")
+{
+	static const char *shm_name = "bpftime_map_in_map_bounds_test";
+	shm_cleanup cleanup(shm_name);
+	managed_shared_memory segment(create_only, shm_name, 65536);
+	array_map_of_maps_impl map(segment, 2);
+
+	uint32_t invalid_key = 2;
+	errno = 0;
+	REQUIRE(map.elem_lookup(&invalid_key) == nullptr);
+	REQUIRE(errno == ENOENT);
+}


### PR DESCRIPTION
## What

Propagate a failed underlying array lookup from `array_map_of_maps_impl::elem_lookup()` instead of dereferencing the null result.

For an out-of-range key, `array_map_impl::elem_lookup()` returns `nullptr` and sets `errno = ENOENT`. The array-of-maps wrapper previously dereferenced that pointer unconditionally, turning a normal failed BPF map lookup into a process crash.

This is a small independent correctness fix toward #653; it intentionally does not change the larger map-in-map helper/syscall representation yet.

## Test

Adds a regression test that looks up key `max_entries` in a two-entry array-of-maps and verifies the result is `nullptr` with `ENOENT`. The old implementation crashes on this case.