### PR TITLE
Add shared agent skills bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ example/attach_implementation/benchmark/wasm-micro-runtime/
 
 build
 target
+/.agents/skills/

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "vm/llvm-jit"]
 	path = vm/llvm-jit
 	url = https://github.com/eunomia-bpf/llvmbpf
+[submodule ".agents/sources/agent-skills"]
+	path = .agents/sources/agent-skills
+	url = https://github.com/eunomia-bpf/agent-skills.git

--- a/scripts/sync-agent-skills.ps1
+++ b/scripts/sync-agent-skills.ps1
@@ -1,0 +1,12 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = [IO.Path]::GetFullPath((Join-Path $PSScriptRoot '..'))
+$submodulePath = '.agents/sources/agent-skills'
+
+git -C $repoRoot submodule update --init -- $submodulePath
+if ($LASTEXITCODE -ne 0) { throw 'Failed to initialize agent-skills.' }
+
+& (Join-Path $repoRoot "$submodulePath/scripts/link-skills.ps1") `
+    -TargetDirectory (Join-Path $repoRoot '.agents/skills')

--- a/scripts/sync-agent-skills.sh
+++ b/scripts/sync-agent-skills.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+submodule_path='.agents/sources/agent-skills'
+
+git -C "$repo_root" submodule update --init -- "$submodule_path"
+"$repo_root/$submodule_path/scripts/link-skills.sh" "$repo_root/.agents/skills"


### PR DESCRIPTION
## Summary

- pin `eunomia-bpf/agent-skills` under `.agents/sources`
- add small PowerShell and Bash sync entrypoints
- keep generated `.agents/skills` links out of Git

## Validation

- PowerShell sync linked 7/7 readable skills
- Bash script passed syntax validation
- `git diff --check` passed

## Scope

No product code or existing repository-specific skills are changed.