### PR TITLE
feat: QNX 8.0 aarch64 phase-1 port skeleton (process hook)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,10 @@ endif()
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-omit-frame-pointer")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer")
 set(CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} -fno-omit-frame-pointer")
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lncurses")
+# ncurses is unavailable on typical QNX SDP installs; skip for QNX builds
+if(NOT BPFTIME_TARGET_QNX AND NOT CMAKE_SYSTEM_NAME STREQUAL "QNX")
+  set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -lncurses")
+endif()
 add_definitions(-DLLVM_DISABLE_ABI_BREAKING_CHECKS_ENFORCING=1)
 
 # set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
@@ -125,8 +128,12 @@ if(${BPFTIME_BUILD_WITH_LIBBPF})
   include(cmake/libbpf.cmake)
 endif()
 
-# install frida
-include(cmake/frida.cmake)
+# Frida: official prebuilt for Linux/macOS; QNX requires a local build
+if(BPFTIME_TARGET_QNX OR CMAKE_SYSTEM_NAME STREQUAL "QNX")
+  include(cmake/frida-qnx.cmake)
+else()
+  include(cmake/frida.cmake)
+endif()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE YES)
 
@@ -250,9 +257,8 @@ if(${BUILD_ATTACH_IMPL_EXAMPLE})
   add_subdirectory(example/attach_implementation)
 endif()
 
-# benchmark that requires bpftime libraries
-if(${BPFTIME_BUILD_WITH_LIBBPF})
-  # Currently benchmark is using libbpf
+# benchmark that requires bpftime libraries (Linux + libbpf only)
+if(${BPFTIME_BUILD_WITH_LIBBPF} AND NOT BPFTIME_TARGET_QNX)
   add_subdirectory(benchmark)
 endif()
 
@@ -260,7 +266,10 @@ set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
 
 set(DEST_DIR "$ENV{HOME}/.bpftime")
 
-if(${BPFTIME_BUILD_WITH_LIBBPF})
+if(BPFTIME_TARGET_QNX)
+  # Phase-1 QNX: agent + CLI only (no syscall-server / text transformer)
+  install(TARGETS bpftime-agent CONFIGURATIONS Release Debug RelWithDebInfo DESTINATION ${DEST_DIR})
+elseif(${BPFTIME_BUILD_WITH_LIBBPF})
   install(TARGETS bpftime-agent bpftime_text_segment_transformer bpftime-syscall-server CONFIGURATIONS Release Debug RelWithDebInfo DESTINATION ${DEST_DIR})
 else()
   install(TARGETS bpftime-agent bpftime-syscall-server CONFIGURATIONS Release Debug RelWithDebInfo DESTINATION ${DEST_DIR})

--- a/attach/CMakeLists.txt
+++ b/attach/CMakeLists.txt
@@ -1,12 +1,13 @@
 add_subdirectory(base_attach_impl)
 add_subdirectory(frida_uprobe_attach_impl)
 add_subdirectory(simple_attach_impl)
-if(UNIX AND NOT APPLE)
+
+# Linux-only attach backends (syscall rewrite / CUDA). QNX phase-1 is uprobe only.
+if(UNIX AND NOT APPLE AND NOT BPFTIME_TARGET_QNX)
   add_subdirectory(syscall_trace_attach_impl)
   add_subdirectory(text_segment_transformer)
 
   if(${BPFTIME_ENABLE_CUDA_ATTACH})
     add_subdirectory(nv_attach_impl)
   endif()
-  
 endif()

--- a/attach/frida_uprobe_attach_impl/CMakeLists.txt
+++ b/attach/frida_uprobe_attach_impl/CMakeLists.txt
@@ -16,6 +16,10 @@ target_include_directories(bpftime_frida_uprobe_attach_impl PRIVATE ${SPDLOG_INC
 
 target_link_libraries(bpftime_frida_uprobe_attach_impl PRIVATE ${FRIDA_GUM_INSTALL_DIR}/libfrida-gum.a PUBLIC bpftime_base_attach_impl spdlog::spdlog dl)
 
+option(TEST_LCOV "option for lcov" OFF)
+
+# Unit tests require Catch2 and a host-runnable binary; skip on QNX cross-builds
+if(NOT BPFTIME_TARGET_QNX)
 set(TEST_SOURCES
     test/test_uprobe_uretprobe.cpp
     test/test_function_address_resolve.cpp
@@ -26,7 +30,6 @@ set(TEST_SOURCES
     test/test_base_attach_impl.cpp
     test/test_back_trace.cpp
 )
-option(TEST_LCOV "option for lcov" OFF)
 add_executable(bpftime_frida_uprobe_attach_tests ${TEST_SOURCES})
 
 if (${TEST_LCOV}) 
@@ -58,3 +61,6 @@ target_include_directories(bpftime_frida_uprobe_attach_tests PRIVATE ${FRIDA_UPR
 add_test(NAME bpftime_frida_uprobe_attach_tests COMMAND bpftime_frida_uprobe_attach_tests)
 
 set_property(TARGET bpftime_frida_uprobe_attach_tests bpftime_frida_uprobe_attach_impl PROPERTY CXX_STANDARD 20)
+else()
+set_property(TARGET bpftime_frida_uprobe_attach_impl PROPERTY CXX_STANDARD 20)
+endif()

--- a/attach/frida_uprobe_attach_impl/src/frida_attach_utils.cpp
+++ b/attach/frida_uprobe_attach_impl/src/frida_attach_utils.cpp
@@ -6,6 +6,9 @@
 #include <unistd.h>
 #if __APPLE__
 #include <libproc.h>
+#elif defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
+#include <fcntl.h>
+#include <limits.h>
 #endif
 static std::string get_executable_path()
 {
@@ -19,6 +22,23 @@ static std::string get_executable_path()
 		SPDLOG_INFO("Executable path: {}", exec_path);
 	} else {
 		SPDLOG_ERROR("Error retrieving executable path: {}", errno);
+	}
+#elif defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
+	// QNX Neutrino exposes the process image via /proc/<pid>/exefile
+	char link_path[64];
+	snprintf(link_path, sizeof(link_path), "/proc/%d/exefile", getpid());
+	int fd = open(link_path, O_RDONLY);
+	if (fd >= 0) {
+		ssize_t n = read(fd, exec_path, sizeof(exec_path) - 1);
+		close(fd);
+		if (n > 0) {
+			exec_path[n] = '\0';
+			SPDLOG_INFO("Executable path: {}", exec_path);
+		} else {
+			SPDLOG_ERROR("Error reading {}: {}", link_path, errno);
+		}
+	} else {
+		SPDLOG_ERROR("Error opening {}: {}", link_path, errno);
 	}
 #elif __APPLE__
 	pid_t pid = getpid();

--- a/cmake/PlatformQNX.cmake
+++ b/cmake/PlatformQNX.cmake
@@ -1,0 +1,43 @@
+# Platform defaults when targeting QNX (Neutrino 8.0+)
+#
+# Included from cmake/StandardSettings.cmake when BPFTIME_TARGET_QNX=ON
+# or when CMAKE_SYSTEM_NAME is QNX.
+
+if(NOT BPFTIME_TARGET_QNX AND CMAKE_SYSTEM_NAME STREQUAL "QNX")
+  set(BPFTIME_TARGET_QNX ON CACHE BOOL "Build for QNX Neutrino" FORCE)
+endif()
+
+if(NOT BPFTIME_TARGET_QNX)
+  return()
+endif()
+
+message(STATUS "Applying QNX platform defaults (phase-1: process hook / uprobe)")
+
+# Phase-1: userspace VM + Frida uprobe only
+set(BPFTIME_BUILD_WITH_LIBBPF OFF CACHE BOOL "libbpf not available on QNX" FORCE)
+set(BPFTIME_BUILD_KERNEL_BPF OFF CACHE BOOL "No kernel eBPF on QNX" FORCE)
+set(BUILD_BPFTIME_DAEMON OFF CACHE BOOL "Daemon requires Linux eBPF" FORCE)
+set(BPFTIME_ENABLE_CUDA_ATTACH OFF CACHE BOOL "No CUDA attach on QNX" FORCE)
+set(BPFTIME_ENABLE_IOURING_EXT OFF CACHE BOOL "io_uring is Linux-only" FORCE)
+set(BPFTIME_ENABLE_UNIT_TESTING OFF CACHE BOOL "Disable host unit tests for QNX cross-build" FORCE)
+set(BPFTIME_BUILD_STATIC_LIB OFF CACHE BOOL "Static archive packing uses Linux ar scripts" FORCE)
+set(ENABLE_EBPF_VERIFIER OFF CACHE BOOL "Verifier not in phase-1 QNX scope" FORCE)
+set(BUILD_ATTACH_IMPL_EXAMPLE OFF CACHE BOOL "" FORCE)
+
+# Prefer uBPF JIT for phase-1 to avoid LLVM cross-compile; enable LLVM later.
+if(NOT DEFINED BPFTIME_QNX_FORCE_LLVM)
+  set(BPFTIME_LLVM_JIT OFF CACHE BOOL "Disable LLVM JIT for QNX phase-1 (set BPFTIME_QNX_FORCE_LLVM=ON to override)" FORCE)
+  set(BPFTIME_UBPF_JIT ON CACHE BOOL "Use uBPF JIT on QNX phase-1" FORCE)
+endif()
+
+add_compile_definitions(BPFTIME_TARGET_QNX=1)
+# Some code paths check __QNX__; qcc usually defines it, reinforce for other compilers.
+add_compile_definitions(__QNX__=1)
+
+# QNX typically has no ncurses; avoid unconditional link from root CMakeLists.
+set(BPFTIME_QNX_SKIP_NCURSES ON CACHE BOOL "" FORCE)
+
+message(STATUS "  BPFTIME_BUILD_WITH_LIBBPF=${BPFTIME_BUILD_WITH_LIBBPF}")
+message(STATUS "  BUILD_BPFTIME_DAEMON=${BUILD_BPFTIME_DAEMON}")
+message(STATUS "  BPFTIME_LLVM_JIT=${BPFTIME_LLVM_JIT}")
+message(STATUS "  BPFTIME_UBPF_JIT=${BPFTIME_UBPF_JIT}")

--- a/cmake/StandardSettings.cmake
+++ b/cmake/StandardSettings.cmake
@@ -5,6 +5,13 @@
 option(BPFTIME_BUILD_EXECUTABLE "Build the project as an executable, rather than a library." OFF)
 
 #
+# Platform: QNX Neutrino (phase-1 userspace uprobe port)
+#
+option(BPFTIME_TARGET_QNX "Build bpftime for QNX Neutrino (userspace VM + Frida uprobe)" OFF)
+# Apply QNX defaults early so later options inherit forced values
+include(${CMAKE_CURRENT_LIST_DIR}/PlatformQNX.cmake)
+
+#
 # library options
 #
 option(BPFTIME_LLVM_JIT "Use LLVM as jit backend." ON)

--- a/cmake/frida-qnx.cmake
+++ b/cmake/frida-qnx.cmake
@@ -1,0 +1,39 @@
+# Frida Gum / Core for QNX — official GitHub releases do NOT ship qnx-arm64
+# prebuilt devkits. Point BPFTIME_FRIDA_QNX_ROOT at a locally built tree:
+#
+#   ${BPFTIME_FRIDA_QNX_ROOT}/
+#     gum/libfrida-gum.a
+#     gum/frida-gum.h          (and related headers)
+#     core/libfrida-core.a
+#     core/frida-core.h
+#
+# Build Frida for QNX (on Linux host with QNX SDP), e.g.:
+#   make -f Makefile.linux.mk FRIDA_HOST=qnx-arm64
+# See: https://github.com/frida/frida/issues/25
+
+set(BPFTIME_FRIDA_QNX_ROOT "" CACHE PATH
+  "Root of self-built Frida for QNX aarch64 (gum/ + core/ subdirs)")
+
+if(NOT BPFTIME_FRIDA_QNX_ROOT)
+  message(FATAL_ERROR
+    "BPFTIME_FRIDA_QNX_ROOT is required when BPFTIME_TARGET_QNX=ON.\n"
+    "Build Frida with FRIDA_HOST=qnx-arm64 and set this path to the output tree.")
+endif()
+
+set(FRIDA_GUM_INSTALL_DIR "${BPFTIME_FRIDA_QNX_ROOT}/gum")
+set(FRIDA_CORE_INSTALL_DIR "${BPFTIME_FRIDA_QNX_ROOT}/core")
+
+if(NOT EXISTS "${FRIDA_GUM_INSTALL_DIR}/libfrida-gum.a")
+  message(FATAL_ERROR "Missing ${FRIDA_GUM_INSTALL_DIR}/libfrida-gum.a")
+endif()
+if(NOT EXISTS "${FRIDA_CORE_INSTALL_DIR}/libfrida-core.a")
+  message(FATAL_ERROR "Missing ${FRIDA_CORE_INSTALL_DIR}/libfrida-core.a")
+endif()
+
+# Keep ExternalProject target names so existing add_dependencies(... FridaGum)
+# and add_dependencies(... FridaCore) continue to work.
+add_custom_target(FridaGum)
+add_custom_target(FridaCore)
+
+message(STATUS "Frida QNX gum:  ${FRIDA_GUM_INSTALL_DIR}")
+message(STATUS "Frida QNX core: ${FRIDA_CORE_INSTALL_DIR}")

--- a/cmake/qnx8-aarch64-toolchain.cmake
+++ b/cmake/qnx8-aarch64-toolchain.cmake
@@ -1,0 +1,54 @@
+# QNX Software Development Platform 8.0 — aarch64 (little-endian) cross toolchain
+#
+# Usage:
+#   source /path/to/qnxsdp-env.sh   # sets QNX_HOST / QNX_TARGET
+#   cmake -B build-qnx \
+#     -DCMAKE_TOOLCHAIN_FILE=cmake/qnx8-aarch64-toolchain.cmake \
+#     -DBPFTIME_TARGET_QNX=ON ...
+#
+# Expected environment:
+#   QNX_HOST   – host tools (qcc, q++, ntoaarch64-ar, ...)
+#   QNX_TARGET – target sysroot for aarch64le
+
+if(NOT DEFINED ENV{QNX_HOST} OR NOT DEFINED ENV{QNX_TARGET})
+  message(FATAL_ERROR
+    "QNX_HOST and QNX_TARGET must be set. Source the QNX SDP 8.0 environment script first.")
+endif()
+
+set(QNX_HOST "$ENV{QNX_HOST}")
+set(QNX_TARGET "$ENV{QNX_TARGET}")
+
+set(CMAKE_SYSTEM_NAME QNX)
+set(CMAKE_SYSTEM_VERSION 8.0)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+
+set(CMAKE_C_COMPILER "${QNX_HOST}/usr/bin/qcc" CACHE FILEPATH "" FORCE)
+set(CMAKE_CXX_COMPILER "${QNX_HOST}/usr/bin/q++" CACHE FILEPATH "" FORCE)
+set(CMAKE_AR "${QNX_HOST}/usr/bin/ntoaarch64-ar" CACHE FILEPATH "" FORCE)
+set(CMAKE_RANLIB "${QNX_HOST}/usr/bin/ntoaarch64-ranlib" CACHE FILEPATH "" FORCE)
+set(CMAKE_STRIP "${QNX_HOST}/usr/bin/ntoaarch64-strip" CACHE FILEPATH "" FORCE)
+set(CMAKE_NM "${QNX_HOST}/usr/bin/ntoaarch64-nm" CACHE FILEPATH "" FORCE)
+
+# QNX qcc/q++ architecture selector for aarch64 little-endian
+set(QNX_ARCH_FLAG "-Vgcc_ntoaarch64le")
+set(CMAKE_C_FLAGS_INIT "${QNX_ARCH_FLAG}")
+set(CMAKE_CXX_FLAGS_INIT "${QNX_ARCH_FLAG} -lang-c++")
+set(CMAKE_EXE_LINKER_FLAGS_INIT "${QNX_ARCH_FLAG}")
+set(CMAKE_SHARED_LINKER_FLAGS_INIT "${QNX_ARCH_FLAG}")
+
+set(CMAKE_FIND_ROOT_PATH "${QNX_TARGET}")
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+# Shared libraries use .so on QNX
+set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
+set(CMAKE_SHARED_LIBRARY_PREFIX "lib")
+
+# Mark that we are cross-compiling for QNX
+set(BPFTIME_CROSS_COMPILING_QNX TRUE CACHE BOOL "Building for QNX via this toolchain" FORCE)
+
+message(STATUS "QNX toolchain: HOST=${QNX_HOST}")
+message(STATUS "QNX toolchain: TARGET=${QNX_TARGET}")
+message(STATUS "QNX toolchain: arch=aarch64le (qcc ${QNX_ARCH_FLAG})")

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -102,7 +102,7 @@ if(${BPFTIME_ENABLE_CUDA_ATTACH})
   list(APPEND sources src/bpf_map/gpu/nv_gpu_shared_array_host_map.cpp)
 endif()
 
-if(UNIX AND NOT APPLE AND BPFTIME_BUILD_WITH_LIBBPF)
+if(UNIX AND NOT APPLE AND BPFTIME_BUILD_WITH_LIBBPF AND NOT BPFTIME_TARGET_QNX)
   list(APPEND sources
     src/bpf_map/shared/array_map_kernel_user.cpp
     src/bpf_map/shared/hash_map_kernel_user.cpp
@@ -130,15 +130,19 @@ endif()
 if(${BPFTIME_UBPF_JIT})
   target_compile_definitions(${PROJECT_NAME} PUBLIC BPFTIME_UBPF_JIT=1)
 endif()
-add_custom_command(
-  OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/syscall_id_list.h
-  COMMAND /bin/bash ${CMAKE_CURRENT_SOURCE_DIR}/generate_syscall_id_table.sh "${CMAKE_CURRENT_BINARY_DIR}/syscall_id_list.h"
-  USES_TERMINAL
-)
-add_custom_target(
-  syscall_id_table
-  DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/syscall_id_list.h
-)
+# Syscall id table generation requires Linux headers + host bash cpp.
+# Skip on QNX (syscall_trace_attach_impl is not built for QNX phase-1).
+if(NOT BPFTIME_TARGET_QNX)
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/syscall_id_list.h
+    COMMAND /bin/bash ${CMAKE_CURRENT_SOURCE_DIR}/generate_syscall_id_table.sh "${CMAKE_CURRENT_BINARY_DIR}/syscall_id_list.h"
+    USES_TERMINAL
+  )
+  add_custom_target(
+    syscall_id_table
+    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/syscall_id_list.h
+  )
+endif()
 
 message(INFO " Found the following boost include dirs : ${Boost_INCLUDE_DIRS}")
 
@@ -286,7 +290,11 @@ if(BPFTIME_BUILD_WITH_LIBBPF)
 endif()
 
 add_subdirectory(agent)
-add_subdirectory(syscall-server)
+
+# syscall-server simulates Linux bpf()/perf_event_open — not part of QNX phase-1
+if(NOT BPFTIME_TARGET_QNX)
+  add_subdirectory(syscall-server)
+endif()
 
 #
 # Unit testing setup

--- a/runtime/agent/CMakeLists.txt
+++ b/runtime/agent/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 
 set_target_properties(bpftime-agent PROPERTIES CXX_STANDARD 20 LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/agent.version)
 
-if(UNIX AND NOT APPLE)
+if(UNIX AND NOT APPLE AND NOT BPFTIME_TARGET_QNX)
   target_link_options(bpftime-agent PRIVATE -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/agent.version)
 endif()
 
@@ -23,13 +23,17 @@ endif()
 # Force link VM compat libraries so constructor-based factory registration is retained
 if(${BPFTIME_UBPF_JIT})
   add_dependencies(bpftime-agent bpftime_ubpf_vm)
-  target_link_options(bpftime-agent PUBLIC "-Wl,--whole-archive" "$<TARGET_FILE:bpftime_ubpf_vm>" "-Wl,--no-whole-archive")
+  if(NOT BPFTIME_TARGET_QNX)
+    target_link_options(bpftime-agent PUBLIC "-Wl,--whole-archive" "$<TARGET_FILE:bpftime_ubpf_vm>" "-Wl,--no-whole-archive")
+  endif()
   target_link_libraries(bpftime-agent PUBLIC bpftime_ubpf_vm)
 endif()
 
 if(${BPFTIME_LLVM_JIT})
   add_dependencies(bpftime-agent bpftime_llvm_vm llvmbpf_vm)
-  target_link_options(bpftime-agent PUBLIC "-Wl,--whole-archive" "$<TARGET_FILE:bpftime_llvm_vm>" "-Wl,--no-whole-archive")
+  if(NOT BPFTIME_TARGET_QNX)
+    target_link_options(bpftime-agent PUBLIC "-Wl,--whole-archive" "$<TARGET_FILE:bpftime_llvm_vm>" "-Wl,--no-whole-archive")
+  endif()
   target_link_libraries(bpftime-agent PUBLIC bpftime_llvm_vm)
   # Statically embed the compat_llvm constructor TU to guarantee VM factory registration in LD_PRELOAD context
   target_sources(bpftime-agent PRIVATE $<TARGET_OBJECTS:bpftime_llvm_vm_obj>)
@@ -91,4 +95,6 @@ else()
     ${EXTRA_LINK_LIBS}
   )
 endif()
-target_link_options(bpftime-agent PUBLIC "-Wl,-export-dynamic")
+if(NOT BPFTIME_TARGET_QNX)
+  target_link_options(bpftime-agent PUBLIC "-Wl,-export-dynamic")
+endif()

--- a/runtime/agent/agent.cpp
+++ b/runtime/agent/agent.cpp
@@ -88,6 +88,9 @@ extern "C" int bpftime_hooked_main(int argc, char **argv, char **envp)
 	return ret;
 }
 
+// LD_PRELOAD / __libc_start_main interception is a glibc/Linux (and some
+// Apple) pattern. On QNX phase-1 we rely on Frida inject only.
+#if !defined(__QNX__) && !defined(BPFTIME_TARGET_QNX)
 extern "C" int __libc_start_main(int (*main)(int, char **, char **), int argc,
 				 char **argv,
 				 int (*init)(int, char **, char **),
@@ -101,6 +104,7 @@ extern "C" int __libc_start_main(int (*main)(int, char **, char **), int argc,
 	return orig(bpftime_hooked_main, argc, argv, init, fini, rtld_fini,
 		    stack_end);
 }
+#endif
 static void sig_handler_sigusr1_detach(int sig)
 {
 	SPDLOG_INFO("Detaching..");

--- a/runtime/include/bpftime_qnx_compat.h
+++ b/runtime/include/bpftime_qnx_compat.h
@@ -1,0 +1,31 @@
+#ifndef BPFTIME_QNX_COMPAT_H
+#define BPFTIME_QNX_COMPAT_H
+
+/*
+ * QNX Neutrino compatibility notes for bpftime phase-1 (process hook).
+ *
+ * This header is intentionally lightweight. Prefer using:
+ *   #if defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
+ * in call sites (same pattern as __APPLE__).
+ *
+ * Phase-1 assumptions:
+ *  - No libbpf / kernel eBPF / syscall-server
+ *  - epoll & bpf UAPI types come from runtime/include/bpftime_epoll.h
+ *  - Injection via Frida-core only (no LD_PRELOAD / __libc_start_main)
+ *  - JIT backend: uBPF
+ */
+
+#if defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
+
+#ifndef BPFTIME_ON_QNX
+#define BPFTIME_ON_QNX 1
+#endif
+
+/* CLOCK_MONOTONIC_COARSE is Linux-specific; helpers use CLOCK_MONOTONIC. */
+#ifndef CLOCK_MONOTONIC_COARSE
+#define CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC
+#endif
+
+#endif /* __QNX__ || BPFTIME_TARGET_QNX */
+
+#endif /* BPFTIME_QNX_COMPAT_H */

--- a/runtime/include/bpftime_shm.hpp
+++ b/runtime/include/bpftime_shm.hpp
@@ -13,7 +13,7 @@
 #include <functional>
 #if __linux__
 #include <sys/epoll.h>
-#elif __APPLE__
+#elif defined(__APPLE__) || defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
 #include "bpftime_epoll.h"
 #endif
 

--- a/runtime/include/platform_utils.hpp
+++ b/runtime/include/platform_utils.hpp
@@ -5,27 +5,53 @@
 
 #if __linux__
 #include <sched.h>
+#elif defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
+#include <sys/neutrino.h>
+#include <sys/syspage.h>
+#include <pthread.h>
+typedef int cpu_set_t;
+
+inline void CPU_ZERO(cpu_set_t *set)
+{
+	*set = 0;
+}
+
+inline void CPU_SET(int cpu, cpu_set_t *set)
+{
+	*set |= (1 << cpu);
+}
+
+inline int CPU_ISSET(int cpu, const cpu_set_t *set)
+{
+	return (*set & (1 << cpu)) != 0;
+}
+
+int sched_getaffinity(pid_t pid, size_t cpusetsize, cpu_set_t *mask);
+int sched_setaffinity(pid_t pid, size_t cpusetsize, const cpu_set_t *mask);
 #elif __APPLE__
 #include <sys/sysctl.h>
 #include <pthread.h>
-    typedef int cpu_set_t;
+typedef int cpu_set_t;
 
-    inline void CPU_ZERO(cpu_set_t *set) {
-        *set = 0;
-    }
+inline void CPU_ZERO(cpu_set_t *set)
+{
+	*set = 0;
+}
 
-    inline void CPU_SET(int cpu, cpu_set_t *set) {
-        *set |= (1 << cpu);
-    }
+inline void CPU_SET(int cpu, cpu_set_t *set)
+{
+	*set |= (1 << cpu);
+}
 
-    inline int CPU_ISSET(int cpu, const cpu_set_t *set) {
-        return (*set & (1 << cpu)) != 0;
-    }
-    int sched_getaffinity(pid_t pid, size_t cpusetsize, cpu_set_t *mask);
-    int sched_setaffinity(pid_t pid, size_t cpusetsize, const cpu_set_t *mask);
+inline int CPU_ISSET(int cpu, const cpu_set_t *set)
+{
+	return (*set & (1 << cpu)) != 0;
+}
+int sched_getaffinity(pid_t pid, size_t cpusetsize, cpu_set_t *mask);
+int sched_setaffinity(pid_t pid, size_t cpusetsize, const cpu_set_t *mask);
 #else
-    #error "Unsupported platform"
+#error "Unsupported platform"
 #endif
 
-int my_sched_getcpu(); 
+int my_sched_getcpu();
 #endif

--- a/runtime/object/bpf_object.cpp
+++ b/runtime/object/bpf_object.cpp
@@ -1,6 +1,6 @@
 #if __linux__
 #include <linux/bpf.h>
-#elif __APPLE__
+#elif defined(__APPLE__) || defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
 #include "bpftime_epoll.h"
 #endif
 #include <string>
@@ -11,7 +11,7 @@
 #include <spdlog/spdlog.h>
 using namespace std;
 using namespace bpftime;
-#if __APPLE__
+#if defined(__APPLE__) || defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
 using namespace bpftime_epoll;
 #endif
 

--- a/runtime/src/attach/bpf_attach_ctx.cpp
+++ b/runtime/src/attach/bpf_attach_ctx.cpp
@@ -19,7 +19,9 @@
 #include <cstdint>
 #include <map>
 #include <memory>
+#if !defined(__QNX__) && !defined(BPFTIME_TARGET_QNX)
 #include <syscall_table.hpp>
+#endif
 #include <bpf_attach_ctx.hpp>
 #include <bpftime_shm_internal.hpp>
 #include <bpftime_prog.hpp>

--- a/runtime/src/bpf_helper.cpp
+++ b/runtime/src/bpf_helper.cpp
@@ -5,11 +5,15 @@
  */
 #include "bpf_attach_ctx.hpp"
 #include "handler/map_handler.hpp"
+#if __linux__
 #include "linux/bpf.h"
+#elif defined(__APPLE__) || defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
+#include "bpftime_epoll.h"
+#endif
 #include <algorithm>
 #include <stdexcept>
 #include <system_error>
-#if __APPLE__
+#if defined(__APPLE__) || defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
 #include <cstdint>
 #include <pthread.h>
 #endif
@@ -307,7 +311,7 @@ uint64_t bpftime_ktime_get_coarse_ns(uint64_t, uint64_t, uint64_t, uint64_t,
 				     uint64_t)
 {
 	timespec spec;
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
 	clock_gettime(CLOCK_MONOTONIC, &spec); // or CLOCK_MONOTONIC_RAW
 #else
 	clock_gettime(CLOCK_MONOTONIC_COARSE, &spec);
@@ -323,6 +327,11 @@ uint64_t bpftime_get_current_pid_tgid(uint64_t, uint64_t, uint64_t, uint64_t,
 	static thread_local int tid = -1;
 	if (tid == -1) {
 		tid = gettid();
+	}
+#elif defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
+	static thread_local int tid = -1;
+	if (tid == -1) {
+		tid = (int)pthread_self();
 	}
 #elif __APPLE__
 	static thread_local uint64_t tid = UINT64_MAX; // cannot use int because
@@ -428,7 +437,7 @@ uint64_t bpf_ktime_get_coarse_ns(uint64_t, uint64_t, uint64_t, uint64_t,
 				 uint64_t)
 {
 	struct timespec ts;
-#if __APPLE__
+#if defined(__APPLE__) || defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
 	clock_gettime(CLOCK_MONOTONIC, &ts); // or CLOCK_MONOTONIC_RAW
 #else
 	clock_gettime(CLOCK_MONOTONIC_COARSE, &ts);

--- a/runtime/src/bpf_map/userspace/prog_array.cpp
+++ b/runtime/src/bpf_map/userspace/prog_array.cpp
@@ -10,7 +10,7 @@
 #include <bpf/libbpf.h>
 #include <gnu/lib-names.h>
 #include <asm/unistd.h>
-#elif __APPLE__
+#elif defined(__APPLE__) || defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
 #include "bpftime_epoll.h"
 #endif
 #include "spdlog/spdlog.h"

--- a/runtime/src/bpftime_shm.cpp
+++ b/runtime/src/bpftime_shm.cpp
@@ -18,14 +18,14 @@
 #include <bpftime_shm_internal.hpp>
 #if __linux__
 #include <sys/epoll.h>
-#elif __APPLE__
+#elif defined(__APPLE__) || defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
 #include "bpftime_epoll.h"
 #endif
 #include <thread>
 #include <chrono>
 #include <variant>
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
 // Custom implementation for sigtimedwait
 int sigtimedwait(const sigset_t *set, siginfo_t *info,
 		 const struct timespec *timeout)

--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -24,7 +24,7 @@
 #include <cuda.h>
 #include <bpf_attach_ctx.hpp>
 #endif
-#elif __APPLE__
+#elif defined(__APPLE__) || defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
 #include "bpftime_epoll.h"
 #endif
 #include <unistd.h>

--- a/runtime/src/bpftime_shm_json.cpp
+++ b/runtime/src/bpftime_shm_json.cpp
@@ -12,7 +12,7 @@
 #include <cstdio>
 #if __linux__
 #include <sys/epoll.h>
-#elif __APPLE__
+#elif defined(__APPLE__) || defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
 #include "bpftime_epoll.h"
 #endif
 #include <unistd.h>

--- a/runtime/src/handler/epoll_handler.cpp
+++ b/runtime/src/handler/epoll_handler.cpp
@@ -6,7 +6,7 @@
 #include <handler/epoll_handler.hpp>
 #if __linux__
 #include <sys/epoll.h>
-#elif __APPLE__
+#elif defined(__APPLE__) || defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
 #include "bpftime_epoll.h"
 #endif
 namespace bpftime

--- a/runtime/src/handler/epoll_handler.hpp
+++ b/runtime/src/handler/epoll_handler.hpp
@@ -11,7 +11,7 @@
 #include <bpf_map/userspace/ringbuf_map.hpp>
 #if __linux__
 #include <sys/epoll.h>
-#elif __APPLE__
+#elif defined(__APPLE__) || defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
 #include "bpftime_epoll.h"
 #endif
 #include <variant>

--- a/runtime/src/handler/map_handler.hpp
+++ b/runtime/src/handler/map_handler.hpp
@@ -25,7 +25,7 @@
 #include "bpf_map/gpu/nv_gpu_ringbuf_map.hpp"
 #endif
 
-#if __APPLE__
+#if defined(__APPLE__) || defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
 #include "spinlock_wrapper.hpp"
 #endif
 namespace bpftime

--- a/runtime/src/handler/perf_event_handler.cpp
+++ b/runtime/src/handler/perf_event_handler.cpp
@@ -5,7 +5,7 @@
  */
 #if __linux__
 #include "linux/perf_event.h"
-#elif __APPLE__
+#elif defined(__APPLE__) || defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
 #include "bpftime_epoll.h"
 #endif
 #include "spdlog/spdlog.h"

--- a/runtime/src/handler/perf_event_handler.hpp
+++ b/runtime/src/handler/perf_event_handler.hpp
@@ -17,6 +17,8 @@
 #include <boost/interprocess/smart_ptr/weak_ptr.hpp>
 #if __linux__
 #include "linux/perf_event.h"
+#elif defined(__APPLE__) || defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
+#include "bpftime_epoll.h"
 #endif
 #include "bpftime_shm.hpp"
 #include <variant>

--- a/runtime/src/platform_utils.cpp
+++ b/runtime/src/platform_utils.cpp
@@ -4,34 +4,76 @@
 #if __linux__
 #include <sched.h>
 
-int my_sched_getcpu() {
-    return ::sched_getcpu();
+int my_sched_getcpu()
+{
+	return ::sched_getcpu();
+}
+
+#elif defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
+#include <sys/neutrino.h>
+#include <sys/syspage.h>
+#include <unistd.h>
+
+int my_sched_getcpu()
+{
+	// QNX: current CPU for the calling thread (see SYSPAGE CPU info).
+	// Fallback to 0 if the API is unavailable on a given SDP build.
+#if defined(_NTO_TCTL_RUNMASK_GET_AND_SET)
+	unsigned runmask = 0;
+	if (ThreadCtl(_NTO_TCTL_RUNMASK_GET_AND_SET, &runmask) != -1) {
+		for (int i = 0; i < (int)sizeof(runmask) * 8; ++i) {
+			if (runmask & (1u << i))
+				return i;
+		}
+	}
+#endif
+	return 0;
+}
+
+int sched_getaffinity([[maybe_unused]] pid_t pid,
+		      [[maybe_unused]] size_t cpusetsize, cpu_set_t *mask)
+{
+	CPU_ZERO(mask);
+	CPU_SET(my_sched_getcpu(), mask);
+	return 0;
+}
+
+int sched_setaffinity([[maybe_unused]] pid_t pid,
+		      [[maybe_unused]] size_t cpusetsize,
+		      [[maybe_unused]] const cpu_set_t *mask)
+{
+	return 0;
 }
 
 #elif __APPLE__
 #include <sys/sysctl.h>
 #include <pthread.h>
 
-int my_sched_getcpu() {
-    int cpu = -1;
-    size_t len = sizeof(cpu);
+int my_sched_getcpu()
+{
+	int cpu = -1;
+	size_t len = sizeof(cpu);
 
-    if (sysctlbyname("hw.cpulocation", &cpu, &len, NULL, 0) == -1) {
-        SPDLOG_ERROR("Couldn't get cpu location for the system");
-        return -1;  
-    }
-    return cpu;
+	if (sysctlbyname("hw.cpulocation", &cpu, &len, NULL, 0) == -1) {
+		SPDLOG_ERROR("Couldn't get cpu location for the system");
+		return -1;
+	}
+	return cpu;
 }
 
-int sched_getaffinity([[maybe_unused]] pid_t pid, [[maybe_unused]]size_t cpusetsize, cpu_set_t *mask) {
-    CPU_ZERO(mask);
-    CPU_SET(my_sched_getcpu(), mask);
-    return 0;
+int sched_getaffinity([[maybe_unused]] pid_t pid,
+		      [[maybe_unused]] size_t cpusetsize, cpu_set_t *mask)
+{
+	CPU_ZERO(mask);
+	CPU_SET(my_sched_getcpu(), mask);
+	return 0;
 }
 
-int sched_setaffinity([[maybe_unused]]pid_t pid, [[maybe_unused]]size_t cpusetsize, [[maybe_unused]]const cpu_set_t *mask) {
-    return 0;
+int sched_setaffinity([[maybe_unused]] pid_t pid,
+		      [[maybe_unused]] size_t cpusetsize,
+		      [[maybe_unused]] const cpu_set_t *mask)
+{
+	return 0;
 }
 
 #endif
-

--- a/runtime/syscall-server/syscall_context.hpp
+++ b/runtime/syscall-server/syscall_context.hpp
@@ -10,7 +10,7 @@
 #include <unordered_map>
 #if __linux__
 #include "linux/perf_event.h"
-#elif __APPLE__
+#elif defined(__APPLE__) || defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
 #include "bpftime_epoll.h"
 #endif
 #include <cstddef>
@@ -25,7 +25,7 @@
 // #include "pos/include/common.h"
 // #include "pos/include/utils/command_caller.h"
 // #include "pos/cli/cli.h"
-#if __APPLE__
+#if defined(__APPLE__) || defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
 using namespace bpftime_epoll;
 #endif
 

--- a/scripts/qnx/README.md
+++ b/scripts/qnx/README.md
@@ -1,0 +1,70 @@
+# QNX 8.0 aarch64 Port — Phase 1 Skeleton
+
+> Status: **scaffold only**. Cross-compiles the userspace VM + Frida uprobe agent path.
+> Does **not** yet claim a verified run on a QNX target (Frida QNX build + Boost sysroot still required).
+
+## Goal
+
+On **QNX Neutrino 8.0 / aarch64**, support:
+
+```
+Linux: clang -target bpf → JSON export
+QNX:   bpftimetool import → bpftime attach <pid> → Frida uprobe → eBPF (uBPF JIT)
+```
+
+Out of scope for phase-1: syscall-server, daemon, libbpf, syscall trace, text transformer, CUDA, LLVM JIT.
+
+## CMake entry
+
+```bash
+source /path/to/qnxsdp-env.sh
+export BPFTIME_FRIDA_QNX_ROOT=/path/to/frida-qnx-arm64-out
+
+./scripts/qnx/build-phase1.sh
+# or manually:
+cmake -B build-qnx \
+  -DCMAKE_TOOLCHAIN_FILE=cmake/qnx8-aarch64-toolchain.cmake \
+  -DBPFTIME_TARGET_QNX=ON \
+  -DBPFTIME_FRIDA_QNX_ROOT=$BPFTIME_FRIDA_QNX_ROOT \
+  -DCMAKE_BUILD_TYPE=Release
+cmake --build build-qnx --target bpftime-agent bpftime-cli-cpp bpftimetool
+```
+
+## New / key files
+
+| Path | Role |
+|------|------|
+| `cmake/qnx8-aarch64-toolchain.cmake` | QNX SDP 8.0 aarch64le toolchain |
+| `cmake/PlatformQNX.cmake` | Force phase-1 option defaults |
+| `cmake/frida-qnx.cmake` | Local Frida gum/core (no GitHub prebuilt) |
+| `scripts/qnx/build-phase1.sh` | One-shot configure + build |
+| `docs/qnx-port-phase1.md` | This document |
+
+## Forced defaults when `BPFTIME_TARGET_QNX=ON`
+
+- `BPFTIME_BUILD_WITH_LIBBPF=OFF`
+- `BUILD_BPFTIME_DAEMON=OFF`
+- `BPFTIME_LLVM_JIT=OFF` / `BPFTIME_UBPF_JIT=ON`
+- Skip: syscall_trace, text_segment_transformer, nv_attach, syscall-server, benchmark, AOT
+
+## Runtime / CLI behavior on QNX
+
+- Agent: Frida inject only (`bpftime_agent_main`); no `__libc_start_main` / LD_PRELOAD path
+- CLI: `attach` / `detach` enabled; `load` / `start` return clear errors
+- Platform stubs: `platform_utils`, epoll via `bpftime_epoll.h`, `/proc/<pid>/exefile` for executable path
+
+## Remaining work (not in this PR)
+
+1. Produce Frida `qnx-arm64` gum + core archives and document exact layout
+2. Provide Boost.Interprocess for QNX target (SDP package or qnx-ports)
+3. Verify `pthread_spinlock` / Boost shm under `/dev/shmem`
+4. End-to-end uprobe demo on board
+5. Optional: lightweight ELF bytecode loader on-target (replace JSON import)
+6. Optional: re-enable LLVM JIT with QNX-hosted LLVM
+
+## Done definition
+
+- [ ] `build-phase1.sh` configures without FATAL (given Frida + Boost)
+- [ ] `libbpftime-agent.so`, `bpftime`, `bpftimetool` link for aarch64le
+- [ ] `bpftime attach <pid>` injects agent via Frida-core
+- [ ] Uprobe fires; map/ringbuf updates visible via `bpftimetool`

--- a/scripts/qnx/build-phase1.sh
+++ b/scripts/qnx/build-phase1.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Phase-1 QNX 8.0 aarch64 build helper for bpftime (process hook / uprobe).
+#
+# Prerequisites:
+#   1. Source QNX SDP 8.0 env (sets QNX_HOST / QNX_TARGET)
+#   2. Build Frida for qnx-arm64 and set BPFTIME_FRIDA_QNX_ROOT
+#   3. Boost.Interprocess available for the QNX target sysroot
+#
+# Usage:
+#   export BPFTIME_FRIDA_QNX_ROOT=/path/to/frida-qnx-arm64-out
+#   ./scripts/qnx/build-phase1.sh [build-dir]
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BUILD_DIR="${1:-${ROOT}/build-qnx}"
+
+if [[ -z "${QNX_HOST:-}" || -z "${QNX_TARGET:-}" ]]; then
+  echo "ERROR: QNX_HOST and QNX_TARGET must be set (source qnxsdp-env.sh)" >&2
+  exit 1
+fi
+
+if [[ -z "${BPFTIME_FRIDA_QNX_ROOT:-}" ]]; then
+  echo "ERROR: BPFTIME_FRIDA_QNX_ROOT must point to Frida qnx-arm64 output" >&2
+  echo "  expected: \$BPFTIME_FRIDA_QNX_ROOT/{gum,core}/libfrida-*.a" >&2
+  exit 1
+fi
+
+JOBS="${JOBS:-$(nproc 2>/dev/null || echo 4)}"
+
+cmake -B "${BUILD_DIR}" \
+  -DCMAKE_TOOLCHAIN_FILE="${ROOT}/cmake/qnx8-aarch64-toolchain.cmake" \
+  -DBPFTIME_TARGET_QNX=ON \
+  -DBPFTIME_BUILD_WITH_LIBBPF=OFF \
+  -DBUILD_BPFTIME_DAEMON=OFF \
+  -DBPFTIME_LLVM_JIT=OFF \
+  -DBPFTIME_UBPF_JIT=ON \
+  -DBPFTIME_FRIDA_QNX_ROOT="${BPFTIME_FRIDA_QNX_ROOT}" \
+  -DCMAKE_BUILD_TYPE=Release \
+  "${ROOT}"
+
+cmake --build "${BUILD_DIR}" \
+  --target bpftime-agent bpftime-cli-cpp bpftimetool \
+  -j"${JOBS}"
+
+echo ""
+echo "Phase-1 QNX build finished."
+echo "  agent:  ${BUILD_DIR}/runtime/agent/libbpftime-agent.so"
+echo "  cli:    ${BUILD_DIR}/tools/cli/bpftime"
+echo "  tool:   ${BUILD_DIR}/tools/bpftimetool/bpftimetool"
+echo ""
+echo "See scripts/qnx/README.md for phase-1 scope and remaining work."

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory(bpftimetool)
 add_subdirectory(cli)
-if(BPFTIME_LLVM_JIT)
+# AOT tooling needs LLVM; skip on QNX phase-1 when LLVM JIT is off
+if(BPFTIME_LLVM_JIT AND NOT BPFTIME_TARGET_QNX)
   message(STATUS "Using llvm-jit")
   add_subdirectory(aot)
 endif()

--- a/tools/cli/CMakeLists.txt
+++ b/tools/cli/CMakeLists.txt
@@ -7,15 +7,20 @@ set_target_properties(bpftime-cli-cpp PROPERTIES OUTPUT_NAME "bpftime")
 
 target_include_directories(bpftime-cli-cpp PRIVATE ${FRIDA_CORE_INSTALL_DIR} ${SPDLOG_INCLUDE} ${argparse_INCLUDE} ${CMAKE_CURRENT_SOURCE_DIR}/../../runtime/include ${CMAKE_CURRENT_SOURCE_DIR}/../../runtime/src ${CMAKE_CURRENT_SOURCE_DIR}/../../vm/vm-core/include)
 target_link_libraries(bpftime-cli-cpp PRIVATE spdlog::spdlog ${FRIDA_CORE_INSTALL_DIR}/libfrida-core.a argparse spdlog::spdlog bpftime_vm_compat runtime)
-# Link the VM compat static libs exactly once via runtime to avoid duplicate symbols
+# Force link VM compat libraries so constructor-based factory registration is retained
+# Ensure VM compat libraries are linked (once) via the runtime library instead of duplicating at server
 if(${BPFTIME_UBPF_JIT})
   add_dependencies(bpftime-cli-cpp bpftime_ubpf_vm)
-  target_link_options(bpftime-cli-cpp PUBLIC "-Wl,--whole-archive" "$<TARGET_FILE:bpftime_ubpf_vm>" "-Wl,--no-whole-archive")
+  if(NOT BPFTIME_TARGET_QNX)
+    target_link_options(bpftime-cli-cpp PUBLIC "-Wl,--whole-archive" "$<TARGET_FILE:bpftime_ubpf_vm>" "-Wl,--no-whole-archive")
+  endif()
   target_link_libraries(bpftime-cli-cpp PUBLIC bpftime_ubpf_vm)
 endif()
 if(${BPFTIME_LLVM_JIT})
   add_dependencies(bpftime-cli-cpp bpftime_llvm_vm llvmbpf_vm)
-  target_link_options(bpftime-cli-cpp PUBLIC "-Wl,--whole-archive" "$<TARGET_FILE:bpftime_llvm_vm>" "-Wl,--no-whole-archive")
+  if(NOT BPFTIME_TARGET_QNX)
+    target_link_options(bpftime-cli-cpp PUBLIC "-Wl,--whole-archive" "$<TARGET_FILE:bpftime_llvm_vm>" "-Wl,--no-whole-archive")
+  endif()
   target_link_libraries(bpftime-cli-cpp PUBLIC bpftime_llvm_vm)
 endif()
 set_property(TARGET bpftime-cli-cpp PROPERTY CXX_STANDARD 20)

--- a/tools/cli/main.cpp
+++ b/tools/cli/main.cpp
@@ -56,6 +56,13 @@ int execvpe(const char *file, char *const argv[], char *const envp[])
 	errno = ENOENT;
 	return -1;
 }
+#elif defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
+extern char **environ;
+constexpr const char *AGENT_LIBRARY = "libbpftime-agent.so";
+// Phase-1 QNX: no syscall-server / text transformer
+constexpr const char *SYSCALL_SERVER_LIBRARY = "libbpftime-syscall-server.so";
+constexpr const char *AGENT_TRANSFORMER_LIBRARY =
+	"libbpftime-agent-transformer.so";
 #elif __linux__
 extern char **environ;
 constexpr const char *AGENT_LIBRARY = "libbpftime-agent.so";
@@ -260,6 +267,12 @@ int main(int argc, const char **argv)
 	}
 	std::filesystem::path install_path(program.get("install-location"));
 	if (program.is_subcommand_used("load")) {
+#if defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
+		spdlog::error(
+			"bpftime load (syscall-server) is not supported on QNX phase-1; "
+			"use bpftimetool import + bpftime attach instead");
+		return 1;
+#else
 		auto so_path = install_path / SYSCALL_SERVER_LIBRARY;
 		if (!std::filesystem::exists(so_path)) {
 			spdlog::error("Library not found: {}", so_path.c_str());
@@ -269,7 +282,14 @@ int main(int argc, const char **argv)
 			extract_path_and_args(load_command);
 		return run_command(executable_path.c_str(), extra_args,
 				   so_path.c_str(), nullptr);
+#endif
 	} else if (program.is_subcommand_used("start")) {
+#if defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
+		spdlog::error(
+			"bpftime start (LD_PRELOAD) is not supported on QNX phase-1; "
+			"use bpftime attach <pid>");
+		return 1;
+#else
 		auto agent_path = install_path / AGENT_LIBRARY;
 		if (!std::filesystem::exists(agent_path)) {
 			spdlog::error("Library not found: {}",
@@ -296,6 +316,7 @@ int main(int argc, const char **argv)
 			return run_command(executable_path.c_str(), extra_args,
 					   agent_path.c_str(), nullptr);
 		}
+#endif
 	} else if (program.is_subcommand_used("attach")) {
 		auto agent_path = install_path / AGENT_LIBRARY;
 		if (!std::filesystem::exists(agent_path)) {
@@ -305,6 +326,11 @@ int main(int argc, const char **argv)
 		}
 		auto pid = attach_command.get<int>("PID");
 		if (attach_command.get<bool>("enable-syscall-trace")) {
+#if defined(__QNX__) || defined(BPFTIME_TARGET_QNX)
+			spdlog::error(
+				"Syscall trace attach is not available on QNX phase-1");
+			return 1;
+#else
 			auto transformer_path =
 				install_path /
 				"libbpftime-agent-transformer.so";
@@ -315,6 +341,7 @@ int main(int argc, const char **argv)
 			}
 			return inject_by_frida(pid, transformer_path.c_str(),
 					       agent_path.c_str());
+#endif
 		} else {
 			return inject_by_frida(pid, agent_path.c_str(), "");
 		}


### PR DESCRIPTION
## Summary
- Add QNX SDP 8.0 aarch64le toolchain, PlatformQNX defaults, and local Frida-qnx CMake wiring for a userspace-only phase-1 build.
- Gate Linux-only components (libbpf, daemon, syscall-server, syscall/text/CUDA attach) and extend platform/shm/epoll/agent/CLI paths for `__QNX__`.
- Provide `scripts/qnx/build-phase1.sh` and README describing attach-only workflow (`bpftimetool import` + `bpftime attach`).

## Test plan
- [ ] With QNX SDP env + `BPFTIME_FRIDA_QNX_ROOT`, run `./scripts/qnx/build-phase1.sh` and confirm agent/cli/bpftimetool link for aarch64le
- [ ] Confirm Linux default build still configures with previous options (no accidental QNX defaults)
- [ ] On QNX target: `bpftimetool import` JSON from Linux-built eBPF, then `bpftime attach <pid>` and verify uprobe hit
- [ ] Confirm `bpftime load` / `start` / `-s` return clear unsupported errors on QNX phase-1


Made with [Cursor](https://cursor.com)