### PR TITLE
fix: reject truncated daemon program captures

### DIFF
--- a/daemon/test/test_daemon_driver.cpp
+++ b/daemon/test/test_daemon_driver.cpp
@@ -9,6 +9,7 @@
 #include "bpftime_shm.hpp"
 #include "bpftime_shm_internal.hpp"
 #include "handler/link_handler.hpp"
+#include "user/bpf_prog_insns.hpp"
 #include "user/bpftime_driver.hpp"
 #if !defined(__x86_64__) && defined(_M_X64)
 #error Only supports x86_64
@@ -45,4 +46,34 @@ TEST_CASE("Daemon driver preserves perf-link cookies")
 		}
 	}
 	REQUIRE(found);
+}
+
+TEST_CASE("Daemon rejects instruction counts beyond the captured buffer")
+{
+	bpf_insn_data captured = {};
+	captured.code_len = BPF_COMPLEXITY_LIMIT_INSNS + 1;
+	std::vector<ebpf_inst> insns(1);
+
+	const int result = bpftime::detail::copy_captured_bpf_prog_insns(
+		insns, captured);
+	REQUIRE(result == -E2BIG);
+	REQUIRE(insns.empty());
+}
+
+TEST_CASE("Daemon accepts the exact captured instruction capacity")
+{
+	bpf_insn_data captured = {};
+	captured.code_len = BPF_COMPLEXITY_LIMIT_INSNS;
+	auto *captured_insns = reinterpret_cast<ebpf_inst *>(captured.code);
+	captured_insns[0].code = EBPF_OP_MOV64_IMM;
+	captured_insns[0].imm = 7;
+	captured_insns[BPF_COMPLEXITY_LIMIT_INSNS - 1].code = EBPF_OP_EXIT;
+	std::vector<ebpf_inst> insns;
+
+	REQUIRE(bpftime::detail::copy_captured_bpf_prog_insns(insns,
+							     captured) == 0);
+	REQUIRE(insns.size() == BPF_COMPLEXITY_LIMIT_INSNS);
+	REQUIRE(insns.front().code == EBPF_OP_MOV64_IMM);
+	REQUIRE(insns.front().imm == 7);
+	REQUIRE(insns.back().code == EBPF_OP_EXIT);
 }

--- a/daemon/user/bpf_prog_insns.hpp
+++ b/daemon/user/bpf_prog_insns.hpp
@@ -1,0 +1,41 @@
+/* SPDX-License-Identifier: MIT
+ *
+ * Copyright (c) 2022, eunomia-bpf org
+ * All rights reserved.
+ */
+#ifndef BPFTIME_BPF_PROG_INSNS_HPP
+#define BPFTIME_BPF_PROG_INSNS_HPP
+
+#include "ebpf_inst.h"
+#include <cerrno>
+#include <cstring>
+#include <linux/bpf.h>
+#include <linux/perf_event.h>
+#include <vector>
+#include "../bpf_tracer_event.h"
+
+namespace bpftime::detail
+{
+
+inline int copy_captured_bpf_prog_insns(std::vector<ebpf_inst> &insns,
+					const bpf_insn_data &captured)
+{
+	static_assert(sizeof(bpf_insn) == sizeof(ebpf_inst));
+	constexpr size_t captured_capacity =
+		sizeof(captured.code) / sizeof(ebpf_inst);
+	if (captured.code_len > captured_capacity) {
+		insns.clear();
+		return -E2BIG;
+	}
+
+	insns.resize(captured.code_len);
+	if (!insns.empty()) {
+		std::memcpy(insns.data(), captured.code,
+			    captured.code_len * sizeof(ebpf_inst));
+	}
+	return 0;
+}
+
+} // namespace bpftime::detail
+
+#endif // BPFTIME_BPF_PROG_INSNS_HPP

--- a/daemon/user/bpftime_driver.cpp
+++ b/daemon/user/bpftime_driver.cpp
@@ -4,6 +4,7 @@
  * All rights reserved.
  */
 #include "bpftime_driver.hpp"
+#include "bpf_prog_insns.hpp"
 #include "bpftime_config.hpp"
 #include <linux/bpf.h>
 #include <bpf/bpf.h>
@@ -84,12 +85,15 @@ static int relocate_bpf_prog_insns(std::vector<ebpf_inst> &insns,
 	}
 	SPDLOG_DEBUG("relocate bpf prog insns for id {}, cnt {}", id,
 		      insn_data.code_len);
-	// resize the insns
-	insns.resize(insn_data.code_len);
-	const ebpf_inst *orignal_insns = (const ebpf_inst *)insn_data.code;
-	insns.assign(orignal_insns, orignal_insns + insn_data.code_len);
+	res = bpftime::detail::copy_captured_bpf_prog_insns(insns, insn_data);
+	if (res < 0) {
+		SPDLOG_ERROR(
+			"BPF program {} has {} instructions, exceeding capture capacity {}",
+			id, insn_data.code_len, BPF_COMPLEXITY_LIMIT_INSNS);
+		return res;
+	}
 	for (size_t i = 0; i < insn_data.code_len; i++) {
-		const struct ebpf_inst inst = orignal_insns[i];
+		const struct ebpf_inst inst = insns[i];
 		bool store = false;
 
 		switch (inst.code) {


### PR DESCRIPTION
## Summary

- reject daemon instruction records whose original count exceeds the fixed 4096-instruction capture buffer
- clear the destination and return `-E2BIG` before resize, copy, relocation, or shared-memory installation
- add focused regressions for an oversized record and the exact 4096-instruction boundary

Closes #655.

## Validation

- focused C++20 guard smoke with `-Wall -Wextra -Werror`
- focused oversized and exact-boundary execution under ASan/UBSan
- `git diff --check`

The full CMake/daemon suite is left to CI because this checkout does not have CMake or initialized submodules.