### PR TITLE
fix: align get_stack buffer semantics with Linux

### DIFF
--- a/runtime/src/bpf_helper.cpp
+++ b/runtime/src/bpf_helper.cpp
@@ -790,6 +790,15 @@ int64_t bpftime_get_stack(uint64_t ctx_raw, uint64_t buf, uint64_t size,
 		SPDLOG_ERROR("bpftime_get_stack doesn't support buildid!");
 		return -ENOTSUP;
 	}
+	auto *buffer = reinterpret_cast<void *>(static_cast<uintptr_t>(buf));
+	if (size % sizeof(uint64_t) != 0) {
+		SPDLOG_ERROR(
+			"bpftime_get_stack buffer size must be a multiple of {} bytes",
+			sizeof(uint64_t));
+		if (size > 0)
+			memset(buffer, 0, size);
+		return -EINVAL;
+	}
 	const int ATTACH_UPROBE = 6;
 
 	auto &attach_ctx = get_global_attach_ctx();
@@ -812,19 +821,24 @@ int64_t bpftime_get_stack(uint64_t ctx_raw, uint64_t buf, uint64_t size,
 
 	auto frames_to_skip = flags & BPF_F_SKIP_FIELD_MASK;
 	SPDLOG_DEBUG("Skipping {} frames", frames_to_skip);
-	if (frames_to_skip >= result->size()) {
-		result->resize(0);
-	} else {
-		std::vector<uint64_t> new_data;
-		new_data.resize(result->size() - frames_to_skip);
-		std::copy(result->begin() + frames_to_skip, result->end(),
-			  new_data.begin());
-		*result = new_data;
+	if (frames_to_skip > result->size()) {
+		if (size > 0)
+			memset(buffer, 0, size);
+		return -EFAULT;
 	}
-	auto size_to_copy = std::min(result->size(), (uintptr_t)size);
+
+	auto frames_to_copy =
+		std::min(result->size() - frames_to_skip,
+			 static_cast<size_t>(size / sizeof(uint64_t)));
+	auto size_to_copy = frames_to_copy * sizeof(uint64_t);
 	SPDLOG_DEBUG("Copied {} bytes of stack", size_to_copy);
-	memcpy((void *)(uintptr_t)buf, result->data(), size_to_copy);
-	return 0;
+	if (size > 0) {
+		memset(buffer, 0, size);
+		if (size_to_copy > 0)
+			memcpy(buffer, result->data() + frames_to_skip,
+			       size_to_copy);
+	}
+	return static_cast<int64_t>(size_to_copy);
 }
 
 } // extern "C"

--- a/runtime/src/bpf_helper.cpp
+++ b/runtime/src/bpf_helper.cpp
@@ -832,12 +832,11 @@ int64_t bpftime_get_stack(uint64_t ctx_raw, uint64_t buf, uint64_t size,
 			 static_cast<size_t>(size / sizeof(uint64_t)));
 	auto size_to_copy = frames_to_copy * sizeof(uint64_t);
 	SPDLOG_DEBUG("Copied {} bytes of stack", size_to_copy);
-	if (size > 0) {
-		memset(buffer, 0, size);
-		if (size_to_copy > 0)
-			memcpy(buffer, result->data() + frames_to_skip,
-			       size_to_copy);
-	}
+	if (size_to_copy > 0)
+		memcpy(buffer, result->data() + frames_to_skip, size_to_copy);
+	if (size > size_to_copy)
+		memset(static_cast<char *>(buffer) + size_to_copy, 0,
+		       size - size_to_copy);
 	return static_cast<int64_t>(size_to_copy);
 }
 

--- a/runtime/unit-test/test_get_stack.cpp
+++ b/runtime/unit-test/test_get_stack.cpp
@@ -1,9 +1,61 @@
+#include "bpf_attach_ctx.hpp"
 #include "linux/bpf.h"
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <algorithm>
+#include <array>
 #include <cerrno>
 #include <cstdint>
+#include <memory>
+#include <vector>
+
+namespace
+{
+
+std::vector<uint64_t> mock_stack;
+
+class mock_stack_attach_impl : public bpftime::attach::base_attach_impl {
+    public:
+	int detach_by_id(int) override
+	{
+		return 0;
+	}
+
+	int create_attach_with_ebpf_callback(
+		bpftime::attach::ebpf_run_callback &&,
+		const bpftime::attach::attach_private_data &, int) override
+	{
+		return 0;
+	}
+
+	void *call_attach_specific_function(const std::string &name,
+					    void *) override
+	{
+		if (name != "generate_stack")
+			return nullptr;
+		return new std::vector<uint64_t>(mock_stack);
+	}
+};
+
+bpftime::bpf_attach_ctx mock_attach_ctx;
+
+} // namespace
+
+bpftime::bpf_attach_ctx &get_global_attach_ctx()
+{
+	static const bool initialized = [] {
+		mock_attach_ctx.register_attach_impl(
+			{ 6 }, std::make_unique<mock_stack_attach_impl>(),
+			[](const std::string_view &, int &) {
+				return std::unique_ptr<
+					bpftime::attach::attach_private_data>();
+			});
+		return true;
+	}();
+	(void)initialized;
+	return mock_attach_ctx;
+}
 
 extern "C" int64_t bpftime_get_stack(uint64_t, uint64_t, uint64_t, uint64_t,
 				     uint64_t);
@@ -13,4 +65,82 @@ TEST_CASE("get_stack rejects build IDs")
 	REQUIRE(bpftime_get_stack(0, 0, 0,
 				  BPF_F_USER_STACK | BPF_F_USER_BUILD_ID,
 				  0) == -ENOTSUP);
+}
+
+TEST_CASE("get_stack uses byte-sized buffers and returns copied bytes")
+{
+	mock_stack = { 0x1111111111111111, 0x2222222222222222,
+		       0x3333333333333333 };
+	std::array<uint64_t, 4> buffer;
+	buffer.fill(UINT64_MAX);
+
+	auto copied =
+		bpftime_get_stack(0, reinterpret_cast<uint64_t>(buffer.data()),
+				  sizeof(buffer), BPF_F_USER_STACK, 0);
+
+	REQUIRE(copied == 3 * sizeof(uint64_t));
+	REQUIRE(buffer[0] == mock_stack[0]);
+	REQUIRE(buffer[1] == mock_stack[1]);
+	REQUIRE(buffer[2] == mock_stack[2]);
+	REQUIRE(buffer[3] == 0);
+}
+
+TEST_CASE("get_stack truncates only at complete frame boundaries")
+{
+	mock_stack = { 0x1111111111111111, 0x2222222222222222,
+		       0x3333333333333333 };
+	std::array<uint64_t, 3> buffer;
+	buffer.fill(UINT64_MAX);
+
+	auto copied =
+		bpftime_get_stack(0, reinterpret_cast<uint64_t>(buffer.data()),
+				  2 * sizeof(uint64_t), BPF_F_USER_STACK, 0);
+
+	REQUIRE(copied == 2 * sizeof(uint64_t));
+	REQUIRE(buffer[0] == mock_stack[0]);
+	REQUIRE(buffer[1] == mock_stack[1]);
+	REQUIRE(buffer[2] == UINT64_MAX);
+}
+
+TEST_CASE("get_stack rejects a partial frame buffer")
+{
+	mock_stack = { 0x1111111111111111, 0x2222222222222222 };
+	std::array<uint8_t, 15> buffer;
+	buffer.fill(0xff);
+
+	REQUIRE(bpftime_get_stack(0, reinterpret_cast<uint64_t>(buffer.data()),
+				  buffer.size(), BPF_F_USER_STACK,
+				  0) == -EINVAL);
+	REQUIRE(std::all_of(buffer.begin(), buffer.end(),
+			    [](uint8_t value) { return value == 0; }));
+}
+
+TEST_CASE("get_stack applies frame skips before the byte limit")
+{
+	mock_stack = { 0x1111111111111111, 0x2222222222222222,
+		       0x3333333333333333 };
+	std::array<uint64_t, 3> buffer;
+	buffer.fill(UINT64_MAX);
+
+	auto copied =
+		bpftime_get_stack(0, reinterpret_cast<uint64_t>(buffer.data()),
+				  sizeof(buffer), BPF_F_USER_STACK | 1, 0);
+
+	REQUIRE(copied == 2 * sizeof(uint64_t));
+	REQUIRE(buffer[0] == mock_stack[1]);
+	REQUIRE(buffer[1] == mock_stack[2]);
+	REQUIRE(buffer[2] == 0);
+}
+
+TEST_CASE("get_stack rejects skips beyond the available trace")
+{
+	mock_stack = { 0x1111111111111111, 0x2222222222222222 };
+	std::array<uint64_t, 2> buffer;
+	buffer.fill(UINT64_MAX);
+
+	REQUIRE(bpftime_get_stack(0, reinterpret_cast<uint64_t>(buffer.data()),
+				  sizeof(buffer), BPF_F_USER_STACK | 3,
+				  0) == -EFAULT);
+	REQUIRE(std::all_of(buffer.begin(), buffer.end(),
+			    [](uint64_t value) { return value == 0; }));
 }


### PR DESCRIPTION
Fixes #652

## Summary

- treat `bpf_get_stack` size as bytes and copy only complete `uint64_t` frames
- apply frame skipping before the byte limit, zero unused/error buffers, and return the copied byte count
- add regressions for truncation, alignment, zero-fill, skip, and return-value semantics

## Testing

- `cmake --build build --target bpftime_runtime_tests -j2`
- `BPFTIME_VM_NAME=ubpf ./build/runtime/unit-test/bpftime_runtime_tests "get_stack*" --reporter compact` (6 cases, 18 assertions)
- same focused suite with `BPFTIME_ENABLE_ASAN=ON` (6 cases, 18 assertions)