### PR TITLE
fix: bounds-check handler fds to prevent OOB and fd leak

### DIFF
--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -678,6 +678,11 @@ int bpftime_shm::open_fake_fd()
 	while (fd <= 2 && fd >= 0 && --cnt > 0) {
 		fd = dup(fd);
 	}
+	if (fd >= 0 && (std::size_t)fd >= manager->size()) {
+		close(fd);
+		errno = ENOSPC;
+		return -1;
+	}
 	return fd;
 }
 

--- a/runtime/src/bpftime_shm_internal.cpp
+++ b/runtime/src/bpftime_shm_internal.cpp
@@ -679,6 +679,7 @@ int bpftime_shm::open_fake_fd()
 		fd = dup(fd);
 	}
 	if (fd >= 0 && (std::size_t)fd >= manager->size()) {
+		SPDLOG_ERROR("open_fake_fd: fd {} exceeds handler pool size {}", fd, manager->size());
 		close(fd);
 		errno = ENOSPC;
 		return -1;

--- a/runtime/src/handler/handler_manager.cpp
+++ b/runtime/src/handler/handler_manager.cpp
@@ -34,11 +34,15 @@ handler_manager::~handler_manager()
 
 const handler_variant &handler_manager::get_handler(int fd) const
 {
+	static const handler_variant oob_handler = unused_handler{};
+	if (fd < 0 || (std::size_t)fd >= handlers.size()) return oob_handler;
 	return handlers[fd];
 }
 
 const handler_variant &handler_manager::operator[](int idx) const
 {
+	static const handler_variant oob_handler = unused_handler{};
+	if (idx < 0 || (std::size_t)idx >= handlers.size()) return oob_handler;
 	return handlers[idx];
 }
 std::size_t handler_manager::size() const
@@ -59,6 +63,10 @@ int handler_manager::set_handler_at_empty_slot(handler_variant &&handler,
 int handler_manager::set_handler(int fd, handler_variant &&handler,
 				 managed_shared_memory &memory)
 {
+	if (fd < 0 || (std::size_t)fd >= handlers.size()) {
+		SPDLOG_ERROR("set_handler: fd {} out of range [0, {})", fd, handlers.size());
+		return -ENOSPC;
+	}
 	if (is_allocated(fd)) {
 		SPDLOG_ERROR("set_handler failed for fd {} aleady exists", fd);
 		return -EEXIST;


### PR DESCRIPTION
Fixes out-of-bounds handler access and an fd leak when the handler slot pool is exhausted.

handler_manager::set_handler() calls is_allocated(fd), which returns false for any fd >= handlers.size(), then writes handlers[fd] anyway. That out-of-bounds write corrupts memory and SIGSEGVs the caller. get_handler() and operator[] read handlers[fd] with the same missing check.

open_fake_fd() uses the OS-assigned /dev/null fd directly as a handlers[] index. Once the pool is full and the OS hands back a value past the array bounds, the fd leaks and the caller gets an unchecked out-of-bounds index.

set_handler now returns -ENOSPC for out-of-range fds before the is_allocated check. get_handler and operator[] return a static unused_handler sentinel for out-of-range indices. open_fake_fd closes the fd and returns -1 with errno=ENOSPC when the value would exceed manager->size().

Closes #667