### PR TITLE
fix: cascade link close to free perf event handler slot

### DIFF
--- a/runtime/src/handler/handler_manager.cpp
+++ b/runtime/src/handler/handler_manager.cpp
@@ -128,6 +128,13 @@ void handler_manager::clear_id_at(int fd, managed_shared_memory &memory)
 				}
 			}
 		}
+	} else if (std::holds_alternative<bpf_link_handler>(handlers[fd])) {
+		auto target_fd =
+			std::get<bpf_link_handler>(handlers[fd]).attach_target_id;
+		handlers[fd] = unused_handler();
+		SPDLOG_DEBUG("Destroying link handler {}, cascading to perf event {}", fd, target_fd);
+		clear_id_at(target_fd, memory);
+		return;
 	}
 	handlers[fd] = unused_handler();
 }


### PR DESCRIPTION
Fixes a handler slot leak: one slot per uprobe leaks on every attach/detach cycle, exhausting the pool over repeated benchmark rounds.

When a BPF_PERF_EVENT link is closed, libbpf relies on the kernel to drop the perf event reference. bpftime runs in userspace, so nothing drops it: clear_id_at() for a bpf_link_handler freed only the link slot and left the perf event handler allocated forever.

clear_id_at() now handles bpf_link_handler explicitly. It clears the link slot first, which stops the perf event handler's own link scan from recursing back into this slot, then calls clear_id_at(attach_target_id) to free the perf event handler.

Closes #668