### PR TITLE
chore(deps): bump bpftool submodule to fix GCC 14 and 6.15+ BTF builds

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -59,7 +59,7 @@ jobs:
           wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 17
           sudo apt update
           sudo apt install -y --no-install-recommends \
-            libelf1 libelf-dev zlib1g-dev make cmake git libboost-all-dev \
+            libelf1 libelf-dev zlib1g-dev libssl-dev make cmake git libboost-all-dev \
             binutils-dev libyaml-cpp-dev ca-certificates clang llvm pkg-config llvm-dev
 
       - name: install additional dependencies for experiments

--- a/.github/workflows/build-gcc13.yml
+++ b/.github/workflows/build-gcc13.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install GCC 13 and dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y gcc-13 g++-13 cmake make libboost-dev libncurses-dev pkg-config libelf-dev zlib1g-dev flex bison clang llvm
+          sudo apt-get install -y gcc-13 g++-13 cmake make libboost-dev libncurses-dev pkg-config libelf-dev zlib1g-dev libssl-dev flex bison clang llvm
 
       - name: Configure (CMake with GCC 13)
         env:

--- a/.github/workflows/test-bpftrace.yml
+++ b/.github/workflows/test-bpftrace.yml
@@ -382,7 +382,7 @@ jobs:
             lcov tree strace gdb sudo libc6-dev bpftrace \
             linux-headers-generic linux-tools-generic \
             linux-headers-$(uname -r) \
-            libelf-dev procps gnupg gnupg-agent pinentry-curses dirmngr
+            libelf-dev libssl-dev procps gnupg gnupg-agent pinentry-curses dirmngr
 
           # Setup GPG agent for Codecov
           mkdir -p ~/.gnupg

--- a/.github/workflows/test-examples.yml
+++ b/.github/workflows/test-examples.yml
@@ -65,11 +65,11 @@ jobs:
       - name: Install lcov (Ubuntu)
         if: ${{matrix.container.name=='ubuntu'}}
         run: |
-          apt-get update -y && apt-get install -y lcov tree
+          apt-get update -y && apt-get install -y lcov tree libssl-dev
       - name: Install lcov (Fedora)
         if: ${{matrix.container.name =='fedora'}}
         run: |
-          dnf install -y lcov tree
+          dnf install -y lcov tree openssl-devel
       - name: Build and install runtime (with llvm-jit)
         if: ${{matrix.enable_jit}}
         run: |
@@ -383,6 +383,13 @@ jobs:
       - name: Show downloaded artifacts
         run: |
           ls ~/.bpftime
+      - name: Install OpenSSL development headers
+        run: |
+          if [ "${{matrix.container.name}}" = "ubuntu" ]; then
+            apt-get update -y && apt-get install -y libssl-dev
+          else
+            dnf install -y openssl-devel
+          fi
       - name: Build test assets
         run: |
           # No special global libbpf handling is needed anymore

--- a/.github/workflows/test-runtime.yml
+++ b/.github/workflows/test-runtime.yml
@@ -67,7 +67,7 @@ jobs:
             cmake make gcc gcc-c++ \
             clang llvm llvm-devel \
             zlib-devel elfutils-libelf-devel pkgconf-pkg-config libasan \
-            boost-devel
+            boost-devel openssl-devel
       - name: Install Python3 (openEuler)
         if: matrix.container == 'openeuler-2403sp2'
         run: |
@@ -92,11 +92,11 @@ jobs:
       - name: Install lcov
         if: "matrix.container == 'ubuntu-2204'"
         run: |
-          apt-get update -y && apt-get install -y lcov libzstd-dev libboost-all-dev gpg
+          apt-get update -y && apt-get install -y lcov libzstd-dev libboost-all-dev gpg libssl-dev
       - name: Install lcov
         if: "matrix.container == 'fedora-39'"
         run: |
-          dnf install -y lcov
+          dnf install -y lcov openssl-devel
 
       - name: Build runtime tests (Ubuntu/Fedora)
         if: matrix.container != 'openeuler-2403sp2'

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:24.04
 WORKDIR /bpftime
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        libelf1 libelf-dev zlib1g-dev make cmake git libboost1.74-all-dev \
+        libelf1 libelf-dev libssl-dev zlib1g-dev make cmake git libboost1.74-all-dev \
         binutils-dev libyaml-cpp-dev gcc g++ ca-certificates \
         clang-16 llvm-16 llvm-16-dev
 

--- a/installation.md
+++ b/installation.md
@@ -47,7 +47,7 @@ Install the required packages:
 
 ```bash
 sudo apt-get update && sudo apt-get install \
-        libelf1 libelf-dev zlib1g-dev make cmake git libboost-all-dev \
+        libelf1 libelf-dev libssl-dev zlib1g-dev make cmake git libboost-all-dev \
         binutils-dev libyaml-cpp-dev ca-certificates clang llvm pkg-config llvm-dev
 git submodule update --init --recursive
 ```

--- a/tools/Dockerfile.arm
+++ b/tools/Dockerfile.arm
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y \
     gcc-12 \
     g++-12 \
     libelf-dev \
+    libssl-dev \
     python3-pytest \
     systemtap-sdt-dev \
     llvm \

--- a/tools/Dockerfile.fedora
+++ b/tools/Dockerfile.fedora
@@ -1,5 +1,5 @@
 FROM fedora:39
 
-RUN dnf install -y make gcc-c++-aarch64-linux-gnu gcc-arm-linux-gnu wget pkgconf clang boost-devel zlib-devel libubsan python3-pytest g++ python3-pip llvm elfutils-libelf-devel git qemu-user cmake gcc-c++ gcc-aarch64-linux-gnu python3 llvm15-devel systemtap-sdt-devel python3.8 gcc
+RUN dnf install -y make gcc-c++-aarch64-linux-gnu gcc-arm-linux-gnu wget pkgconf clang boost-devel zlib-devel libubsan python3-pytest g++ python3-pip llvm elfutils-libelf-devel openssl-devel git qemu-user cmake gcc-c++ gcc-aarch64-linux-gnu python3 llvm15-devel systemtap-sdt-devel python3.8 gcc
 
 ENV LLVM_ROOT=/usr/lib64/llvm15

--- a/tools/Dockerfile.ubuntu
+++ b/tools/Dockerfile.ubuntu
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04
 
-RUN apt-get update && apt-get install -y g++-aarch64-linux-gnu make libyaml-cpp-dev wget pkg-config zlib1g-dev gcc-arm-linux-gnueabi clang llvm-15-dev gcc-12 libelf-dev python3-pytest g++ systemtap-sdt-dev llvm git qemu-user cmake binutils-dev g++-12 gcc-aarch64-linux-gnu libboost1.74-all-dev python3 gcc
+RUN apt-get update && apt-get install -y g++-aarch64-linux-gnu make libyaml-cpp-dev wget pkg-config zlib1g-dev gcc-arm-linux-gnueabi clang llvm-15-dev gcc-12 libelf-dev libssl-dev python3-pytest g++ systemtap-sdt-dev llvm git qemu-user cmake binutils-dev g++-12 gcc-aarch64-linux-gnu libboost1.74-all-dev python3 gcc
 
 ENV LLVM_ROOT=/usr/lib/llvm-15
 ENV CC=gcc-12


### PR DESCRIPTION
Bumps third_party/bpftool from 53c1852 to c0960e4 to fix two build failures in the vendored bpftool/libbpf.

libbpf.c declared res, sym_sfx, and next_path as non-const char pointers. GCC 14 and later promote the discarded const qualifier to a hard error and break the build (#669).

The bundled bpf_helpers.h declared bpf_stream_vprintk with a signature that conflicts with the 4-parameter kfunc emitted in kernel 6.15+ BTF, so skeleton generation failed to compile (#670).

c0960e4 is the oldest commit on bpftool main that carries both upstream fixes: bpftool 640fb7c (the bpf_stream_vprintk _impl suffix) and a libbpf pin at f5dcbae (the const-qualifier fix). It moves the vendored libbpf to f5dcbae736e5.

Verified locally on GCC 16.2.1 with kernel 7.1.6 BTF: libbpf.c compiles clean under GCC, and a BPF object including the kernel vmlinux.h plus the bundled bpf_helpers.h compiles clean with no bpf_stream_vprintk conflict.

Closes #669
Closes #670