### PR TITLE
ci: add native RISC-V trap safety evidence harness

### DIFF
--- a/.github/script/test-riscv64-native-trap.sh
+++ b/.github/script/test-riscv64-native-trap.sh
@@ -4,10 +4,15 @@ set -euo pipefail
 case "$(uname -m)" in
     riscv64) ;;
     *)
-        echo "native riscv64 host required; refusing emulated evidence" >&2
+        echo "riscv64 host required; refusing qemu-user or cross-architecture evidence" >&2
         exit 2
         ;;
 esac
+
+if [[ -n "$(git status --porcelain --untracked-files=no --ignore-submodules=none)" ]]; then
+    echo "clean tracked worktree and submodules required for reproducible evidence" >&2
+    exit 3
+fi
 
 build_dir="${1:-build-native-riscv64-trap}"
 build_type="${BUILD_TYPE:-Release}"
@@ -15,6 +20,7 @@ build_type="${BUILD_TYPE:-Release}"
 echo "commit=$(git rev-parse HEAD)"
 echo "kernel=$(uname -srvm)"
 lscpu
+echo "hardware provenance must be supplied separately by the operator"
 
 cmake -S . -B "$build_dir" \
     -DCMAKE_BUILD_TYPE="$build_type" \

--- a/.github/script/test-riscv64-native-trap.sh
+++ b/.github/script/test-riscv64-native-trap.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "$(uname -m)" in
+    riscv64) ;;
+    *)
+        echo "native riscv64 host required; refusing emulated evidence" >&2
+        exit 2
+        ;;
+esac
+
+build_dir="${1:-build-native-riscv64-trap}"
+build_type="${BUILD_TYPE:-Release}"
+
+echo "commit=$(git rev-parse HEAD)"
+echo "kernel=$(uname -srvm)"
+lscpu
+
+cmake -S . -B "$build_dir" \
+    -DCMAKE_BUILD_TYPE="$build_type" \
+    -DBUILD_BPFTIME_DAEMON=OFF \
+    -DBPFTIME_ENABLE_UNIT_TESTING=ON \
+    -DBPFTIME_ENABLE_FRIDA=OFF \
+    -DBPFTIME_ENABLE_TRAP_UPROBE=ON \
+    -DENABLE_EBPF_VERIFIER=OFF \
+    -DBPFTIME_LLVM_JIT=OFF \
+    -DBPFTIME_BUILD_WITH_LIBBPF=OFF
+
+cmake --build "$build_dir" \
+    --target bpftime_trap_uprobe_attach_tests bpftime_trap_late_host \
+    -j"$(nproc)"
+
+trap_tests="$build_dir/attach/trap_uprobe_attach_impl/bpftime_trap_uprobe_attach_tests"
+late_host="$build_dir/attach/trap_uprobe_attach_impl/bpftime_trap_late_host"
+late_module="$build_dir/attach/trap_uprobe_attach_impl/libbpftime_trap_late_module.so"
+
+"$trap_tests" "Trap backend: concurrent three-phase patch*"
+"$trap_tests" "Trap backend: handler signal-safety*,Trap backend: new threads*"
+"$late_host" "$late_module"

--- a/.github/script/test-riscv64-native-trap.sh
+++ b/.github/script/test-riscv64-native-trap.sh
@@ -19,10 +19,16 @@ build_type="${BUILD_TYPE:-Release}"
 
 echo "commit=$(git rev-parse HEAD)"
 echo "kernel=$(uname -srvm)"
-lscpu
+if command -v lscpu >/dev/null 2>&1; then
+    lscpu
+elif [[ -r /proc/cpuinfo ]]; then
+    cat /proc/cpuinfo
+else
+    echo "CPU topology unavailable"
+fi
 echo "hardware provenance must be supplied separately by the operator"
 
-cmake -S . -B "$build_dir" \
+cmake -S . -B "$build_dir" -G "Unix Makefiles" \
     -DCMAKE_BUILD_TYPE="$build_type" \
     -DBUILD_BPFTIME_DAEMON=OFF \
     -DBPFTIME_ENABLE_UNIT_TESTING=ON \

--- a/attach/trap_uprobe_attach_impl/README.md
+++ b/attach/trap_uprobe_attach_impl/README.md
@@ -152,3 +152,15 @@ workflow runs the trap eBPF integration and direct program admission tests;
 the shared-memory link admission test also requires robust futex support
 (`set_robust_list`), which qemu-user does not implement. Do not disable
 Boost's robust mutexes to make that test pass under emulation.
+
+For native concurrency and signal-safety evidence, run the repository harness
+on a riscv64 host:
+
+```console
+./.github/script/test-riscv64-native-trap.sh
+```
+
+The harness records the exact commit, kernel, and CPU topology before running
+the 2-mod-4 three-phase patch stress case, allocator/TLS safety cases, and late
+injection test. It rejects non-riscv64 hosts so emulated results cannot be
+mistaken for native evidence.

--- a/attach/trap_uprobe_attach_impl/README.md
+++ b/attach/trap_uprobe_attach_impl/README.md
@@ -160,7 +160,9 @@ on a riscv64 host:
 ./.github/script/test-riscv64-native-trap.sh
 ```
 
-The harness records the exact commit, kernel, and CPU topology before running
-the 2-mod-4 three-phase patch stress case, allocator/TLS safety cases, and late
-injection test. It rejects non-riscv64 hosts so emulated results cannot be
-mistaken for native evidence.
+The harness requires a clean tracked worktree, then records the exact commit,
+kernel, and CPU topology before running the 2-mod-4 three-phase patch stress
+case, allocator/TLS safety cases, and late injection test. It rejects
+non-riscv64 and qemu-user execution. Because a full-system riscv64 virtual
+machine also reports `riscv64`, attach separate operator provenance when the
+result is intended to demonstrate physical-hardware execution.


### PR DESCRIPTION
Follow-up to #665.

The merged PR has strong qemu-user coverage and earlier native measurements, but the corrected 2-mod-4 concurrent patch case landed after the recorded native run. This adds a single reproducible riscv64-host harness that:

- records the exact Git commit, kernel, and CPU topology from a clean tracked worktree and submodules;
- runs the corrected concurrent three-phase patch stress case;
- runs the allocator/TLS signal-handler and new-thread cases;
- runs the late-injection wrapper audit; and
- refuses non-riscv64/qemu-user execution while requiring separate operator provenance for physical-hardware claims.

Local verification on x86_64: Bash syntax and ShellCheck pass, and the architecture guard exits 2 with the documented refusal. A physical riscv64 run with operator provenance is intentionally required for the remaining evidence.